### PR TITLE
Add Django scanning portal for document intake and review

### DIFF
--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -27,9 +27,8 @@ FROM build-base AS python-base
 WORKDIR /opt/scanning
 
 # uv install dependencies
-# Copy lock file if it exists, generate it if not
 COPY pyproject.toml .
-COPY uv.loc[k] .
+COPY uv.lock .
 ENV \
     UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
@@ -40,7 +39,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 # npm install dependencies
 COPY package.json ./
-COPY package-lock.jso[n] ./
+COPY package-lock.json ./
 RUN npm install
 
 COPY . .


### PR DESCRIPTION
## Summary

Implementation of the FLP Scanning Portal, a standalone Django app for volunteer scanners to upload legal document PDFs for staff review.

### Two-model design

The portal uses two separate models to reflect the physical scanning workflow:

- **Scan** (Book Scan): represents a full scanned book volume (e.g. "Federal Reporter, 3d vol. 42, pages 1-200"). Volunteers upload entire book PDFs here. Staff can approve or reject these uploads.
- **OpinionScan**: represents an individual opinion extracted from a book (or uploaded standalone). Each opinion belongs to a reporter + volume and optionally links back to its parent Scan. Only superusers can upload opinion scans; staff can review them (approve/reject with notes).

This separation keeps the intake pipeline clean: books come in as bulk scans, then individual opinions are carved out and tracked independently with their own status and page ranges.

### Features

- Single-app Django project (`scanning/` as both project and app)
- Scan and OpinionScan models with Reporter FK, S3-backed file storage, and signed URLs
- Function-based views: login, upload, filterable/paginated lists, detail with inline PDF viewer
- Staff review workflow (approve/reject) on both scan and opinion detail pages
- Opinion upload restricted to superusers
- Reporter select dropdowns display "Full Name (slug)" across all forms and filters
- 33-reporter fixture covering all regional and federal West reporters
- OpinionScan tracks page range (page_start/page_end) and has a "No status" default
- Dockerized dev environment (Django + PostgreSQL + Tailwind watcher)
- Tailwind CSS with dark mode, cotton template components
- 42 tests covering upload, list, detail, review, permissions, and model logic
- GitHub Actions CI: lint (pre-commit), tests (Docker-based), CodeQL security analysis
- Docker Hub push workflow: builds and pushes `freelawproject/scanning` on merges to main

## Screenshots

### Login
<img width="2214" height="1136" alt="image" src="https://github.com/user-attachments/assets/21b64f2c-d492-4829-8f6b-2ea6479ebd7d" />

### List of uploaded scans
<img width="2214" height="1136" alt="image" src="https://github.com/user-attachments/assets/b4586c1c-2a0e-4ded-b731-933e14106914" />

### Upload form
<img width="2214" height="1136" alt="image" src="https://github.com/user-attachments/assets/be72c1bb-707f-47ed-b455-c1106225ee5e" />

### Detail view (original and redacted side by side)
<img width="2214" height="1136" alt="image" src="https://github.com/user-attachments/assets/255905d6-57e8-4ed0-9133-bfc80a90fbaf" />

### Scan reviewed
<img width="2214" height="1136" alt="image" src="https://github.com/user-attachments/assets/c69ad10b-d30f-453d-936f-4b10427c4bb8" />

## Test plan

- [ ] `docker compose -f docker/scanning/docker-compose.yml up --build` starts all services
- [ ] Login at `localhost:8002/login/` works
- [ ] Upload a book scan PDF at `/upload/`, verify it appears in the Book Scans list
- [ ] Staff user can approve/reject from the book scan detail page
- [ ] Superuser can upload an opinion scan at `/opinions/upload/` with page range
- [ ] Regular user gets 403 on opinion upload
- [ ] Staff user can approve/reject opinion scans from the detail page
- [ ] Reporter dropdowns show "Full Name (slug)" format
- [ ] Nav labels show "Upload book scan", "Book Scans", "Opinion Scans"
- [ ] Tests pass: `docker exec scanning-django python manage.py test scanning.tests -v 2` (42 tests)
- [ ] CI workflows run on the PR (lint, tests, CodeQL)
- [ ] Docker Hub push workflow is configured for main merges

Closes #12

---
Authored by @quevon24 and [Claude Code](https://claude.ai/code)