### PR TITLE
Fix private storage URL generation

### DIFF
--- a/scanning/storage.py
+++ b/scanning/storage.py
@@ -3,6 +3,9 @@ from storages.backends.s3boto3 import S3Boto3Storage, S3ManifestStaticStorage
 
 class SubDirectoryS3ManifestStaticStorage(S3ManifestStaticStorage):
     location = "static"
+    # Fall back to unhashed URLs instead of raising ValueError
+    # when a file is missing from the staticfiles manifest.
+    manifest_strict = False
 
 
 class PrivateS3Storage(S3Boto3Storage):
@@ -12,6 +15,7 @@ class PrivateS3Storage(S3Boto3Storage):
     file_overwrite = False
     querystring_auth = True
     querystring_expire = 300  # 5-minute signed URLs
+    custom_domain = False  # disable custom domain so signed URLs use the S3 hostname
 
     def __init__(self, **kwargs):
         from django.conf import settings

--- a/scanning/storage.py
+++ b/scanning/storage.py
@@ -15,7 +15,9 @@ class PrivateS3Storage(S3Boto3Storage):
     file_overwrite = False
     querystring_auth = True
     querystring_expire = 300  # 5-minute signed URLs
-    custom_domain = False  # disable custom domain so signed URLs use the S3 hostname
+    custom_domain = (
+        False  # disable custom domain so signed URLs use the S3 hostname
+    )
 
     def __init__(self, **kwargs):
         from django.conf import settings


### PR DESCRIPTION
- Fix `PrivateS3Storage` generating URLs that point to the public bucket instead of the private one
- `AWS_S3_CUSTOM_DOMAIN` is a global setting derived from `AWS_STORAGE_BUCKET_NAME` (the public bucket). `PrivateS3Storage` was inheriting this, causing signed URLs to use the
wrong hostname and fail signature validation.
- Add `custom_domain = False` so django-storages uses the S3 hostname (<bucket>.s3.amazonaws.com) for signed URLs
- Add `manifest_strict = False` to `SubDirectoryS3ManifestStaticStorage` to fall back to unhashed URLs when a file is missing from the staticfiles manifest


**Private bucket (scanned documents):**
- Before: https://com-freelawproject-scanning-storage.s3.amazonaws.com/scans/2026/03/09/file.pdf (wrong bucket, no signature)
- After: https://com-freelawproject-scanning-private-storage.s3.amazonaws.com/scans/2026/03/09/file.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=... (correct bucket,
signed)

**Public bucket (static files, unchanged):**
- Before & after: https://com-freelawproject-scanning-storage.s3.amazonaws.com/static/css/tailwind_styles.css

The core issue was that `AWS_S3_CUSTOM_DOMAIN` is set to `com-freelawproject-scanning-storage.s3.amazonaws.com` (the public bucket), and `PrivateS3Storage` was inheriting that domain, so private file URLs pointed to the public bucket and lacked valid signatures.
