### PR TITLE
fix(web): lazy-load blackletter to prevent scanning-web OOM at boot

### DIFF
--- a/scanning/views_process.py
+++ b/scanning/views_process.py
@@ -17,7 +17,6 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.views.decorators.http import require_POST
 
-from scanning import services
 from scanning.models import (
     CheckName,
     Detection,
@@ -538,6 +537,8 @@ def recalculate(request: HttpRequest, pk: int) -> HttpResponse:
     scan = get_object_or_404(Scan, pk=pk)
     if not scan.ocr_results:
         return redirect("scan_process", pk=pk)
+    from scanning import services
+
     services.recalculate_issues(scan)
     return redirect("scan_process", pk=pk)
 


### PR DESCRIPTION
## Summary

- Move `from scanning import services` out of the top of `scanning/views_process.py` and into the one view that uses it (`recalculate`).
- Stops `scanning-web` gunicorn workers from transitively importing `blackletter.scanner` (and therefore `torch`, `cv2`, `ultralytics`, `numpy`) at boot.
- Unblocks rollouts that were failing with `OOMKilled` / `ProgressDeadlineExceeded` against the pod's 500Mi memory limit.

## Before vs. after (this branch)

| Metric | Before | After | Delta |
|---|---|---|---|
| Per-worker RSS after `import scanning.urls` | 427.4 MiB | 143.1 MiB | **−284 MiB (−66%)** |
| Heavy modules loaded by web path | torch, cv2, ultralytics, numpy, blackletter, fitz, PIL | fitz, numpy | — |
| Test suite (`manage.py test scanning.tests`) | 124 passed | 124 passed | no regression |

At `NUM_WORKERS=4` this brings pod-level RSS from ~1.7 GiB down to ~575 MiB. A follow-up bump of the k8s limit to ~768 MiB in the infra repo would give comfortable headroom for request spikes.

## Per-library attribution (isolated subprocess)

Numbers are from a fresh Python 3.13 process with CPU-only `torch==2.11.0+cpu`. "Added RSS" is the increase over the bare interpreter (14 MiB baseline).

| Import | Added RSS |
|---|---|
| django (module only, no `setup()`) | ~0 MiB |
| PIL (module only) | ~0 MiB |
| numpy | +16 MiB |
| fitz (PyMuPDF) | +34 MiB |
| cv2 | +42 MiB |
| torch | **+207 MiB** |
| ultralytics (transitively pulls torch + cv2 + numpy) | +237 MiB |
| blackletter (transitively pulls ultralytics + fitz) | +341 MiB |

## How these numbers were measured

1. Synced deps with `uv sync --all-extras` (produces the same CPU-only `torch==2.11.0+cpu` wheel used in the production image).
2. **Total web-path RSS:** a fresh Python subprocess calls `django.setup()`, imports `scanning.urls` (which pulls in every URLConf-level dependency a gunicorn worker would see), and reports `resource.getrusage(RUSAGE_SELF).ru_maxrss`. Ran the same script against `main` and against this branch.
3. **Per-library attribution:** for each library in the list, spawn a separate subprocess that performs only `import <lib>` and reports RSS. Isolation means the order of imports can't skew any single measurement.

## Test plan

- [x] `DEVELOPMENT=True DB_HOST=localhost DB_PORT=5434 DB_SSL_MODE=prefer python manage.py test scanning.tests -v 1` — 124 passed, 1 pre-existing skip.
- [ ] After merge, confirm the new ReplicaSet reaches Ready and the `Progressing=False/ProgressDeadlineExceeded` condition clears.
- [ ] `kubectl top pod -n scanning -l service=scanning-web` — expect ~400–600 MiB per pod, no OOMKills.
- [ ] Exercise the `recalculate` action on a scan in the process viewer to confirm the lazy import works end-to-end.

Refs #43