### PR TITLE
ci: add workflow to build and push RunPod GPU worker image

### DIFF
--- a/.github/workflows/build-runpod-worker.yml
+++ b/.github/workflows/build-runpod-worker.yml
@@ -1,0 +1,38 @@
+name: Build and Push RunPod Worker
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'scanning/runpod/**'
+
+jobs:
+  build-runpod-worker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Get short SHA
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Build and Push
+        uses: docker/build-push-action@v6
+        with:
+          context: scanning/runpod
+          push: true
+          tags: |
+            freelawproject/blackletter-gpu-worker:${{ steps.vars.outputs.sha_short }}
+            freelawproject/blackletter-gpu-worker:latest
+          cache-from: type=registry,ref=freelawproject/blackletter-gpu-worker:cache
+          cache-to: type=registry,ref=freelawproject/blackletter-gpu-worker:cache,mode=max


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/build-runpod-worker.yml` to automate building and pushing the RunPod GPU worker image
- Triggers only on pushes to `main` that touch files under `scanning/runpod/` (no unnecessary builds)
- Pushes to `freelawproject/blackletter-gpu-worker` tagged with the short git SHA and `latest`
- Uses a dedicated registry cache tag (`cache`) with `mode=max` for efficient layer caching across builds

Closes #46