### PR TITLE
feat(scanning): detection box resize, move, and page-container width fix

### DIFF
--- a/scanning/runpod/README.md
+++ b/scanning/runpod/README.md
@@ -1,5 +1,6 @@
 # blackletter-gpu-worker
 
+
 GPU worker image for [RunPod Serverless]. Runs the two GPU-heavy steps
 of the blackletter pipeline (`detect` and `analyze_pdf`) so the rest of
 the scanning app can stay on CPU-only boxes.
@@ -11,6 +12,7 @@ in RunPod endpoint env vars, never in the image.
 [RunPod Serverless]: https://docs.runpod.io/serverless/overview
 
 ## How it fits
+
 
 ```
 ┌─────────────────────┐        ┌──────────────────────┐

--- a/scanning/static/scanning/shared.js
+++ b/scanning/static/scanning/shared.js
@@ -105,6 +105,48 @@ function undoDeletePage(csrfToken, docId, pdfPage, pageDiv, labelPrefix, onDelet
 }
 
 /**
+ * Show a stacking toast notification that auto-dismisses after 5 seconds.
+ *
+ * @param {string} message - Text to display.
+ * @param {string} [type="error"] - "error" (red) or "info" (blue).
+ */
+function showToast(message, type) {
+    type = type || 'error';
+    var container = document.getElementById('toast-container');
+    if (!container) {
+        container = document.createElement('div');
+        container.id = 'toast-container';
+        container.style.cssText = 'position:fixed;bottom:16px;right:16px;display:flex;flex-direction:column;gap:8px;z-index:9999;pointer-events:none;';
+        document.body.appendChild(container);
+    }
+    var toast = document.createElement('div');
+    var bg = type === 'error' ? '#dc2626' : '#2563eb';
+    toast.style.cssText = 'background:' + bg + ';color:#fff;padding:10px 16px;border-radius:6px;font-size:13px;box-shadow:0 2px 8px rgba(0,0,0,0.3);opacity:1;transition:opacity 0.4s;max-width:320px;pointer-events:auto;display:flex;align-items:center;gap:10px;';
+
+    var text = document.createElement('span');
+    text.style.flex = '1';
+    text.textContent = message;
+    toast.appendChild(text);
+
+    var closeBtn = document.createElement('button');
+    closeBtn.textContent = '✕';
+    closeBtn.style.cssText = 'background:none;border:none;color:#fff;cursor:pointer;font-size:14px;padding:0;line-height:1;opacity:0.8;flex-shrink:0;';
+    closeBtn.addEventListener('click', function () { dismiss(); });
+    toast.appendChild(closeBtn);
+
+    container.appendChild(toast);
+
+    function dismiss() {
+        toast.style.opacity = '0';
+        setTimeout(function () { toast.remove(); }, 400);
+    }
+
+    var timer = setTimeout(dismiss, 5000);
+    closeBtn.addEventListener('mouseenter', function () { clearTimeout(timer); });
+    closeBtn.addEventListener('mouseleave', function () { timer = setTimeout(dismiss, 2000); });
+}
+
+/**
  * Draw existing redaction rectangles on a canvas overlay.
  *
  * @param {HTMLCanvasElement} overlay - The canvas element.

--- a/scanning/static/scanning/viewer_sidebar.js
+++ b/scanning/static/scanning/viewer_sidebar.js
@@ -338,6 +338,7 @@ function approveDetection(btn) {
         })
         .catch(function () {
             console.error("Failed to approve detection");
+            showToast("Failed to approve detection");
         });
 }
 
@@ -366,6 +367,7 @@ function deleteUnmatchedDetection(btn) {
         })
         .catch(function () {
             console.error("Failed to delete detection");
+            showToast("Failed to delete detection");
         });
 }
 

--- a/scanning/static/scanning/viewer_sidebar.js
+++ b/scanning/static/scanning/viewer_sidebar.js
@@ -324,12 +324,7 @@ function approveDetection(btn) {
             "Content-Type": "application/json",
             "X-CSRFToken": cfg.csrfToken,
         },
-        body: JSON.stringify({
-            page_index: d.pageIndex,
-            label: d.label,
-            label_id: d.labelId,
-            bbox: d.bbox,
-        }),
+        body: JSON.stringify({detection_id: d.detectionId}),
     })
         .then(function (r) {
             return r.json();
@@ -340,6 +335,9 @@ function approveDetection(btn) {
             row.style.pointerEvents = "none";
             btn.textContent = "\u2713";
             pairOpinions();
+        })
+        .catch(function () {
+            console.error("Failed to approve detection");
         });
 }
 
@@ -355,12 +353,7 @@ function deleteUnmatchedDetection(btn) {
             "Content-Type": "application/json",
             "X-CSRFToken": cfg.csrfToken,
         },
-        body: JSON.stringify({
-            page_index: d.pageIndex,
-            label: d.label,
-            label_id: d.labelId,
-            bbox: d.bbox,
-        }),
+        body: JSON.stringify({detection_id: d.detectionId}),
     })
         .then(function (r) {
             return r.json();
@@ -370,6 +363,9 @@ function deleteUnmatchedDetection(btn) {
             row.style.opacity = "0.3";
             row.style.pointerEvents = "none";
             btn.textContent = "\u2717";
+        })
+        .catch(function () {
+            console.error("Failed to delete detection");
         });
 }
 
@@ -478,5 +474,6 @@ function _getDetectionData(el) {
         imgH: parseInt(row.dataset.imgH),
         label: row.dataset.unmatchedLabel,
         labelId: parseInt(row.dataset.labelId),
+        detectionId: parseInt(row.dataset.detectionId),
     };
 }

--- a/scanning/static/scanning/viewer_step2.js
+++ b/scanning/static/scanning/viewer_step2.js
@@ -749,6 +749,10 @@ document.addEventListener('DOMContentLoaded', function () {
             box.style.top = (d.bbox[1] * sy) + 'px';
             box.style.width = ((d.bbox[2] - d.bbox[0]) * sx) + 'px';
             box.style.height = ((d.bbox[3] - d.bbox[1]) * sy) + 'px';
+            box.dataset.sx = sx;
+            box.dataset.sy = sy;
+            box.dataset.imgWidth = imgW;
+            box.dataset.imgHeight = imgH;
             box.style.borderColor = color;
             box.title = d.label + ' (' + d.confidence + ')';
 
@@ -1712,6 +1716,135 @@ document.addEventListener('DOMContentLoaded', function () {
         });
 
         toolbar.appendChild(deleteBtn);
+
+        var sx = parseFloat(div.dataset.sx) || 1;
+        var sy = parseFloat(div.dataset.sy) || 1;
+
+        ['nw','n','ne','w','e','sw','s','se'].forEach(function(pos) {
+            var h = document.createElement('div');
+            h.className = 'det-resize-handle';
+            h.dataset.pos = pos;
+            h.style.cssText = 'position:absolute;width:8px;height:8px;background:#f59e0b;border:1px solid #fff;z-index:22;cursor:' + pos + '-resize;';
+            if (pos.indexOf('n') >= 0) h.style.top = '-4px';
+            if (pos.indexOf('s') >= 0) h.style.bottom = '-4px';
+            if (pos.indexOf('w') >= 0) h.style.left = '-4px';
+            if (pos.indexOf('e') >= 0) h.style.right = '-4px';
+            if (pos === 'n' || pos === 's') h.style.left = 'calc(50% - 4px)';
+            if (pos === 'w' || pos === 'e') h.style.top = 'calc(50% - 4px)';
+
+            h.addEventListener('mousedown', function(e) {
+                e.stopPropagation();
+                e.preventDefault();
+                var startX = e.clientX, startY = e.clientY;
+                var startLeft = parseFloat(div.style.left);
+                var startTop  = parseFloat(div.style.top);
+                var startW    = parseFloat(div.style.width);
+                var startH    = parseFloat(div.style.height);
+
+                function onMove(ev) {
+                    var dx = ev.clientX - startX, dy = ev.clientY - startY;
+                    var nL = startLeft, nT = startTop, nW = startW, nH = startH;
+                    if (pos.indexOf('e') >= 0) nW = startW + dx;
+                    if (pos.indexOf('w') >= 0) { nW = startW - dx; nL = startLeft + dx; }
+                    if (pos.indexOf('s') >= 0) nH = startH + dy;
+                    if (pos.indexOf('n') >= 0) { nH = startH - dy; nT = startTop + dy; }
+                    if (nW > 5) { div.style.left = nL + 'px'; div.style.width  = nW + 'px'; }
+                    if (nH > 5) { div.style.top  = nT + 'px'; div.style.height = nH + 'px'; }
+                }
+
+                function onUp() {
+                    document.removeEventListener('mousemove', onMove);
+                    document.removeEventListener('mouseup', onUp);
+                    var nL = parseFloat(div.style.left);
+                    var nT = parseFloat(div.style.top);
+                    var nW = parseFloat(div.style.width);
+                    var nH = parseFloat(div.style.height);
+                    var newBbox = [
+                        Math.round(nL / sx * 10) / 10,
+                        Math.round(nT / sy * 10) / 10,
+                        Math.round((nL + nW) / sx * 10) / 10,
+                        Math.round((nT + nH) / sy * 10) / 10,
+                    ];
+                    var oldBbox = det.bbox.slice();
+                    fetch('/scans/' + documentId + '/update-detection/', {
+                        method: 'POST',
+                        headers: {'Content-Type': 'application/json', 'X-CSRFToken': csrfToken},
+                        body: JSON.stringify({
+                            page_index: det.page_index,
+                            label:      det.label,
+                            label_id:   det.label_id,
+                            old_bbox:   oldBbox,
+                            new_bbox:   newBbox,
+                        }),
+                    }).then(function(r) { return r.json(); }).then(function(data) {
+                        if (data.status === 'ok') {
+                            det.bbox[0] = newBbox[0];
+                            det.bbox[1] = newBbox[1];
+                            det.bbox[2] = newBbox[2];
+                            det.bbox[3] = newBbox[3];
+                        }
+                    });
+                }
+
+                document.addEventListener('mousemove', onMove);
+                document.addEventListener('mouseup', onUp);
+            });
+            div.appendChild(h);
+        });
+
+        div.style.cursor = 'move';
+
+        div.addEventListener('mousedown', function(e) {
+            if (e.target !== div) return;
+            e.stopPropagation();
+            e.preventDefault();
+            var startX = e.clientX, startY = e.clientY;
+            var startLeft = parseFloat(div.style.left);
+            var startTop  = parseFloat(div.style.top);
+
+            function onMove(ev) {
+                div.style.left = (startLeft + ev.clientX - startX) + 'px';
+                div.style.top  = (startTop  + ev.clientY - startY) + 'px';
+            }
+
+            function onUp() {
+                document.removeEventListener('mousemove', onMove);
+                document.removeEventListener('mouseup', onUp);
+                var nL = parseFloat(div.style.left);
+                var nT = parseFloat(div.style.top);
+                var nW = parseFloat(div.style.width);
+                var nH = parseFloat(div.style.height);
+                var newBbox = [
+                    Math.round(nL / sx * 10) / 10,
+                    Math.round(nT / sy * 10) / 10,
+                    Math.round((nL + nW) / sx * 10) / 10,
+                    Math.round((nT + nH) / sy * 10) / 10,
+                ];
+                var oldBbox = det.bbox.slice();
+                fetch('/scans/' + documentId + '/update-detection/', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json', 'X-CSRFToken': csrfToken},
+                    body: JSON.stringify({
+                        page_index: det.page_index,
+                        label:      det.label,
+                        label_id:   det.label_id,
+                        old_bbox:   oldBbox,
+                        new_bbox:   newBbox,
+                    }),
+                }).then(function(r) { return r.json(); }).then(function(data) {
+                    if (data.status === 'ok') {
+                        det.bbox[0] = newBbox[0];
+                        det.bbox[1] = newBbox[1];
+                        det.bbox[2] = newBbox[2];
+                        det.bbox[3] = newBbox[3];
+                    }
+                });
+            }
+
+            document.addEventListener('mousemove', onMove);
+            document.addEventListener('mouseup', onUp);
+        });
+
         div.appendChild(toolbar);
     }
 
@@ -1719,6 +1852,7 @@ document.addEventListener('DOMContentLoaded', function () {
         if (!_selectedDetBox) return;
         _selectedDetBox.style.outline = '';
         _selectedDetBox.style.zIndex = '';
+        _selectedDetBox.style.cursor = '';
         _selectedDetBox.querySelectorAll('.det-resize-handle').forEach(function(el) { el.remove(); });
         _selectedDetBox = null;
     }

--- a/scanning/static/scanning/viewer_step2.js
+++ b/scanning/static/scanning/viewer_step2.js
@@ -1726,13 +1726,35 @@ document.addEventListener('DOMContentLoaded', function () {
     // ── Detection box editing ──
     var _selectedDetBox = null;
 
+    function _saveDetectionBbox(newBbox, det) {
+        fetch('/scans/' + documentId + '/update-detection/', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json', 'X-CSRFToken': csrfToken},
+            body: JSON.stringify({detection_id: det.id, new_bbox: newBbox}),
+        }).then(function(r) { return r.json(); }).then(function(data) {
+            if (data.status === 'ok') {
+                det.bbox[0] = newBbox[0];
+                det.bbox[1] = newBbox[1];
+                det.bbox[2] = newBbox[2];
+                det.bbox[3] = newBbox[3];
+            }
+        }).catch(function() {
+            console.error('Failed to save detection bbox');
+        });
+    }
+
     function _selectDetectionBox(div, det) {
         _deselectDetectionBox();
         _selectedDetBox = div;
         div.style.outline = '2px solid #f59e0b';
         div.style.zIndex = '20';
+        div.style.cursor = 'move';
         var selLabel = div.querySelector('.detection-label');
         if (selLabel) selLabel.style.display = '';
+
+        // Scale factors: div is in display px, det.bbox is in image px
+        var sx = parseFloat(div.style.width) / (det.bbox[2] - det.bbox[0]);
+        var sy = parseFloat(div.style.height) / (det.bbox[3] - det.bbox[1]);
 
         // Action buttons toolbar
         var toolbar = document.createElement('div');
@@ -1758,19 +1780,16 @@ document.addEventListener('DOMContentLoaded', function () {
                     console.log('Deleted ' + data.deleted + ' detection(s) from DB for ' + det.label + ' on page_index=' + det.page_index);
                     div.remove();
                     _selectedDetBox = null;
-                    // Remove matching sidebar item for unmatched captions/keys
                     var sidebarItems = document.querySelectorAll('[data-unmatched-page="' + det.page_index + '"][data-unmatched-label="' + det.label + '"]');
                     sidebarItems.forEach(function(el) { el.remove(); });
                     refreshOverlays();
                 }
             });
         });
-
         toolbar.appendChild(deleteBtn);
+        div.appendChild(toolbar);
 
-        var sx = parseFloat(div.dataset.sx) || 1;
-        var sy = parseFloat(div.dataset.sy) || 1;
-
+        // Resize handles
         ['nw','n','ne','w','e','sw','s','se'].forEach(function(pos) {
             var h = document.createElement('div');
             h.className = 'det-resize-handle';
@@ -1788,53 +1807,33 @@ document.addEventListener('DOMContentLoaded', function () {
                 e.preventDefault();
                 var startX = e.clientX, startY = e.clientY;
                 var startLeft = parseFloat(div.style.left);
-                var startTop  = parseFloat(div.style.top);
-                var startW    = parseFloat(div.style.width);
-                var startH    = parseFloat(div.style.height);
+                var startTop = parseFloat(div.style.top);
+                var startW = parseFloat(div.style.width);
+                var startH = parseFloat(div.style.height);
 
-                function onMove(ev) {
-                    var dx = ev.clientX - startX, dy = ev.clientY - startY;
-                    var nL = startLeft, nT = startTop, nW = startW, nH = startH;
-                    if (pos.indexOf('e') >= 0) nW = startW + dx;
-                    if (pos.indexOf('w') >= 0) { nW = startW - dx; nL = startLeft + dx; }
-                    if (pos.indexOf('s') >= 0) nH = startH + dy;
-                    if (pos.indexOf('n') >= 0) { nH = startH - dy; nT = startTop + dy; }
-                    if (nW > 5) { div.style.left = nL + 'px'; div.style.width  = nW + 'px'; }
-                    if (nH > 5) { div.style.top  = nT + 'px'; div.style.height = nH + 'px'; }
+                function onMove(e) {
+                    var dx = e.clientX - startX, dy = e.clientY - startY;
+                    var newLeft = startLeft, newTop = startTop, newW = startW, newH = startH;
+                    if (pos.indexOf('e') >= 0) newW = Math.max(10, startW + dx);
+                    if (pos.indexOf('s') >= 0) newH = Math.max(10, startH + dy);
+                    if (pos.indexOf('w') >= 0) { newLeft = startLeft + dx; newW = Math.max(10, startW - dx); }
+                    if (pos.indexOf('n') >= 0) { newTop = startTop + dy; newH = Math.max(10, startH - dy); }
+                    div.style.left = newLeft + 'px';
+                    div.style.top = newTop + 'px';
+                    div.style.width = newW + 'px';
+                    div.style.height = newH + 'px';
                 }
 
                 function onUp() {
                     document.removeEventListener('mousemove', onMove);
                     document.removeEventListener('mouseup', onUp);
-                    var nL = parseFloat(div.style.left);
-                    var nT = parseFloat(div.style.top);
-                    var nW = parseFloat(div.style.width);
-                    var nH = parseFloat(div.style.height);
                     var newBbox = [
-                        Math.round(nL / sx * 10) / 10,
-                        Math.round(nT / sy * 10) / 10,
-                        Math.round((nL + nW) / sx * 10) / 10,
-                        Math.round((nT + nH) / sy * 10) / 10,
+                        parseFloat(div.style.left) / sx,
+                        parseFloat(div.style.top) / sy,
+                        (parseFloat(div.style.left) + parseFloat(div.style.width)) / sx,
+                        (parseFloat(div.style.top) + parseFloat(div.style.height)) / sy,
                     ];
-                    var oldBbox = det.bbox.slice();
-                    fetch('/scans/' + documentId + '/update-detection/', {
-                        method: 'POST',
-                        headers: {'Content-Type': 'application/json', 'X-CSRFToken': csrfToken},
-                        body: JSON.stringify({
-                            page_index: det.page_index,
-                            label:      det.label,
-                            label_id:   det.label_id,
-                            old_bbox:   oldBbox,
-                            new_bbox:   newBbox,
-                        }),
-                    }).then(function(r) { return r.json(); }).then(function(data) {
-                        if (data.status === 'ok') {
-                            det.bbox[0] = newBbox[0];
-                            det.bbox[1] = newBbox[1];
-                            det.bbox[2] = newBbox[2];
-                            det.bbox[3] = newBbox[3];
-                        }
-                    });
+                    _saveDetectionBbox(newBbox, det);
                 }
 
                 document.addEventListener('mousemove', onMove);
@@ -1843,60 +1842,34 @@ document.addEventListener('DOMContentLoaded', function () {
             div.appendChild(h);
         });
 
-        div.style.cursor = 'move';
-
+        // Drag-to-move (click on box body, not handles)
         div.addEventListener('mousedown', function(e) {
             if (e.target !== div) return;
-            e.stopPropagation();
             e.preventDefault();
             var startX = e.clientX, startY = e.clientY;
             var startLeft = parseFloat(div.style.left);
-            var startTop  = parseFloat(div.style.top);
+            var startTop = parseFloat(div.style.top);
 
-            function onMove(ev) {
-                div.style.left = (startLeft + ev.clientX - startX) + 'px';
-                div.style.top  = (startTop  + ev.clientY - startY) + 'px';
+            function onMove(e) {
+                div.style.left = (startLeft + e.clientX - startX) + 'px';
+                div.style.top = (startTop + e.clientY - startY) + 'px';
             }
 
             function onUp() {
                 document.removeEventListener('mousemove', onMove);
                 document.removeEventListener('mouseup', onUp);
-                var nL = parseFloat(div.style.left);
-                var nT = parseFloat(div.style.top);
-                var nW = parseFloat(div.style.width);
-                var nH = parseFloat(div.style.height);
                 var newBbox = [
-                    Math.round(nL / sx * 10) / 10,
-                    Math.round(nT / sy * 10) / 10,
-                    Math.round((nL + nW) / sx * 10) / 10,
-                    Math.round((nT + nH) / sy * 10) / 10,
+                    parseFloat(div.style.left) / sx,
+                    parseFloat(div.style.top) / sy,
+                    (parseFloat(div.style.left) + parseFloat(div.style.width)) / sx,
+                    (parseFloat(div.style.top) + parseFloat(div.style.height)) / sy,
                 ];
-                var oldBbox = det.bbox.slice();
-                fetch('/scans/' + documentId + '/update-detection/', {
-                    method: 'POST',
-                    headers: {'Content-Type': 'application/json', 'X-CSRFToken': csrfToken},
-                    body: JSON.stringify({
-                        page_index: det.page_index,
-                        label:      det.label,
-                        label_id:   det.label_id,
-                        old_bbox:   oldBbox,
-                        new_bbox:   newBbox,
-                    }),
-                }).then(function(r) { return r.json(); }).then(function(data) {
-                    if (data.status === 'ok') {
-                        det.bbox[0] = newBbox[0];
-                        det.bbox[1] = newBbox[1];
-                        det.bbox[2] = newBbox[2];
-                        det.bbox[3] = newBbox[3];
-                    }
-                });
+                _saveDetectionBbox(newBbox, det);
             }
 
             document.addEventListener('mousemove', onMove);
             document.addEventListener('mouseup', onUp);
         });
-
-        div.appendChild(toolbar);
     }
 
     function _deselectDetectionBox() {

--- a/scanning/static/scanning/viewer_step2.js
+++ b/scanning/static/scanning/viewer_step2.js
@@ -1740,6 +1740,7 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         }).catch(function() {
             console.error('Failed to save detection bbox');
+            showToast('Failed to save detection bbox');
         });
     }
 
@@ -1780,6 +1781,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 }
             }).catch(function() {
                 console.error('Failed to delete detection');
+                showToast('Failed to delete detection');
             });
         });
         toolbar.appendChild(deleteBtn);
@@ -1807,7 +1809,9 @@ document.addEventListener('DOMContentLoaded', function () {
                 var startW = parseFloat(div.style.width);
                 var startH = parseFloat(div.style.height);
 
+                var hasMoved = false;
                 function onMove(e) {
+                    hasMoved = true;
                     var dx = e.clientX - startX, dy = e.clientY - startY;
                     var newLeft = startLeft, newTop = startTop, newW = startW, newH = startH;
                     if (pos.indexOf('e') >= 0) newW = Math.max(10, startW + dx);
@@ -1823,6 +1827,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 function onUp() {
                     document.removeEventListener('mousemove', onMove);
                     document.removeEventListener('mouseup', onUp);
+                    if (!hasMoved) return;
                     var newBbox = [
                         parseFloat(div.style.left) / sx,
                         parseFloat(div.style.top) / sy,
@@ -1839,14 +1844,16 @@ document.addEventListener('DOMContentLoaded', function () {
         });
 
         // Drag-to-move (click on box body, not handles)
-        div.addEventListener('mousedown', function(e) {
+        div._moveHandler = function(e) {
             if (e.target !== div) return;
             e.preventDefault();
             var startX = e.clientX, startY = e.clientY;
             var startLeft = parseFloat(div.style.left);
             var startTop = parseFloat(div.style.top);
+            var hasMoved = false;
 
             function onMove(e) {
+                hasMoved = true;
                 div.style.left = (startLeft + e.clientX - startX) + 'px';
                 div.style.top = (startTop + e.clientY - startY) + 'px';
             }
@@ -1854,6 +1861,7 @@ document.addEventListener('DOMContentLoaded', function () {
             function onUp() {
                 document.removeEventListener('mousemove', onMove);
                 document.removeEventListener('mouseup', onUp);
+                if (!hasMoved) return;
                 var newBbox = [
                     parseFloat(div.style.left) / sx,
                     parseFloat(div.style.top) / sy,
@@ -1865,7 +1873,8 @@ document.addEventListener('DOMContentLoaded', function () {
 
             document.addEventListener('mousemove', onMove);
             document.addEventListener('mouseup', onUp);
-        });
+        };
+        div.addEventListener('mousedown', div._moveHandler);
     }
 
     function _deselectDetectionBox() {
@@ -1874,6 +1883,10 @@ document.addEventListener('DOMContentLoaded', function () {
         _selectedDetBox.style.zIndex = '';
         _selectedDetBox.style.cursor = '';
         _selectedDetBox.querySelectorAll('.det-resize-handle').forEach(function(el) { el.remove(); });
+        if (_selectedDetBox._moveHandler) {
+            _selectedDetBox.removeEventListener('mousedown', _selectedDetBox._moveHandler);
+            _selectedDetBox._moveHandler = null;
+        }
         _selectedDetBox = null;
     }
 

--- a/scanning/static/scanning/viewer_step2.js
+++ b/scanning/static/scanning/viewer_step2.js
@@ -1537,15 +1537,17 @@ document.addEventListener('DOMContentLoaded', function () {
 
         div.style.cursor = 'move';
 
-        div.addEventListener('mousedown', function(e) {
+        div._redactionMoveHandler = function(e) {
             if (e.target !== div) return;
             e.stopPropagation();
             e.preventDefault();
             var startX = e.clientX, startY = e.clientY;
             var startLeft = parseFloat(div.style.left);
             var startTop  = parseFloat(div.style.top);
+            var hasMoved = false;
 
             function onMove(ev) {
+                hasMoved = true;
                 div.style.left = (startLeft + ev.clientX - startX) + 'px';
                 div.style.top  = (startTop  + ev.clientY - startY) + 'px';
             }
@@ -1553,6 +1555,7 @@ document.addEventListener('DOMContentLoaded', function () {
             function onUp() {
                 document.removeEventListener('mousemove', onMove);
                 document.removeEventListener('mouseup', onUp);
+                if (!hasMoved) return;
                 var nL = parseFloat(div.style.left);
                 var nT = parseFloat(div.style.top);
                 var nW = parseFloat(div.style.width);
@@ -1579,7 +1582,8 @@ document.addEventListener('DOMContentLoaded', function () {
 
             document.addEventListener('mousemove', onMove);
             document.addEventListener('mouseup', onUp);
-        });
+        };
+        div.addEventListener('mousedown', div._redactionMoveHandler);
     }
 
     function _deselectRedactionBox() {
@@ -1589,6 +1593,10 @@ document.addEventListener('DOMContentLoaded', function () {
         _selectedRedactionBox.style.cursor = '';
         // Remove edit controls
         _selectedRedactionBox.querySelectorAll('.redaction-edit-btn, .redaction-resize-handle').forEach(function(el) { el.remove(); });
+        if (_selectedRedactionBox._redactionMoveHandler) {
+            _selectedRedactionBox.removeEventListener('mousedown', _selectedRedactionBox._redactionMoveHandler);
+            _selectedRedactionBox._redactionMoveHandler = null;
+        }
         _selectedRedactionBox = null;
     }
 
@@ -1605,7 +1613,9 @@ document.addEventListener('DOMContentLoaded', function () {
         var startW = parseFloat(div.style.width);
         var startH = parseFloat(div.style.height);
 
+        var hasMoved = false;
         function onMove(e) {
+            hasMoved = true;
             var dx = e.clientX - startX;
             var dy = e.clientY - startY;
             var newLeft = startLeft, newTop = startTop, newW = startW, newH = startH;
@@ -1622,6 +1632,7 @@ document.addEventListener('DOMContentLoaded', function () {
         function onUp() {
             document.removeEventListener('mousemove', onMove);
             document.removeEventListener('mouseup', onUp);
+            if (!hasMoved) return;
 
             // Update rectData with new position in PDF coordinates
             var newLeft = parseFloat(div.style.left);
@@ -1958,7 +1969,9 @@ document.addEventListener('DOMContentLoaded', function () {
                 var startW = parseFloat(div.style.width);
                 var startH = parseFloat(div.style.height);
 
+                var hasMoved = false;
                 function onMove(ev) {
+                    hasMoved = true;
                     var dx = ev.clientX - startX, dy = ev.clientY - startY;
                     var nL = startLeft, nT = startTop, nW = startW, nH = startH;
                     if (pos.indexOf('e') >= 0) nW = startW + dx;
@@ -1971,6 +1984,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 function onUp() {
                     document.removeEventListener('mousemove', onMove);
                     document.removeEventListener('mouseup', onUp);
+                    if (!hasMoved) return;
                     // Save updated margin rect (PDF points)
                     var nL = parseFloat(div.style.left);
                     var nT = parseFloat(div.style.top);

--- a/scanning/static/scanning/viewer_step2.js
+++ b/scanning/static/scanning/viewer_step2.js
@@ -369,13 +369,17 @@ document.addEventListener('DOMContentLoaded', function () {
             wrapper.style.width = viewport.width + 'px';
             wrapper.style.height = viewport.height + 'px';
             wrapper.style.background = '';
+            pageDiv.style.width = viewport.width + 'px';
 
             if (defaultPageWidth === 918 && viewport.width !== 918) {
                 defaultPageWidth = viewport.width;
                 container.querySelectorAll('.lazy-page').forEach(function (el) {
                     if (!renderedPages[parseInt(el.dataset.pdfIndex)]) {
                         var w = el.querySelector('.canvas-wrapper');
-                        if (w) w.style.width = defaultPageWidth + 'px';
+                        if (w) {
+                            w.style.width = defaultPageWidth + 'px';
+                            el.style.width = defaultPageWidth + 'px';
+                        }
                     }
                 });
             }

--- a/scanning/static/scanning/viewer_step2.js
+++ b/scanning/static/scanning/viewer_step2.js
@@ -1769,21 +1769,17 @@ document.addEventListener('DOMContentLoaded', function () {
             fetch('/scans/' + documentId + '/delete-detection/', {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json', 'X-CSRFToken': csrfToken},
-                body: JSON.stringify({
-                    page_index: det.page_index,
-                    label: det.label,
-                    label_id: det.label_id,
-                    bbox: det.bbox,
-                }),
+                body: JSON.stringify({detection_id: det.id}),
             }).then(function(r) { return r.json(); }).then(function(data) {
                 if (data.status === 'ok') {
-                    console.log('Deleted ' + data.deleted + ' detection(s) from DB for ' + det.label + ' on page_index=' + det.page_index);
                     div.remove();
                     _selectedDetBox = null;
                     var sidebarItems = document.querySelectorAll('[data-unmatched-page="' + det.page_index + '"][data-unmatched-label="' + det.label + '"]');
                     sidebarItems.forEach(function(el) { el.remove(); });
                     refreshOverlays();
                 }
+            }).catch(function() {
+                console.error('Failed to delete detection');
             });
         });
         toolbar.appendChild(deleteBtn);

--- a/scanning/static/scanning/viewer_step2.js
+++ b/scanning/static/scanning/viewer_step2.js
@@ -1534,12 +1534,59 @@ document.addEventListener('DOMContentLoaded', function () {
             });
             div.appendChild(h);
         });
+
+        div.style.cursor = 'move';
+
+        div.addEventListener('mousedown', function(e) {
+            if (e.target !== div) return;
+            e.stopPropagation();
+            e.preventDefault();
+            var startX = e.clientX, startY = e.clientY;
+            var startLeft = parseFloat(div.style.left);
+            var startTop  = parseFloat(div.style.top);
+
+            function onMove(ev) {
+                div.style.left = (startLeft + ev.clientX - startX) + 'px';
+                div.style.top  = (startTop  + ev.clientY - startY) + 'px';
+            }
+
+            function onUp() {
+                document.removeEventListener('mousemove', onMove);
+                document.removeEventListener('mouseup', onUp);
+                var nL = parseFloat(div.style.left);
+                var nT = parseFloat(div.style.top);
+                var nW = parseFloat(div.style.width);
+                var nH = parseFloat(div.style.height);
+                var oldX0 = rectData.x0, oldY0 = rectData.y0;
+                var oldX1 = rectData.x1, oldY1 = rectData.y1;
+                rectData.x0 = Math.round(nL / dsx * 10) / 10;
+                rectData.y0 = Math.round(nT / dsy * 10) / 10;
+                rectData.x1 = Math.round((nL + nW) / dsx * 10) / 10;
+                rectData.y1 = Math.round((nT + nH) / dsy * 10) / 10;
+                var csrfToken = document.querySelector('[name=csrfmiddlewaretoken]').value;
+                fetch('/scans/' + documentId + '/save-redaction-rect/', {
+                    method: 'POST',
+                    headers: {'X-CSRFToken': csrfToken, 'Content-Type': 'application/json'},
+                    body: JSON.stringify({
+                        page_index: _pageIndexForNum(pageNum),
+                        original: {x0: oldX0, y0: oldY0, x1: oldX1, y1: oldY1},
+                        adjusted: {x0: rectData.x0, y0: rectData.y0, x1: rectData.x1, y1: rectData.y1},
+                        type: rectData.type,
+                        fill: rectData.fill,
+                    }),
+                });
+            }
+
+            document.addEventListener('mousemove', onMove);
+            document.addEventListener('mouseup', onUp);
+        });
     }
 
     function _deselectRedactionBox() {
         if (!_selectedRedactionBox) return;
         _selectedRedactionBox.style.outline = '';
         _selectedRedactionBox.style.zIndex = '6';
+        _selectedRedactionBox.style.cursor = '';
         // Remove edit controls
         _selectedRedactionBox.querySelectorAll('.redaction-edit-btn, .redaction-resize-handle').forEach(function(el) { el.remove(); });
         _selectedRedactionBox = null;

--- a/scanning/templates/scanning/scan_process.html
+++ b/scanning/templates/scanning/scan_process.html
@@ -253,6 +253,7 @@
            data-logical-page="{{ d.logical_page }}" data-page-index="{{ d.page_index }}"
            data-bbox="{{ d.bbox.0 }},{{ d.bbox.1 }},{{ d.bbox.2 }},{{ d.bbox.3 }}"
            data-img-w="{{ d.img_width }}" data-img-h="{{ d.img_height }}" data-label-id="{{ d.label_id }}"
+           data-detection-id="{{ d.id }}"
            onclick="highlightDetection(this)">
         <span class="font-medium">p.{{ d.logical_page }}</span>
         <span class="text-gray-500 dark:text-gray-400">{{ d.conf }}</span>
@@ -274,6 +275,7 @@
            data-logical-page="{{ d.logical_page }}" data-page-index="{{ d.page_index }}"
            data-bbox="{{ d.bbox.0 }},{{ d.bbox.1 }},{{ d.bbox.2 }},{{ d.bbox.3 }}"
            data-img-w="{{ d.img_width }}" data-img-h="{{ d.img_height }}" data-label-id="{{ d.label_id }}"
+           data-detection-id="{{ d.id }}"
            onclick="highlightDetection(this)">
         <span class="font-medium">p.{{ d.logical_page }}</span>
         <span class="text-gray-500 dark:text-gray-400">{{ d.conf }}</span>

--- a/scanning/tests/test_views.py
+++ b/scanning/tests/test_views.py
@@ -1,4 +1,6 @@
 import io
+import json
+import pathlib
 import shutil
 import tempfile
 from datetime import timedelta
@@ -1034,3 +1036,131 @@ class TestRunFullPipelinePullsFromS3(ScanningTestCase):
             run_full_pipeline(scan.pk)
 
         mock_pull.assert_called_once_with(scan.pk)
+
+
+@override_settings(MEDIA_ROOT=MEDIA_ROOT)
+class TestUpdateDetection(ScanningTestCase):
+    """Tests for the update_detection API endpoint."""
+
+    def _make_scan_with_detection(self):
+        """Create a scan, output dir, Detection, and detections.json.
+
+        :returns: Tuple of (scan, detection, det_path).
+        :rtype: tuple
+        """
+        scan = ScanFactory()
+        output = pathlib.Path(scan.output_dir)
+        output.mkdir(parents=True, exist_ok=True)
+        det = Detection.objects.create(
+            scan=scan,
+            page_index=0,
+            label="CASE_CAPTION",
+            label_id=0,
+            confidence=0.9,
+            x0=100.0,
+            y0=100.0,
+            x1=200.0,
+            y1=200.0,
+            img_width=1000,
+            img_height=1000,
+        )
+        det_path = output / "detections.json"
+        det_path.write_text(
+            json.dumps(
+                [
+                    {
+                        "page_index": 0,
+                        "label": "CASE_CAPTION",
+                        "label_id": 0,
+                        "confidence": 0.9,
+                        "bbox": [100.0, 100.0, 200.0, 200.0],
+                        "img_width": 1000,
+                        "img_height": 1000,
+                        "model_count": 1,
+                    }
+                ]
+            )
+        )
+        return scan, det, det_path
+
+    def _post(self, scan, body):
+        """POST JSON body to the update_detection endpoint.
+
+        :param scan: The scan instance.
+        :param body: Dict to serialize as JSON.
+        :returns: The response.
+        """
+        return self.client.post(
+            reverse("update_detection", kwargs={"pk": scan.pk}),
+            data=json.dumps(body),
+            content_type="application/json",
+        )
+
+    def test_updates_db_and_disk(self):
+        """Bbox update is persisted to both the DB and detections.json."""
+        user = self.make_user()
+        self.client.force_login(user)
+        scan, det, det_path = self._make_scan_with_detection()
+
+        response = self._post(
+            scan,
+            {
+                "page_index": 0,
+                "label": "CASE_CAPTION",
+                "old_bbox": [100.0, 100.0, 200.0, 200.0],
+                "new_bbox": [150.0, 150.0, 250.0, 250.0],
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "ok", "updated": 1})
+        det.refresh_from_db()
+        self.assertEqual(det.x0, 150.0)
+        self.assertEqual(det.y0, 150.0)
+        self.assertEqual(det.x1, 250.0)
+        self.assertEqual(det.y1, 250.0)
+        disk = json.loads(det_path.read_text())
+        self.assertEqual(disk[0]["bbox"], [150.0, 150.0, 250.0, 250.0])
+
+    def test_updates_by_label_id(self):
+        """Bbox update works when matched by label_id instead of label."""
+        user = self.make_user()
+        self.client.force_login(user)
+        scan, det, det_path = self._make_scan_with_detection()
+
+        response = self._post(
+            scan,
+            {
+                "page_index": 0,
+                "label_id": 0,
+                "old_bbox": [100.0, 100.0, 200.0, 200.0],
+                "new_bbox": [10.0, 10.0, 50.0, 50.0],
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["updated"], 1)
+        det.refresh_from_db()
+        self.assertEqual(det.x0, 10.0)
+        self.assertEqual(det.x1, 50.0)
+        disk = json.loads(det_path.read_text())
+        self.assertEqual(disk[0]["bbox"], [10.0, 10.0, 50.0, 50.0])
+
+    def test_missing_detections_json_returns_404(self):
+        """Returns 404 when detections.json does not exist on disk."""
+        user = self.make_user()
+        self.client.force_login(user)
+        scan, _det, det_path = self._make_scan_with_detection()
+        det_path.unlink()
+
+        response = self._post(
+            scan,
+            {
+                "page_index": 0,
+                "label": "CASE_CAPTION",
+                "old_bbox": [100.0, 100.0, 200.0, 200.0],
+                "new_bbox": [150.0, 150.0, 250.0, 250.0],
+            },
+        )
+
+        self.assertEqual(response.status_code, 404)

--- a/scanning/tests/test_views.py
+++ b/scanning/tests/test_views.py
@@ -1125,3 +1125,162 @@ class TestUpdateDetection(ScanningTestCase):
         body = json.loads(response.content)
         self.assertEqual(body["status"], "ok")
         self.assertEqual(body["updated"], 0)
+
+
+class TestDeleteDetection(ScanningTestCase):
+    """Tests for the delete_detection endpoint."""
+
+    def _make_scan_with_detection(self):
+        """Create a scan, its output_dir, and one active Detection record.
+
+        :return: Tuple of (scan, detection).
+        :rtype: tuple
+        """
+        scan = ScanFactory()
+        output = pathlib.Path(scan.output_dir)
+        output.mkdir(parents=True, exist_ok=True)
+        det = Detection.objects.create(
+            scan=scan,
+            page_index=0,
+            label="CASE_CAPTION",
+            label_id=1,
+            confidence=0.9,
+            x0=100.0,
+            y0=100.0,
+            x1=200.0,
+            y1=200.0,
+            img_width=1200,
+            img_height=1600,
+            model_name=Detection.ModelName.SMALL,
+            model_count=1,
+            found_by=[{"model": "small", "confidence": 0.9}],
+        )
+        return scan, det
+
+    def test_deactivates_db_and_removes_from_disk(self):
+        """POST with valid detection_id sets active=False and removes it from detections.json."""
+        from unittest.mock import patch
+
+        user = self.make_staff_user()
+        self.client.force_login(user)
+        scan, det = self._make_scan_with_detection()
+
+        with patch("scanning.s3_sync.upload_file_to_s3"):
+            response = self.client.post(
+                reverse("delete_detection", kwargs={"pk": scan.pk}),
+                data=json.dumps({"detection_id": det.pk}),
+                content_type="application/json",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        body = json.loads(response.content)
+        self.assertEqual(body["status"], "ok")
+        self.assertEqual(body["deleted"], 1)
+
+        det.refresh_from_db()
+        self.assertFalse(det.active)
+
+        det_path = pathlib.Path(scan.output_dir) / "detections.json"
+        self.assertTrue(det_path.exists())
+        saved = json.loads(det_path.read_text())
+        self.assertEqual(len(saved), 0)
+
+    def test_unknown_id_deletes_zero(self):
+        """POST with a non-existent detection_id returns deleted=0 without error."""
+        from unittest.mock import patch
+
+        user = self.make_staff_user()
+        self.client.force_login(user)
+        scan, _det = self._make_scan_with_detection()
+
+        with patch("scanning.s3_sync.upload_file_to_s3"):
+            response = self.client.post(
+                reverse("delete_detection", kwargs={"pk": scan.pk}),
+                data=json.dumps({"detection_id": 999999}),
+                content_type="application/json",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        body = json.loads(response.content)
+        self.assertEqual(body["status"], "ok")
+        self.assertEqual(body["deleted"], 0)
+
+
+class TestApproveDetection(ScanningTestCase):
+    """Tests for the approve_detection endpoint."""
+
+    def _make_scan_with_detection(self):
+        """Create a scan, its output_dir, and one Detection record.
+
+        :return: Tuple of (scan, detection).
+        :rtype: tuple
+        """
+        scan = ScanFactory()
+        output = pathlib.Path(scan.output_dir)
+        output.mkdir(parents=True, exist_ok=True)
+        det = Detection.objects.create(
+            scan=scan,
+            page_index=0,
+            label="KEY_ICON",
+            label_id=2,
+            confidence=0.7,
+            x0=50.0,
+            y0=50.0,
+            x1=100.0,
+            y1=100.0,
+            img_width=1200,
+            img_height=1600,
+            model_name=Detection.ModelName.SMALL,
+            model_count=1,
+            found_by=[{"model": "small", "confidence": 0.7}],
+        )
+        return scan, det
+
+    def test_sets_confidence_and_syncs_disk(self):
+        """POST with valid detection_id sets confidence=1.0 and updates detections.json."""
+        from unittest.mock import patch
+
+        user = self.make_staff_user()
+        self.client.force_login(user)
+        scan, det = self._make_scan_with_detection()
+
+        with patch("scanning.s3_sync.upload_file_to_s3"):
+            response = self.client.post(
+                reverse("approve_detection", kwargs={"pk": scan.pk}),
+                data=json.dumps({"detection_id": det.pk}),
+                content_type="application/json",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        body = json.loads(response.content)
+        self.assertEqual(body["status"], "ok")
+        self.assertEqual(body["updated"], 1)
+
+        det.refresh_from_db()
+        self.assertEqual(det.confidence, 1.0)
+
+        det_path = pathlib.Path(scan.output_dir) / "detections.json"
+        self.assertTrue(det_path.exists())
+        saved = json.loads(det_path.read_text())
+        self.assertEqual(len(saved), 1)
+        self.assertEqual(saved[0]["confidence"], 1.0)
+
+    def test_unknown_id_updates_zero(self):
+        """POST with a non-existent detection_id returns updated=0 without error."""
+        from unittest.mock import patch
+
+        user = self.make_staff_user()
+        self.client.force_login(user)
+        scan, _det = self._make_scan_with_detection()
+
+        with patch("scanning.s3_sync.upload_file_to_s3"):
+            response = self.client.post(
+                reverse("approve_detection", kwargs={"pk": scan.pk}),
+                data=json.dumps({"detection_id": 999999}),
+                content_type="application/json",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        body = json.loads(response.content)
+        self.assertEqual(body["status"], "ok")
+        self.assertEqual(body["updated"], 0)

--- a/scanning/tests/test_views.py
+++ b/scanning/tests/test_views.py
@@ -1022,7 +1022,9 @@ class TestRunFullPipelinePullsFromS3(ScanningTestCase):
             # close_all() resets connections for daemon-process forking; in
             # tests it kills the test transaction -- patch it out.
             patch("django.db.connections.close_all"),
-            patch("scanning.services._pull_processing_files_from_s3"),
+            patch(
+                "scanning.services._pull_processing_files_from_s3"
+            ) as mock_pull,
             # Stop the pipeline early by failing the first read.
             patch(
                 "scanning.services.ensure_output_dir",
@@ -1032,6 +1034,8 @@ class TestRunFullPipelinePullsFromS3(ScanningTestCase):
             from scanning.services import run_full_pipeline
 
             run_full_pipeline(scan.pk)
+
+        mock_pull.assert_called_once_with(scan.pk)
 
 
 class TestUpdateDetection(ScanningTestCase):
@@ -1101,8 +1105,8 @@ class TestUpdateDetection(ScanningTestCase):
         self.assertEqual(len(saved), 1)
         self.assertEqual(saved[0]["bbox"], [150.0, 150.0, 250.0, 250.0])
 
-    def test_unknown_detection_id_updates_zero(self):
-        """POST with a non-existent detection_id returns updated=0 without error."""
+    def test_unknown_detection_id_returns_404(self):
+        """POST with a non-existent detection_id returns 404."""
         from unittest.mock import patch
 
         user = self.make_staff_user()
@@ -1121,10 +1125,9 @@ class TestUpdateDetection(ScanningTestCase):
                 content_type="application/json",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 404)
         body = json.loads(response.content)
-        self.assertEqual(body["status"], "ok")
-        self.assertEqual(body["updated"], 0)
+        self.assertEqual(body["status"], "error")
 
 
 class TestDeleteDetection(ScanningTestCase):
@@ -1185,8 +1188,8 @@ class TestDeleteDetection(ScanningTestCase):
         saved = json.loads(det_path.read_text())
         self.assertEqual(len(saved), 0)
 
-    def test_unknown_id_deletes_zero(self):
-        """POST with a non-existent detection_id returns deleted=0 without error."""
+    def test_unknown_id_returns_404(self):
+        """POST with a non-existent detection_id returns 404."""
         from unittest.mock import patch
 
         user = self.make_staff_user()
@@ -1200,10 +1203,9 @@ class TestDeleteDetection(ScanningTestCase):
                 content_type="application/json",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 404)
         body = json.loads(response.content)
-        self.assertEqual(body["status"], "ok")
-        self.assertEqual(body["deleted"], 0)
+        self.assertEqual(body["status"], "error")
 
 
 class TestApproveDetection(ScanningTestCase):
@@ -1265,8 +1267,8 @@ class TestApproveDetection(ScanningTestCase):
         self.assertEqual(len(saved), 1)
         self.assertEqual(saved[0]["confidence"], 1.0)
 
-    def test_unknown_id_updates_zero(self):
-        """POST with a non-existent detection_id returns updated=0 without error."""
+    def test_unknown_id_returns_404(self):
+        """POST with a non-existent detection_id returns 404."""
         from unittest.mock import patch
 
         user = self.make_staff_user()
@@ -1280,7 +1282,6 @@ class TestApproveDetection(ScanningTestCase):
                 content_type="application/json",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 404)
         body = json.loads(response.content)
-        self.assertEqual(body["status"], "ok")
-        self.assertEqual(body["updated"], 0)
+        self.assertEqual(body["status"], "error")

--- a/scanning/tests/test_views.py
+++ b/scanning/tests/test_views.py
@@ -1022,9 +1022,7 @@ class TestRunFullPipelinePullsFromS3(ScanningTestCase):
             # close_all() resets connections for daemon-process forking; in
             # tests it kills the test transaction -- patch it out.
             patch("django.db.connections.close_all"),
-            patch(
-                "scanning.services._pull_processing_files_from_s3"
-            ) as mock_pull,
+            patch("scanning.services._pull_processing_files_from_s3"),
             # Stop the pipeline early by failing the first read.
             patch(
                 "scanning.services.ensure_output_dir",
@@ -1035,17 +1033,14 @@ class TestRunFullPipelinePullsFromS3(ScanningTestCase):
 
             run_full_pipeline(scan.pk)
 
-        mock_pull.assert_called_once_with(scan.pk)
 
-
-@override_settings(MEDIA_ROOT=MEDIA_ROOT)
 class TestUpdateDetection(ScanningTestCase):
-    """Tests for the update_detection API endpoint."""
+    """Tests for the update_detection endpoint."""
 
     def _make_scan_with_detection(self):
-        """Create a scan, output dir, Detection, and detections.json.
+        """Create a scan, its output_dir, and one Detection record.
 
-        :returns: Tuple of (scan, detection, det_path).
+        :return: Tuple of (scan, detection).
         :rtype: tuple
         """
         scan = ScanFactory()
@@ -1055,112 +1050,78 @@ class TestUpdateDetection(ScanningTestCase):
             scan=scan,
             page_index=0,
             label="CASE_CAPTION",
-            label_id=0,
+            label_id=1,
             confidence=0.9,
             x0=100.0,
             y0=100.0,
             x1=200.0,
             y1=200.0,
-            img_width=1000,
-            img_height=1000,
+            img_width=1200,
+            img_height=1600,
+            model_name=Detection.ModelName.SMALL,
+            model_count=1,
+            found_by=[{"model": "yolo", "confidence": 0.9}],
         )
-        det_path = output / "detections.json"
-        det_path.write_text(
-            json.dumps(
-                [
-                    {
-                        "page_index": 0,
-                        "label": "CASE_CAPTION",
-                        "label_id": 0,
-                        "confidence": 0.9,
-                        "bbox": [100.0, 100.0, 200.0, 200.0],
-                        "img_width": 1000,
-                        "img_height": 1000,
-                        "model_count": 1,
-                    }
-                ]
-            )
-        )
-        return scan, det, det_path
-
-    def _post(self, scan, body):
-        """POST JSON body to the update_detection endpoint.
-
-        :param scan: The scan instance.
-        :param body: Dict to serialize as JSON.
-        :returns: The response.
-        """
-        return self.client.post(
-            reverse("update_detection", kwargs={"pk": scan.pk}),
-            data=json.dumps(body),
-            content_type="application/json",
-        )
+        return scan, det
 
     def test_updates_db_and_disk(self):
-        """Bbox update is persisted to both the DB and detections.json."""
-        user = self.make_user()
-        self.client.force_login(user)
-        scan, det, det_path = self._make_scan_with_detection()
+        """POST with valid detection_id updates DB coords and writes detections.json."""
+        from unittest.mock import patch
 
-        response = self._post(
-            scan,
-            {
-                "page_index": 0,
-                "label": "CASE_CAPTION",
-                "old_bbox": [100.0, 100.0, 200.0, 200.0],
-                "new_bbox": [150.0, 150.0, 250.0, 250.0],
-            },
-        )
+        user = self.make_staff_user()
+        self.client.force_login(user)
+        scan, det = self._make_scan_with_detection()
+
+        with patch("scanning.s3_sync.upload_file_to_s3"):
+            response = self.client.post(
+                reverse("update_detection", kwargs={"pk": scan.pk}),
+                data=json.dumps(
+                    {
+                        "detection_id": det.pk,
+                        "new_bbox": [150.0, 150.0, 250.0, 250.0],
+                    }
+                ),
+                content_type="application/json",
+            )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {"status": "ok", "updated": 1})
+        body = json.loads(response.content)
+        self.assertEqual(body["status"], "ok")
+        self.assertEqual(body["updated"], 1)
+
         det.refresh_from_db()
         self.assertEqual(det.x0, 150.0)
         self.assertEqual(det.y0, 150.0)
         self.assertEqual(det.x1, 250.0)
         self.assertEqual(det.y1, 250.0)
-        disk = json.loads(det_path.read_text())
-        self.assertEqual(disk[0]["bbox"], [150.0, 150.0, 250.0, 250.0])
 
-    def test_updates_by_label_id(self):
-        """Bbox update works when matched by label_id instead of label."""
-        user = self.make_user()
+        det_path = pathlib.Path(scan.output_dir) / "detections.json"
+        self.assertTrue(det_path.exists())
+        saved = json.loads(det_path.read_text())
+        self.assertEqual(len(saved), 1)
+        self.assertEqual(saved[0]["bbox"], [150.0, 150.0, 250.0, 250.0])
+
+    def test_unknown_detection_id_updates_zero(self):
+        """POST with a non-existent detection_id returns updated=0 without error."""
+        from unittest.mock import patch
+
+        user = self.make_staff_user()
         self.client.force_login(user)
-        scan, det, det_path = self._make_scan_with_detection()
+        scan, _det = self._make_scan_with_detection()
 
-        response = self._post(
-            scan,
-            {
-                "page_index": 0,
-                "label_id": 0,
-                "old_bbox": [100.0, 100.0, 200.0, 200.0],
-                "new_bbox": [10.0, 10.0, 50.0, 50.0],
-            },
-        )
+        with patch("scanning.s3_sync.upload_file_to_s3"):
+            response = self.client.post(
+                reverse("update_detection", kwargs={"pk": scan.pk}),
+                data=json.dumps(
+                    {
+                        "detection_id": 999999,
+                        "new_bbox": [0.0, 0.0, 10.0, 10.0],
+                    }
+                ),
+                content_type="application/json",
+            )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["updated"], 1)
-        det.refresh_from_db()
-        self.assertEqual(det.x0, 10.0)
-        self.assertEqual(det.x1, 50.0)
-        disk = json.loads(det_path.read_text())
-        self.assertEqual(disk[0]["bbox"], [10.0, 10.0, 50.0, 50.0])
-
-    def test_missing_detections_json_returns_404(self):
-        """Returns 404 when detections.json does not exist on disk."""
-        user = self.make_user()
-        self.client.force_login(user)
-        scan, _det, det_path = self._make_scan_with_detection()
-        det_path.unlink()
-
-        response = self._post(
-            scan,
-            {
-                "page_index": 0,
-                "label": "CASE_CAPTION",
-                "old_bbox": [100.0, 100.0, 200.0, 200.0],
-                "new_bbox": [150.0, 150.0, 250.0, 250.0],
-            },
-        )
-
-        self.assertEqual(response.status_code, 404)
+        body = json.loads(response.content)
+        self.assertEqual(body["status"], "ok")
+        self.assertEqual(body["updated"], 0)

--- a/scanning/urls.py
+++ b/scanning/urls.py
@@ -40,6 +40,7 @@ from scanning.views_api import (
     serve_opinionscan_pdf,
     serve_redacted_pdf,
     serve_redaction_rects,
+    update_detection,
 )
 from scanning.views_process import (
     add_page_insert,
@@ -196,6 +197,11 @@ urlpatterns = [
         "scans/<int:pk>/delete-detection/",
         delete_detection,
         name="delete_detection",
+    ),
+    path(
+        "scans/<int:pk>/update-detection/",
+        update_detection,
+        name="update_detection",
     ),
     path(
         "scans/<int:pk>/bake-redactions/",

--- a/scanning/views_api.py
+++ b/scanning/views_api.py
@@ -689,7 +689,7 @@ def delete_detection(request: HttpRequest, pk: int) -> JsonResponse:
     :param request: The HTTP request (JSON body with ``detection_id``
         (int, DB pk)).
     :param pk: Scan primary key.
-    :return: JSON response with the count of deactivated detections.
+    :return: JSON response with ``deleted`` count, or 404 if not found.
     """
     from scanning.services import _sync_detections_to_disk
 
@@ -701,6 +701,10 @@ def delete_detection(request: HttpRequest, pk: int) -> JsonResponse:
     count = Detection.objects.filter(pk=detection_id, scan=scan).update(
         active=False
     )
+    if count == 0:
+        return JsonResponse(
+            {"status": "error", "message": "Detection not found"}, status=404
+        )
     output_dir = Path(scan.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
     _sync_detections_to_disk(scan.pk)
@@ -719,7 +723,7 @@ def update_detection(request: HttpRequest, pk: int) -> JsonResponse:
     :param request: The HTTP request (JSON body with ``detection_id``
         (int, DB pk) and ``new_bbox`` (list[float], ``[x0,y0,x1,y1]``)).
     :param pk: Scan primary key.
-    :return: JSON response with ``updated`` count (0 if id not found).
+    :return: JSON response with ``updated`` count, or 404 if not found.
     """
     from scanning.services import _sync_detections_to_disk
 
@@ -735,6 +739,10 @@ def update_detection(request: HttpRequest, pk: int) -> JsonResponse:
         x1=new_bbox[2],
         y1=new_bbox[3],
     )
+    if count == 0:
+        return JsonResponse(
+            {"status": "error", "message": "Detection not found"}, status=404
+        )
     output_dir = Path(scan.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
     _sync_detections_to_disk(scan.pk)
@@ -827,7 +835,7 @@ def approve_detection(request: HttpRequest, pk: int) -> JsonResponse:
     :param request: The HTTP request (JSON body with ``detection_id``
         (int, DB pk)).
     :param pk: Scan primary key.
-    :return: JSON response with the count of updated detections.
+    :return: JSON response with ``updated`` count, or 404 if not found.
     """
     from scanning.services import _sync_detections_to_disk
 
@@ -839,6 +847,10 @@ def approve_detection(request: HttpRequest, pk: int) -> JsonResponse:
     count = Detection.objects.filter(pk=detection_id, scan=scan).update(
         confidence=1.0
     )
+    if count == 0:
+        return JsonResponse(
+            {"status": "error", "message": "Detection not found"}, status=404
+        )
     output_dir = Path(scan.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
     _sync_detections_to_disk(scan.pk)

--- a/scanning/views_api.py
+++ b/scanning/views_api.py
@@ -84,6 +84,7 @@ def serve_detections(request: HttpRequest, pk: int) -> JsonResponse:
     )
     data = [
         {
+            "id": d.pk,
             "page_index": d.page_index,
             "label": d.label,
             "label_id": d.label_id,
@@ -735,67 +736,34 @@ def delete_detection(request: HttpRequest, pk: int) -> JsonResponse:
 @login_required
 @require_POST
 def update_detection(request: HttpRequest, pk: int) -> JsonResponse:
-    """Update the bounding box of an existing detection in place.
+    """Update the bounding box of an existing detection.
 
-    Locates the detection by ``page_index``, label/label_id, and the
-    old ``bbox`` (±15 px tolerance on x0/y0), then replaces its
-    coordinates in both the DB and ``detections.json`` on disk.
+    Looks up the detection by its DB primary key, updates the bbox
+    columns, then rebuilds ``detections.json`` from the DB via
+    ``_sync_detections_to_disk`` so the file and S3 stay in sync.
 
-    :param request: The HTTP request. JSON body must contain:
-        ``page_index`` (int), ``label`` (str, optional),
-        ``label_id`` (int, optional), ``old_bbox`` (list[float]),
-        and ``new_bbox`` (list[float]).
+    :param request: The HTTP request (JSON body with ``detection_id``
+        (int, DB pk) and ``new_bbox`` (list[float], ``[x0,y0,x1,y1]``)).
     :param pk: Scan primary key.
-    :return: JSON ``{"status": "ok", "updated": <count>}`` on success.
-    :rtype: JsonResponse
+    :return: JSON response with ``updated`` count (0 if id not found).
     """
+    from scanning.services import _sync_detections_to_disk
+
     scan = get_object_or_404(Scan, pk=pk)
     data = _parse_json_body(request)
     if isinstance(data, JsonResponse):
         return data
-    page_index = data["page_index"]
-    label = data.get("label", "")
-    label_id = data.get("label_id")
-    old_bbox = data["old_bbox"]
+    detection_id = data["detection_id"]
     new_bbox = data["new_bbox"]
-    db_filter = dict(
-        scan=scan,
-        page_index=page_index,
-        x0__gte=old_bbox[0] - 15,
-        x0__lte=old_bbox[0] + 15,
-        y0__gte=old_bbox[1] - 15,
-        y0__lte=old_bbox[1] + 15,
+    count = Detection.objects.filter(pk=detection_id, scan=scan).update(
+        x0=new_bbox[0],
+        y0=new_bbox[1],
+        x1=new_bbox[2],
+        y1=new_bbox[3],
     )
-    if label:
-        db_filter["label"] = label
-    elif label_id is not None:
-        db_filter["label_id"] = label_id
-    count = Detection.objects.filter(**db_filter).update(
-        x0=new_bbox[0], y0=new_bbox[1], x1=new_bbox[2], y1=new_bbox[3]
-    )
-    output_base = Path(scan.output_dir)
-    det_path = find_json_file(output_base, "detections.json")
-    if not det_path:
-        return JsonResponse({"error": "No detections.json"}, status=404)
-    existing = json.loads(det_path.read_text())
-    for e in existing:
-        if e["page_index"] != page_index:
-            continue
-        if label and e.get("label") != label:
-            continue
-        if (
-            not label
-            and label_id is not None
-            and e.get("label_id") != label_id
-        ):
-            continue
-        if (
-            abs(e["bbox"][0] - old_bbox[0]) < 15
-            and abs(e["bbox"][1] - old_bbox[1]) < 15
-        ):
-            e["bbox"] = [new_bbox[0], new_bbox[1], new_bbox[2], new_bbox[3]]
-            break
-    det_path.write_text(json.dumps(existing))
+    output_dir = Path(scan.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _sync_detections_to_disk(scan.pk)
     return JsonResponse({"status": "ok", "updated": count})
 
 

--- a/scanning/views_api.py
+++ b/scanning/views_api.py
@@ -684,52 +684,26 @@ def remove_flag(request: HttpRequest, pk: int, flag_id: int) -> JsonResponse:
 @login_required
 @require_POST
 def delete_detection(request: HttpRequest, pk: int) -> JsonResponse:
-    """Deactivate a detection in the database and remove it from disk.
+    """Deactivate a detection in the database and sync the JSON file.
 
-    :param request: The HTTP request (JSON body with page_index,
-        label, label_id, and bbox).
+    :param request: The HTTP request (JSON body with ``detection_id``
+        (int, DB pk)).
     :param pk: Scan primary key.
     :return: JSON response with the count of deactivated detections.
     """
+    from scanning.services import _sync_detections_to_disk
+
     scan = get_object_or_404(Scan, pk=pk)
     data = _parse_json_body(request)
     if isinstance(data, JsonResponse):
         return data
-    page_index = data["page_index"]
-    label = data.get("label", "")
-    label_id = data.get("label_id")
-    bbox = data["bbox"]
-    # Deactivate matching Detection(s) in DB
-    db_filter = dict(
-        scan=scan,
-        page_index=page_index,
-        x0__gte=bbox[0] - 15,
-        x0__lte=bbox[0] + 15,
-        y0__gte=bbox[1] - 15,
-        y0__lte=bbox[1] + 15,
+    detection_id = data["detection_id"]
+    count = Detection.objects.filter(pk=detection_id, scan=scan).update(
+        active=False
     )
-    if label:
-        db_filter["label"] = label
-    elif label_id is not None:
-        db_filter["label_id"] = label_id
-    qs = Detection.objects.filter(**db_filter)
-    count = qs.update(active=False)
-    # Remove from detections.json on disk
-    output_base = Path(scan.output_dir)
-    det_path = find_json_file(output_base, "detections.json")
-    if det_path:
-        existing = json.loads(det_path.read_text())
-        existing = [
-            e
-            for e in existing
-            if not (
-                e["page_index"] == page_index
-                and (e.get("label") == label or e.get("label_id") == label_id)
-                and abs(e["bbox"][0] - bbox[0]) < 15
-                and abs(e["bbox"][1] - bbox[1]) < 15
-            )
-        ]
-        det_path.write_text(json.dumps(existing))
+    output_dir = Path(scan.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _sync_detections_to_disk(scan.pk)
     return JsonResponse({"status": "ok", "deleted": count})
 
 
@@ -848,60 +822,26 @@ def add_single_detection(request: HttpRequest, pk: int) -> JsonResponse:
 @login_required
 @require_POST
 def approve_detection(request: HttpRequest, pk: int) -> JsonResponse:
-    """Set a detection's confidence to 1.0 in the DB and on disk.
+    """Set a detection's confidence to 1.0 in the DB and sync the JSON file.
 
-    :param request: The HTTP request (JSON body with page_index,
-        label, label_id, and bbox).
+    :param request: The HTTP request (JSON body with ``detection_id``
+        (int, DB pk)).
     :param pk: Scan primary key.
     :return: JSON response with the count of updated detections.
     """
+    from scanning.services import _sync_detections_to_disk
+
     scan = get_object_or_404(Scan, pk=pk)
     data = _parse_json_body(request)
     if isinstance(data, JsonResponse):
         return data
-    page_index = data["page_index"]
-    label = data.get("label", "")
-    label_id = data.get("label_id")
-    bbox = data["bbox"]
-
-    # Update matching Detection(s) in DB
-    db_filter = dict(
-        scan=scan,
-        page_index=page_index,
-        x0__gte=bbox[0] - 15,
-        x0__lte=bbox[0] + 15,
-        y0__gte=bbox[1] - 15,
-        y0__lte=bbox[1] + 15,
+    detection_id = data["detection_id"]
+    count = Detection.objects.filter(pk=detection_id, scan=scan).update(
+        confidence=1.0
     )
-    if label:
-        db_filter["label"] = label
-    elif label_id is not None:
-        db_filter["label_id"] = label_id
-    count = Detection.objects.filter(**db_filter).update(confidence=1.0)
-
-    # Update confidence in detections.json on disk
-    output_base = Path(scan.output_dir)
-    det_path = find_json_file(output_base, "detections.json")
-    if det_path:
-        existing = json.loads(det_path.read_text())
-        for e in existing:
-            if e["page_index"] != page_index:
-                continue
-            if label and e.get("label") != label:
-                continue
-            if (
-                not label
-                and label_id is not None
-                and e.get("label_id") != label_id
-            ):
-                continue
-            if (
-                abs(e["bbox"][0] - bbox[0]) < 15
-                and abs(e["bbox"][1] - bbox[1]) < 15
-            ):
-                e["confidence"] = 1.0
-        det_path.write_text(json.dumps(existing))
-
+    output_dir = Path(scan.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _sync_detections_to_disk(scan.pk)
     return JsonResponse({"status": "ok", "updated": count})
 
 

--- a/scanning/views_api.py
+++ b/scanning/views_api.py
@@ -734,6 +734,73 @@ def delete_detection(request: HttpRequest, pk: int) -> JsonResponse:
 
 @login_required
 @require_POST
+def update_detection(request: HttpRequest, pk: int) -> JsonResponse:
+    """Update the bounding box of an existing detection in place.
+
+    Locates the detection by ``page_index``, label/label_id, and the
+    old ``bbox`` (±15 px tolerance on x0/y0), then replaces its
+    coordinates in both the DB and ``detections.json`` on disk.
+
+    :param request: The HTTP request. JSON body must contain:
+        ``page_index`` (int), ``label`` (str, optional),
+        ``label_id`` (int, optional), ``old_bbox`` (list[float]),
+        and ``new_bbox`` (list[float]).
+    :param pk: Scan primary key.
+    :return: JSON ``{"status": "ok", "updated": <count>}`` on success.
+    :rtype: JsonResponse
+    """
+    scan = get_object_or_404(Scan, pk=pk)
+    data = _parse_json_body(request)
+    if isinstance(data, JsonResponse):
+        return data
+    page_index = data["page_index"]
+    label = data.get("label", "")
+    label_id = data.get("label_id")
+    old_bbox = data["old_bbox"]
+    new_bbox = data["new_bbox"]
+    db_filter = dict(
+        scan=scan,
+        page_index=page_index,
+        x0__gte=old_bbox[0] - 15,
+        x0__lte=old_bbox[0] + 15,
+        y0__gte=old_bbox[1] - 15,
+        y0__lte=old_bbox[1] + 15,
+    )
+    if label:
+        db_filter["label"] = label
+    elif label_id is not None:
+        db_filter["label_id"] = label_id
+    count = Detection.objects.filter(**db_filter).update(
+        x0=new_bbox[0], y0=new_bbox[1], x1=new_bbox[2], y1=new_bbox[3]
+    )
+    output_base = Path(scan.output_dir)
+    det_path = find_json_file(output_base, "detections.json")
+    if not det_path:
+        return JsonResponse({"error": "No detections.json"}, status=404)
+    existing = json.loads(det_path.read_text())
+    for e in existing:
+        if e["page_index"] != page_index:
+            continue
+        if label and e.get("label") != label:
+            continue
+        if (
+            not label
+            and label_id is not None
+            and e.get("label_id") != label_id
+        ):
+            continue
+        if (
+            abs(e["bbox"][0] - old_bbox[0]) < 15
+            and abs(e["bbox"][1] - old_bbox[1]) < 15
+        ):
+            e["bbox"] = [new_bbox[0], new_bbox[1], new_bbox[2], new_bbox[3]]
+            break
+    det_path.write_text(json.dumps(existing))
+    return JsonResponse({"status": "ok", "updated": count})
+
+
+@login_required
+@require_POST
 def add_single_detection(request: HttpRequest, pk: int) -> JsonResponse:
     """Add a new detection or boost an existing one.
 

--- a/scanning/views_process.py
+++ b/scanning/views_process.py
@@ -45,6 +45,7 @@ def _unmatched_detection_dict(
     :rtype: dict
     """
     return {
+        "id": det.pk,
         "pdf_page": det.page_index + 1,
         "page_index": det.page_index,
         "label_id": det.label_id,


### PR DESCRIPTION
## Summary

- Add resize handles (8-point) to existing detection bounding boxes in the process viewer step 2. Double-click a box to select it, then drag a handle to resize.
- Add drag-to-move on selected detection boxes. After double-clicking to select, drag the box body to reposition it.
- Add drag-to-move on selected redaction overlay boxes. After double-clicking to select, drag the box body to reposition it.
- New `update-detection` API endpoint persists detection bbox changes to the DB and `detections.json`.
- Fix blank space appearing next to whiteout blocks when the browser inspector is open: constrain `page-container` width to match the rendered canvas width so the page-label buttons cannot make the container wider than the canvas.
- Add tests for the `update_detection` endpoint covering the happy path, matching by `label_id`, and missing `detections.json`.