### PR TITLE
fix(runpod): exit CPU-only workers before accepting jobs

### DIFF
--- a/scanning/runpod/README.md
+++ b/scanning/runpod/README.md
@@ -104,6 +104,39 @@ docker tag blackletter-gpu-worker:local \
 docker push ghcr.io/freelawproject/blackletter-gpu-worker:<tag>
 ```
 
+## Releasing a new image version
+
+Pushing a new image tag to the registry does **not** automatically update
+the running endpoint. You must create a new release in the RunPod console
+so workers boot from the new image:
+
+1. Go to the **Serverless** page and open your endpoint.
+2. Click **Manage**.
+3. Select **New Release**.
+4. In the **Container Image** field, paste the full new tag, e.g.
+   `freelawproject/blackletter-gpu-worker:ff73140`.
+5. Save. Existing warm workers drain their current jobs; new workers
+   start from the updated image.
+
+### Why we pin a commit SHA instead of using `:latest`
+
+Using `:latest` is unreliable for serverless deployments for three reasons:
+
+- **Caching conflicts.** RunPod caches images on each node for faster
+  cold starts. Pushing a new `:latest` does not invalidate that cache,
+  so workers on cached nodes may continue running the old image even
+  after you "updated" it.
+- **Unpredictable deployments.** You cannot guarantee which version of
+  the code is running, making it hard to reproduce issues or roll back
+  to a known-good state.
+- **Debugging difficulties.** When a problem occurs, you won't know
+  which exact image version caused it.
+
+Pinning to a commit SHA (e.g. `:8c71f45`) makes every release
+explicit, diffable in git history, and instantly reversible.
+
+See also: [RunPod image versioning docs](https://docs.runpod.io/serverless/workers/deploy#image-versioning).
+
 ## Configuring the RunPod endpoint
 
 In the RunPod Serverless console:

--- a/scanning/runpod/handler.py
+++ b/scanning/runpod/handler.py
@@ -102,7 +102,8 @@ def _preload() -> None:
     if not _CUDA_AVAILABLE:
         logger.error(
             "GPU not available; skipping weight/model preload. Jobs on "
-            "this worker will fail fast with error_code=NO_GPU."
+            "this worker will return error_code=NO_GPU; fitness check "
+            "will prevent this worker from accepting jobs."
         )
         return
 
@@ -160,6 +161,21 @@ _WORKER_BOOT_MS = int((_WORKER_READY_AT - _WORKER_BOOT_START) * 1000)
 logger.info(
     "worker ready: boot_ms=%d cuda=%s", _WORKER_BOOT_MS, _CUDA_AVAILABLE
 )
+
+
+# ── Fitness check ────────────────────────────────────────────────────
+@runpod.serverless.register_fitness_check
+def _require_gpu() -> None:
+    """Exit before accepting jobs if no GPU is available.
+
+    Runs at startup before RunPod's heartbeat, so the worker is never
+    added to the available pool and no jobs are ever assigned to it.
+    Queued jobs are picked up automatically by healthy GPU workers.
+    """
+    if not _CUDA_AVAILABLE:
+        raise RuntimeError(
+            "GPU not available on this worker. Exiting to avoid CPU-only billing."
+        )
 
 
 # ── Helpers ─────────────────────────────────────────────────────────
@@ -465,9 +481,9 @@ def handler(job: dict) -> dict:
 
     _tag_sentry(job, action, scan_pk)
 
-    # Fail fast if this worker got scheduled onto a CPU-only host.
-    # Daemon-side maps error_code=NO_GPU to a transient error and
-    # re-queues the scan so the next daemon tick gets a fresh worker.
+    # Belt-and-suspenders: fitness check should prevent CPU-only workers
+    # from ever reaching this point, but handle it defensively in case
+    # CUDA becomes unavailable after startup.
     if not _CUDA_AVAILABLE:
         logger.error(
             "rejecting %s job for scan %s: no GPU on this worker",

--- a/scanning/runpod_client.py
+++ b/scanning/runpod_client.py
@@ -51,11 +51,9 @@ class RunpodError(RuntimeError):
 class RunpodTransientError(RunpodError):
     """Retriable RunPod failure.
 
-    Today this is raised when the handler reports ``error_code="NO_GPU"``
-    (worker scheduled onto a CPU-only host). Callers in
-    ``scanning/services.py`` catch this specifically and re-queue the
-    scan to ``Status.QUEUED`` so the next daemon tick retries on a
-    (hopefully) different worker. Contrast with the base
+    Callers in ``scanning/services.py`` catch this specifically and
+    re-queue the scan to ``Status.QUEUED`` so the next daemon tick
+    retries on a (hopefully) different worker. Contrast with the base
     ``RunpodError`` which signals a terminal failure worth marking
     the scan as ``ERROR``.
     """
@@ -529,9 +527,9 @@ def _poll(
                 )
             if "error" in output:
                 # Handler returned a structured error. ``error_code``
-                # disambiguates the retriable ones (NO_GPU →
-                # RunpodTransientError) from terminal ones (bad input,
-                # unknown action → RunpodError).
+                # disambiguates transient codes (re-queue with retry
+                # increment) from terminal ones (bad input, unknown
+                # action → ERROR).
                 err_code = output.get("error_code") or ""
                 err_msg = output.get("error") or err_code or "unknown"
                 exc_cls = (
@@ -558,8 +556,10 @@ def _poll(
             return output
 
         if status in ("FAILED", "TIMED_OUT", "CANCELLED"):
-            err = body.get("error") or status
-            raise RunpodError(f"RunPod job {job_id} {status}: {err}")
+            err = body.get("error") or ""
+            raise RunpodError(
+                f"RunPod job {job_id} {status}" + (f": {err}" if err else "")
+            )
 
         # IN_QUEUE / IN_PROGRESS / unknown — keep polling.
         if status and status != last_status:

--- a/scanning/services.py
+++ b/scanning/services.py
@@ -93,12 +93,10 @@ def _handle_pipeline_exception(
 ) -> None:
     """Classify a pipeline-level exception and update the scan status.
 
-    Transient RunPod failures (e.g. worker scheduled without a GPU)
-    increment ``Scan.retry_count`` and re-queue the scan so the next
-    daemon tick retries on a different worker, up to
-    ``settings.RUNPOD_MAX_TRANSIENT_RETRIES`` attempts. When the cap
-    is hit the scan is escalated to ERROR instead. All other exceptions
-    immediately mark the scan as ERROR.
+    - ``RunpodTransientError``: increment ``retry_count`` and re-queue
+      up to ``settings.RUNPOD_MAX_TRANSIENT_RETRIES`` attempts, then
+      escalate to ERROR.
+    - All other exceptions: immediately mark the scan as ERROR.
 
     All transitions are guarded by ``status=Status.PROCESSING`` so we
     never stomp a scan that a concurrent process (stale-recovery, admin


### PR DESCRIPTION
## Problem

When RunPod's scheduler assigned a serverless worker to a CPU-only host, `_preload()` detected no GPU and returned early, but the worker process kept running. It would accept jobs, immediately return `error_code=NO_GPU`, and wait for the next one. Since RunPod bills from the moment a worker boots until it is terminated, this wasted money on workers that could never do useful work.

## Fix

**Fitness check in `handler.py`**

A `@runpod.serverless.register_fitness_check` function now checks `_CUDA_AVAILABLE` at worker startup. If no GPU is present, the worker exits with `sys.exit(1)` before RunPod's heartbeat starts, meaning it is never added to the available pool and no jobs are ever routed to it. Queued jobs are picked up automatically by healthy GPU workers with no daemon changes needed.

The fitness check runs before the heartbeat and job loop (see [Worker Fitness Checks](https://github.com/runpod/runpod-python/blob/main/docs/serverless/worker_fitness_checks.md)), so the worker never bills for job time, only the cold-start cost up to the check.

The handler still returns `error_code=NO_GPU` as a belt-and-suspenders fallback for the unlikely case where CUDA disappears after startup. `NO_GPU` remains in `_TRANSIENT_ERROR_CODES` so the daemon re-queues the scan normally.

Also included: a cosmetic fix to the terminal-status error message (previously produced `"RunPod job X CANCELLED: CANCELLED"`) and README instructions for deploying a new image version to an existing endpoint.