### PR TITLE
fix(runpod): handle FAILED job responses by error source

### DIFF
--- a/scanning/runpod/handler.py
+++ b/scanning/runpod/handler.py
@@ -461,10 +461,11 @@ def handler(job: dict) -> dict:
         (cold-start cost of this worker process, constant per
         worker), ``worker_uptime_ms`` (ms since preload finished, at
         job start), and ``gpu_available`` (whether torch.cuda saw a
-        device). On unknown action an ``{"error": ...}`` dict is
-        returned (status COMPLETED with an error payload, so the
-        client can distinguish "handler rejected input" from
-        "handler crashed").
+        device). On bad/unknown input an ``{"error": ..., "error_code":
+        ...}`` dict is returned; the SDK moves ``error`` to the top
+        level and RunPod marks the job ``FAILED``. The daemon reads
+        ``error_code`` from ``output`` to distinguish transient errors
+        (re-queue) from terminal ones (mark scan ERROR).
     :rtype: dict
     """
     inputs = job.get("input") or {}

--- a/scanning/runpod_client.py
+++ b/scanning/runpod_client.py
@@ -525,19 +525,6 @@ def _poll(
                 raise RunpodError(
                     f"RunPod job {job_id} returned non-dict output: {output!r}"
                 )
-            if "error" in output:
-                # Handler returned a structured error. ``error_code``
-                # disambiguates transient codes (re-queue with retry
-                # increment) from terminal ones (bad input, unknown
-                # action → ERROR).
-                err_code = output.get("error_code") or ""
-                err_msg = output.get("error") or err_code or "unknown"
-                exc_cls = (
-                    RunpodTransientError
-                    if err_code in _TRANSIENT_ERROR_CODES
-                    else RunpodError
-                )
-                raise exc_cls(f"handler error_code={err_code!r}: {err_msg}")
             execution_ms = body.get("executionTime", "?")
             action_ms = output.get("duration_ms", "?")
             model_durations = output.get("model_durations_ms")
@@ -557,7 +544,38 @@ def _poll(
 
         if status in ("FAILED", "TIMED_OUT", "CANCELLED"):
             err = body.get("error") or ""
-            raise RunpodError(
+            # The RunPod SDK (rp_job.py::run_job) pops ``error`` from
+            # the handler's return dict and places it at the top level
+            # of the result payload before POSTing to RunPod. For example,
+            # a handler returning:
+            #
+            #   {"error": "bad input", "error_code": "BAD_INPUT", ...}
+            #
+            # becomes:
+            #
+            #   {"output": {"error_code": "BAD_INPUT", ...}, "error": "bad input"}
+            #
+            # RunPod marks this FAILED with ``error`` at the top level.
+            # ``error_code`` survives inside ``output``, so we can still
+            # distinguish transient errors (re-queue) from terminal ones
+            # (mark scan ERROR).
+            #
+            # When ``output`` is absent the failure is a RunPod platform
+            # error (e.g. "job timed out after 1 retries", worker crash).
+            # Those are infrastructure problems, not handler logic failures,
+            # so re-queue rather than permanently failing the scan.
+            err_code = (body.get("output") or {}).get("error_code") or ""
+            if err_code:
+                exc_cls = (
+                    RunpodTransientError
+                    if err_code in _TRANSIENT_ERROR_CODES
+                    else RunpodError
+                )
+            elif status == "FAILED":
+                exc_cls = RunpodTransientError
+            else:
+                exc_cls = RunpodError
+            raise exc_cls(
                 f"RunPod job {job_id} {status}" + (f": {err}" if err else "")
             )
 

--- a/scanning/tests/test_runpod_client.py
+++ b/scanning/tests/test_runpod_client.py
@@ -374,34 +374,37 @@ class TestPoll(TestCase):
             self._poll([(404, None)])
 
     def test_no_gpu_output_raises_transient(self):
+        # Handler returns {"error": ..., "error_code": "NO_GPU", ...}.
+        # The SDK moves "error" to the top level; RunPod marks the job
+        # FAILED. The daemon reads error_code from output to raise
+        # RunpodTransientError so the scan is re-queued.
         with self.assertRaises(runpod_client.RunpodTransientError):
             self._poll(
                 [
                     (
                         200,
                         {
-                            "status": "COMPLETED",
-                            "output": {
-                                "error": "no gpu",
-                                "error_code": "NO_GPU",
-                            },
+                            "status": "FAILED",
+                            "error": "no gpu",
+                            "output": {"error_code": "NO_GPU"},
                         },
                     )
                 ]
             )
 
     def test_non_transient_handler_error_raises_runpod_error(self):
+        # Handler errors with non-transient codes (BAD_INPUT, UNKNOWN_ACTION)
+        # also arrive as FAILED but raise the base RunpodError, not the
+        # transient subclass, so the scan is marked ERROR rather than re-queued.
         with self.assertRaises(runpod_client.RunpodError) as ctx:
             self._poll(
                 [
                     (
                         200,
                         {
-                            "status": "COMPLETED",
-                            "output": {
-                                "error": "bad input",
-                                "error_code": "BAD_INPUT",
-                            },
+                            "status": "FAILED",
+                            "error": "bad input",
+                            "output": {"error_code": "BAD_INPUT"},
                         },
                     )
                 ]
@@ -411,13 +414,32 @@ class TestPoll(TestCase):
             ctx.exception, runpod_client.RunpodTransientError
         )
 
-    def test_terminal_failure_statuses_raise(self):
-        """FAILED / TIMED_OUT / CANCELLED all end the poll as RunpodError.
+    def test_failed_with_no_output_raises_transient(self):
+        # RunPod platform failures (worker timeout, "job timed out after N
+        # retries", worker crash) arrive as FAILED with no output field.
+        # These are infrastructure problems, not handler logic failures, so
+        # re-queue rather than permanently failing the scan.
+        with self.assertRaises(runpod_client.RunpodTransientError):
+            self._poll(
+                [
+                    (
+                        200,
+                        {
+                            "status": "FAILED",
+                            "error": "job timed out after 1 retries",
+                            "retries": 1,
+                        },
+                    )
+                ]
+            )
 
-        One test with subTest so coverage pins the tuple contents
-        without three nearly-identical test definitions.
+    def test_terminal_failure_statuses_raise(self):
+        """TIMED_OUT / CANCELLED end the poll as RunpodError.
+
+        FAILED without output is transient (platform failure); FAILED
+        with output.error_code is handled by the structured-error tests.
         """
-        for status in ("FAILED", "TIMED_OUT", "CANCELLED"):
+        for status in ("TIMED_OUT", "CANCELLED"):
             with self.subTest(status=status):
                 with self.assertRaises(runpod_client.RunpodError):
                     self._poll([(200, {"status": status, "error": "boom"})])


### PR DESCRIPTION
The RunPod SDK pops `error` from the handler's return dict and places it at the top level of the result payload. This means handler errors (bad input, no GPU, unknown action) arrive as `FAILED` jobs with `error_code` inside `output`, not as `COMPLETED` jobs with `error` in `output`.

Previously the client had a dead code path checking `"error" in output` on COMPLETED responses (never triggered), and treated all FAILED/TIMED_OUT/CANCELLED as terminal errors.

**New behavior:**
- `FAILED` + `output.error_code` present: transient if `NO_GPU`, terminal otherwise
- `FAILED` + no `output`: transient (RunPod platform failure, e.g. "job timed out after 1 retries", worker crash)
- `TIMED_OUT` / `CANCELLED`: terminal