### PR TITLE
fix: recover scans across daemon/web container boundaries

### DIFF
--- a/scanning/management/commands/run_daemon.py
+++ b/scanning/management/commands/run_daemon.py
@@ -155,8 +155,9 @@ class Command(BaseCommand):
                 ),
             )
             if requeued:
-                self.stdout.write(
-                    f"Re-queued {requeued} in-flight scan(s) before shutdown."
+                logger.info(
+                    "Re-queued %d in-flight scan(s) before shutdown.",
+                    requeued,
                 )
         except Exception:
             logger.exception("Failed to re-queue in-flight scans on shutdown")

--- a/scanning/management/commands/run_daemon.py
+++ b/scanning/management/commands/run_daemon.py
@@ -127,9 +127,46 @@ class Command(BaseCommand):
     def _handle_signal(self, signum, frame):
         """Set the shutdown flag on receipt of a termination signal.
 
+        Also re-queues any PROCESSING scans so they retry on the next
+        daemon tick instead of waiting out ``DAEMON_PROCESSING_TIMEOUT``,
+        and reports the shutdown to Sentry to help diagnose unexpected
+        kills (deploys, OOM, container restarts).
+
         :param signum: The signal number received.
         :param frame: The interrupted stack frame.
         :return: None.
         """
         self.stdout.write(f"Received signal {signum}, shutting down...")
         self.shutdown = True
+
+        try:
+            from scanning.models import Scan, Status
+
+            # Don't bump retry_count: the scan didn't fail, the daemon
+            # was killed. Only RunpodTransientError-driven re-queues
+            # (in _handle_pipeline_exception) consume the retry budget,
+            # so a stream of deploys can't push a scan to ERROR_MAX_RETRIES
+            # without a single real GPU/runpod failure.
+            requeued = Scan.objects.filter(status=Status.PROCESSING).update(
+                status=Status.QUEUED,
+                progress_message=(
+                    f"Daemon received signal {signum} mid-pipeline, "
+                    "re-queued for next tick."
+                ),
+            )
+            if requeued:
+                self.stdout.write(
+                    f"Re-queued {requeued} in-flight scan(s) before shutdown."
+                )
+        except Exception:
+            logger.exception("Failed to re-queue in-flight scans on shutdown")
+
+        try:
+            import sentry_sdk
+
+            sentry_sdk.capture_message(
+                f"scanning daemon received signal {signum}, shutting down",
+                level="warning",
+            )
+        except Exception:
+            logger.exception("Failed to report daemon shutdown to Sentry")

--- a/scanning/runpod/handler.py
+++ b/scanning/runpod/handler.py
@@ -100,10 +100,16 @@ def _preload() -> None:
         _CUDA_AVAILABLE = False
 
     if not _CUDA_AVAILABLE:
+        # The fitness check (_require_gpu) blocks this worker from the
+        # available pool, so queued jobs route to healthy GPU workers.
+        # If a job does leak through it returns error_code=NO_GPU, which
+        # the scanning daemon classifies as transient and re-queues the
+        # scan (up to RUNPOD_MAX_TRANSIENT_RETRIES attempts) for the next
+        # tick to resubmit to a different worker.
         logger.error(
-            "GPU not available; skipping weight/model preload. Jobs on "
-            "this worker will return error_code=NO_GPU; fitness check "
-            "will prevent this worker from accepting jobs."
+            "GPU not available; skipping weight/model preload. Jobs "
+            "will return error_code=NO_GPU; scans are re-queued "
+            "automatically by the daemon."
         )
         return
 
@@ -486,8 +492,12 @@ def handler(job: dict) -> dict:
     # from ever reaching this point, but handle it defensively in case
     # CUDA becomes unavailable after startup.
     if not _CUDA_AVAILABLE:
+        # error_code=NO_GPU is in scanning's _TRANSIENT_ERROR_CODES, so
+        # the daemon re-queues the scan (up to RUNPOD_MAX_TRANSIENT_RETRIES
+        # attempts) and the next tick lands on a different worker.
         logger.error(
-            "rejecting %s job for scan %s: no GPU on this worker",
+            "rejecting %s job for scan %s: no GPU on this worker; "
+            "daemon will re-queue.",
             action,
             scan_pk,
         )

--- a/scanning/services.py
+++ b/scanning/services.py
@@ -2228,9 +2228,7 @@ def upload_approved_files(scan_pk: int) -> str:
     if scan.s3_uploaded and scan.s3_path:
         return f"Files were already uploaded to S3 ({scan.s3_path})."
 
-    output_dir = Path(scan.output_dir)
-    redacted_dir = output_dir / "redacted"
-    if not redacted_dir.is_dir() or not list(redacted_dir.glob("*.pdf")):
+    if scan.stage != Stage.APPROVED:
         return "Before approving you need to generate the files."
 
     s3_prefix = s3_sync.approved_prefix(scan)

--- a/scanning/tests/test_run_daemon.py
+++ b/scanning/tests/test_run_daemon.py
@@ -4,7 +4,9 @@ from unittest.mock import patch
 
 from django.test import TestCase, override_settings
 
+from scanning.factories import ScanFactory
 from scanning.management.commands.run_daemon import Command, ScheduledTask
+from scanning.models import Scan, Status
 
 
 class TestScheduledTask(TestCase):
@@ -63,3 +65,36 @@ class TestRunDaemonSchedule(TestCase):
         self.assertIn(
             calls[0], {"process_next_scan", "cleanup_processing_tmp"}
         )
+
+
+class TestHandleSignal(TestCase):
+    """The signal handler should re-queue in-flight scans and report to Sentry."""
+
+    def test_signal_requeues_processing_scans(self):
+        """PROCESSING scans get reset to QUEUED so the next tick retries them."""
+        cmd = Command()
+        in_flight = ScanFactory(status=Status.PROCESSING)
+        other = ScanFactory(status=Status.UPLOADED)
+
+        with patch("sentry_sdk.capture_message") as mock_capture:
+            cmd._handle_signal(15, None)
+
+        in_flight.refresh_from_db()
+        other.refresh_from_db()
+        self.assertTrue(cmd.shutdown)
+        self.assertEqual(in_flight.status, Status.QUEUED)
+        self.assertIn("signal 15", in_flight.progress_message)
+        self.assertEqual(other.status, Status.UPLOADED)
+        mock_capture.assert_called_once()
+
+    def test_signal_with_no_processing_scans(self):
+        """No-op on the DB side if nothing is in flight, but Sentry still fires."""
+        cmd = Command()
+        ScanFactory(status=Status.UPLOADED)
+
+        with patch("sentry_sdk.capture_message") as mock_capture:
+            cmd._handle_signal(2, None)
+
+        self.assertTrue(cmd.shutdown)
+        self.assertEqual(Scan.objects.filter(status=Status.QUEUED).count(), 0)
+        mock_capture.assert_called_once()

--- a/scanning/tests/test_services.py
+++ b/scanning/tests/test_services.py
@@ -13,7 +13,7 @@ from django.db.models import F
 from django.test import TestCase, override_settings
 
 from scanning.factories import ReporterFactory, ScanFactory, UserFactory
-from scanning.models import Detection, Status
+from scanning.models import Detection, Stage, Status
 
 FIXTURE_DIR = pathlib.Path(__file__).parent / "fixtures"
 PDF_PATH = FIXTURE_DIR / "a3d.332.1.1.pdf"
@@ -757,8 +757,8 @@ class TestUploadApprovedFiles(TestCase):
     """Test the upload_approved_files helper."""
 
     def _make_scan_with_generated_files(self):
-        """Create a scan with a populated output_dir."""
-        scan = ScanFactory(start_page=1, end_page=95)
+        """Create a scan that has been through file generation."""
+        scan = ScanFactory(start_page=1, end_page=95, stage=Stage.APPROVED)
         output = pathlib.Path(scan.output_dir)
         output.mkdir(parents=True, exist_ok=True)
 
@@ -780,13 +780,12 @@ class TestUploadApprovedFiles(TestCase):
         )
         return scan
 
-    def test_missing_files_returns_error(self):
-        """Return error message when redacted dir is missing."""
+    def test_pre_generation_returns_error(self):
+        """Return error when the scan hasn't reached the APPROVED stage."""
         from scanning.services import upload_approved_files
 
         scan = ScanFactory(start_page=1, end_page=95)
-        output = pathlib.Path(scan.output_dir)
-        output.mkdir(parents=True, exist_ok=True)
+        self.assertNotEqual(scan.stage, Stage.APPROVED)
 
         result = upload_approved_files(scan.pk)
         self.assertIn("Before approving", result)

--- a/scanning/tests/test_views.py
+++ b/scanning/tests/test_views.py
@@ -25,6 +25,7 @@ from scanning.models import (
     OpinionStatus,
     Scan,
     Source,
+    Stage,
     Status,
 )
 
@@ -785,10 +786,10 @@ class TestApproveScan(ScanningTestCase):
     """Test the approve_scan view."""
 
     def _make_scan_with_generated_files(self):
-        """Create a scan with generated files in output_dir."""
+        """Create a scan that has been through file generation."""
         import pathlib
 
-        scan = ScanFactory(start_page=1, end_page=95)
+        scan = ScanFactory(start_page=1, end_page=95, stage=Stage.APPROVED)
         output = pathlib.Path(scan.output_dir)
         output.mkdir(parents=True, exist_ok=True)
 
@@ -801,14 +802,10 @@ class TestApproveScan(ScanningTestCase):
         return scan
 
     def test_approve_without_files_shows_error(self):
-        """Approving without generated files redirects with error."""
-        import pathlib
-
+        """Approving before reaching the APPROVED stage shows an error."""
         user = self.make_staff_user()
         self.client.force_login(user)
         scan = ScanFactory(start_page=1, end_page=95)
-        output = pathlib.Path(scan.output_dir)
-        output.mkdir(parents=True, exist_ok=True)
 
         response = self.client.post(
             reverse("approve_scan", kwargs={"pk": scan.pk}),

--- a/scanning/tests/test_views.py
+++ b/scanning/tests/test_views.py
@@ -1,9 +1,11 @@
 import io
 import json
+import os
 import pathlib
 import shutil
 import tempfile
 from datetime import timedelta
+from unittest.mock import patch
 
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -1090,11 +1092,6 @@ class TestServeScanPdfLazyPull(ScanningTestCase):
 
     def test_lazy_pull_when_local_dir_missing(self):
         """When output_dir doesn't exist locally, pull from S3 and serve."""
-        import os
-        import pathlib
-        import tempfile
-        from unittest.mock import patch
-
         user = self.make_user()
         self.client.force_login(user)
 
@@ -1134,10 +1131,6 @@ class TestServeScanPdfLazyPull(ScanningTestCase):
 
     def test_returns_404_when_nothing_available(self):
         """When local is empty and S3 pull yields nothing, return 404."""
-        import os
-        import tempfile
-        from unittest.mock import patch
-
         user = self.make_user()
         self.client.force_login(user)
 

--- a/scanning/tests/test_views.py
+++ b/scanning/tests/test_views.py
@@ -1085,6 +1085,85 @@ class TestServeOpinionPdfLazyPull(ScanningTestCase):
         mock_pull.assert_called_once()
 
 
+class TestServeScanPdfLazyPull(ScanningTestCase):
+    """serve_scan_pdf falls back to S3 pull when /tmp/ is stale."""
+
+    def test_lazy_pull_when_local_dir_missing(self):
+        """When output_dir doesn't exist locally, pull from S3 and serve."""
+        import os
+        import pathlib
+        import tempfile
+        from unittest.mock import patch
+
+        user = self.make_user()
+        self.client.force_login(user)
+
+        tmp_root = tempfile.mkdtemp()
+        reporter = ReporterFactory(short_name="se2d")
+        scan = ScanFactory(
+            reporter=reporter, volume=921, start_page=290, end_page=350
+        )
+        # Simulate the prod web container: no local FileField copy, no
+        # local /tmp/ dir. The only way to serve is via S3.
+        original_path = scan.original_pdf.path
+        if os.path.exists(original_path):
+            os.remove(original_path)
+
+        def _fake_download(scan_arg):
+            output = pathlib.Path(scan_arg.output_dir)
+            output.mkdir(parents=True, exist_ok=True)
+            (output / "bitonal.pdf").write_bytes(b"%PDF-1.4 pulled")
+
+        with (
+            override_settings(
+                DEVELOPMENT=False,
+                TESTING=False,
+                PROCESSING_TMP_DIR=tmp_root,
+            ),
+            patch(
+                "scanning.s3_sync.download_processing_files",
+                side_effect=_fake_download,
+            ) as mock_pull,
+        ):
+            response = self.client.get(
+                reverse("serve_scan_pdf", kwargs={"pk": scan.pk})
+            )
+
+        self.assertEqual(response.status_code, 200)
+        mock_pull.assert_called_once()
+
+    def test_returns_404_when_nothing_available(self):
+        """When local is empty and S3 pull yields nothing, return 404."""
+        import os
+        import tempfile
+        from unittest.mock import patch
+
+        user = self.make_user()
+        self.client.force_login(user)
+
+        tmp_root = tempfile.mkdtemp()
+        scan = ScanFactory(start_page=1, end_page=2)
+        # Delete the local FileField file so scan.pdf_path can't resolve
+        # to the original upload either.
+        original_path = scan.original_pdf.path
+        if os.path.exists(original_path):
+            os.remove(original_path)
+
+        with (
+            override_settings(
+                DEVELOPMENT=False,
+                TESTING=False,
+                PROCESSING_TMP_DIR=tmp_root,
+            ),
+            patch("scanning.s3_sync.download_processing_files"),
+        ):
+            response = self.client.get(
+                reverse("serve_scan_pdf", kwargs={"pk": scan.pk})
+            )
+
+        self.assertEqual(response.status_code, 404)
+
+
 class TestRunFullPipelinePullsFromS3(ScanningTestCase):
     """run_full_pipeline pulls files from S3 at entry (prod only)."""
 

--- a/scanning/views_process.py
+++ b/scanning/views_process.py
@@ -9,6 +9,7 @@ import fitz
 from django.contrib.auth.decorators import login_required
 from django.http import (
     FileResponse,
+    Http404,
     HttpRequest,
     HttpResponse,
     JsonResponse,
@@ -401,25 +402,55 @@ def progress_api(request: HttpRequest, pk: int) -> JsonResponse:
 def serve_scan_pdf(request: HttpRequest, pk: int) -> FileResponse:
     """Serve the best available PDF for a scan (OCR, bitonal, or original).
 
+    Resolves the local file in three passes: try the cached ``output_dir``,
+    fall back to the original ``pdf_path``, and if neither is on disk,
+    lazy-pull processing files from S3 and try once more. The pull covers
+    prod where the daemon and web run in separate containers with separate
+    ``/tmp/`` volumes.
+
     :param request: The HTTP request.
     :param pk: Scan primary key.
     :return: File response streaming the PDF.
+    :raises Http404: When no local copy exists and S3 has nothing to pull.
     """
     scan = get_object_or_404(Scan, pk=pk)
-    output = Path(scan.output_dir)
-    if output.is_dir():
-        ocr = find_ocr_pdf(scan.output_dir)
-        if ocr:
-            return FileResponse(ocr.open("rb"), content_type="application/pdf")
 
-        bitonal = output / "bitonal.pdf"
-        if bitonal.exists():
+    def _try_local() -> FileResponse | None:
+        output = Path(scan.output_dir)
+        if output.is_dir():
+            ocr = find_ocr_pdf(scan.output_dir)
+            if ocr:
+                return FileResponse(
+                    ocr.open("rb"), content_type="application/pdf"
+                )
+            bitonal = output / "bitonal.pdf"
+            if bitonal.exists():
+                return FileResponse(
+                    bitonal.open("rb"), content_type="application/pdf"
+                )
+        try:
             return FileResponse(
-                bitonal.open("rb"), content_type="application/pdf"
+                Path(scan.pdf_path).open("rb"),
+                content_type="application/pdf",
             )
-    return FileResponse(
-        Path(scan.pdf_path).open("rb"), content_type="application/pdf"
-    )
+        except FileNotFoundError:
+            return None
+
+    response = _try_local()
+    if response is not None:
+        return response
+
+    try:
+        from scanning import s3_sync
+
+        s3_sync.download_processing_files(scan)
+    except Exception:
+        logger.exception("Lazy S3 pull failed for scan %s", scan.pk)
+
+    response = _try_local()
+    if response is not None:
+        return response
+    raise Http404
 
 
 @login_required


### PR DESCRIPTION
In prod the daemon and web run in separate containers with separate `/tmp/` volumes. The daemon writes processing files to its own `/tmp/scanning/{pk}/` and pushes them to S3; the web container's local copy is empty and is populated lazily when needed. That split was breaking several code paths that assumed a shared filesystem, plus a couple of unrelated daemon-shutdown / observability gaps surfaced along the way.

## Bugs found

### 1. "Before approving you need to generate the files"

Click "Generate files" on step 3, wait for it to finish, click "Approve", and the page redirects with "Before approving you need to generate the files." Opening any opinion in the sidebar (which lazy-pulls from S3) then makes Approve work.

`upload_approved_files` was checking `output_dir/redacted/*.pdf` on the web container's local disk, which in prod is empty until something pulls from S3. The check was a poor proxy for "did generate-files run?".

### 2. PDF area on the process viewer shows 500

After OCR / RunPod returns successfully, the left column renders Issues / Pages correctly but the PDF panel shows `Error loading PDF: Unexpected server response (500)`.

`serve_scan_pdf` only looked at local disk. With no `/tmp/` files and no local FileField copy (prod uses S3-backed storage), `scan.pdf_path` raised `FileNotFoundError` and the uncaught exception became a 500.

### 3. Scans stuck in PROCESSING for up to an hour after a deploy

When the daemon container was restarted mid-pipeline (deploy, OOM, K8s eviction), the scan it was processing sat in `PROCESSING` until the stale-recovery sweep picked it up, which uses `DAEMON_PROCESSING_TIMEOUT` (default 3600s).

The signal handler only set `self.shutdown = True`; it never touched the row.

### 4. NO_GPU log lines read like a hard failure

Sentry was firing `GPU not available; skipping weight/model preload. Jobs on this worker will return error_code=NO_GPU; fitness check will prevent this worker from accepting jobs.` That sounds bad, but `NO_GPU` is in `_TRANSIENT_ERROR_CODES`, so the daemon re-queues the scan automatically and the next tick lands on a different worker. The message didn't say so.

## Changes

- `fix(approve)`: `upload_approved_files` now uses `scan.stage != Stage.APPROVED` instead of a filesystem probe. `run_generate_files` already sets stage to APPROVED on success, and the actual S3 copy is server-side, so the daemon and web containers don't need to share files for approval to work.
- `fix(views)`: `serve_scan_pdf` now does try-local, lazy-pull from S3 via `s3_sync.download_processing_files`, try-local again, then `Http404`. Mirrors the pattern `serve_opinionscan_pdf` already uses. Replaces the uncaught 500 with a 404 if S3 also has nothing.
- `fix(daemon)`: SIGTERM/SIGINT handler now atomically resets all `PROCESSING` scans to `QUEUED` with a progress message saying the daemon crashed mid-pipeline. The next tick (~5s) re-claims them. The re-queue does NOT bump `retry_count`, since the scan didn't fail; that budget is reserved for real RunPod transient errors so a string of deploys can't push a scan to `ERROR_MAX_RETRIES`. Also captures a `sentry_sdk.capture_message` warning when the signal arrives, so unexpected kills (deploys, OOM, evictions) become visible.
- `docs(runpod)`: both NO_GPU log lines (the preload guard and the per-job belt-and-suspenders) now mention that the scan is re-queued automatically up to `RUNPOD_MAX_TRANSIENT_RETRIES` attempts. The longer explanation lives in a comment above each line; the log message itself stays terse.

## Tests

- `TestUploadApprovedFiles`: renamed `test_missing_files_returns_error` to `test_pre_generation_returns_error`; fixtures now seed `stage=APPROVED`.
- `TestApproveScan`: same fixture update.
- `TestHandleSignal` (new, 2 cases): verifies re-queue + Sentry capture, and that `_handle_signal` is a no-op on the DB side when nothing is in flight.
- `TestServeScanPdfLazyPull` (new, 2 cases): exercises the S3 fallback path and the 404 case.

All four commits are independent and could be reverted separately.