### PR TITLE
feat(viewer): add zoom controls to processing pdf viewer

### DIFF
--- a/scanning/static/scanning/checker.css
+++ b/scanning/static/scanning/checker.css
@@ -376,6 +376,8 @@ a.doc-name:hover { text-decoration: underline; }
     display: flex;
     align-items: center;
     justify-content: space-between;
+    flex-wrap: wrap;
+    row-gap: 4px;
     border-bottom: 1px solid #eee;
 }
 

--- a/scanning/static/scanning/checker.css
+++ b/scanning/static/scanning/checker.css
@@ -282,9 +282,52 @@ a.doc-name:hover { text-decoration: underline; }
 /* PDF Viewer */
 .viewer-panel {
     flex: 1;
-    overflow-y: auto;
+    overflow: auto;
     background: #525659;
     padding: 20px;
+    position: relative;
+}
+
+/* Zoom toolbar — floats at the top-left of the viewer panel.
+   Sticky on both axes so it stays visible when horizontal overflow
+   appears at zoom > 1. */
+.zoom-toolbar {
+    position: sticky;
+    top: 0;
+    left: 0;
+    width: max-content;
+    margin-bottom: 12px;
+    padding: 4px 8px;
+    background: rgba(40, 42, 45, 0.92);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 6px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    z-index: 30;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    backdrop-filter: blur(4px);
+}
+.zoom-toolbar .zoom-btn {
+    background: #3f4347;
+    color: #f3f4f6;
+    border: 1px solid #585c61;
+    border-radius: 4px;
+    padding: 3px 10px;
+    font-size: 13px;
+    line-height: 1.2;
+    cursor: pointer;
+    min-width: 28px;
+}
+.zoom-toolbar .zoom-btn:hover { background: #4b5056; }
+.zoom-toolbar .zoom-btn:active { background: #2f3337; }
+.zoom-toolbar .zoom-btn.zoom-reset { font-size: 11px; padding: 3px 8px; }
+.zoom-toolbar .zoom-pct {
+    color: #f3f4f6;
+    font-size: 12px;
+    min-width: 44px;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
 }
 
 #pdf-viewer {

--- a/scanning/static/scanning/shared.js
+++ b/scanning/static/scanning/shared.js
@@ -217,6 +217,24 @@ function pageRenderedZoom(pageDiv) {
 }
 
 /**
+ * Ratio of an element's visual size on screen to its CSS layout size,
+ * i.e. the cumulative scale of any CSS transforms on its ancestors.
+ * Use this to convert screen-pixel mouse deltas into the natural CSS
+ * pixel space the element's `style.left/top/width/height` live in,
+ * for drag handlers that operate while a wrapper is mid-zoom (between
+ * the immediate visual transform and the post-debounce re-render).
+ *
+ * @param {HTMLElement} el - The element being dragged.
+ * @returns {number} visual / natural ratio (1 if no transform).
+ */
+function cssToVisualScale(el) {
+    if (!el) return 1;
+    var rect = el.getBoundingClientRect();
+    var nat = el.offsetWidth || 1;
+    return rect.width && nat ? rect.width / nat : 1;
+}
+
+/**
  * Apply the active zoom level to a single rendered page container by
  * applying a CSS `transform: scale(visualZoom)` to its canvas wrapper.
  * `visualZoom` is the ratio between the active zoom and the zoom at

--- a/scanning/static/scanning/shared.js
+++ b/scanning/static/scanning/shared.js
@@ -147,6 +147,98 @@ function showToast(message, type) {
 }
 
 /**
+ * Convert a mouse event into the target's natural pixel coordinates.
+ * Robust to any CSS zoom or transform applied to the target's ancestors,
+ * which is what the PDF viewer's zoom controls rely on.
+ *
+ * @param {MouseEvent} e - The mouse event.
+ * @param {HTMLCanvasElement|HTMLElement} target - Element to map into; canvas
+ *   targets use canvas.width/height, others fall back to offsetWidth/Height.
+ * @returns {{x: number, y: number}} Coordinates in target natural pixels.
+ */
+function eventToCanvasPixels(e, target) {
+    var rect = target.getBoundingClientRect();
+    var w = target.width || target.offsetWidth || rect.width || 1;
+    var h = target.height || target.offsetHeight || rect.height || 1;
+    var sx = rect.width ? w / rect.width : 1;
+    var sy = rect.height ? h / rect.height : 1;
+    return {
+        x: (e.clientX - rect.left) * sx,
+        y: (e.clientY - rect.top) * sy,
+    };
+}
+
+// PDF viewer zoom controls.
+var PDF_ZOOM_MIN = 0.5;
+var PDF_ZOOM_MAX = 3;
+var PDF_ZOOM_STEP = 0.1;
+
+/**
+ * Read the persisted PDF viewer zoom level (multiplier; 1 = unzoomed).
+ *
+ * @returns {number} Zoom level clamped to [PDF_ZOOM_MIN, PDF_ZOOM_MAX].
+ */
+function getPdfZoom() {
+    var v = parseFloat(localStorage.getItem('pdfZoom'));
+    if (!isFinite(v) || v <= 0) return 1;
+    return Math.max(PDF_ZOOM_MIN, Math.min(PDF_ZOOM_MAX, v));
+}
+
+/**
+ * Apply the current zoom level to a single rendered page container.
+ * The wrapper is scaled with a CSS transform so detection boxes,
+ * redaction overlays, and image overlays (all positioned absolutely
+ * inside the wrapper) inherit the visual scale automatically. The
+ * page-container is sized to the scaled dimensions to reserve layout
+ * space without re-rendering pdf.js canvases.
+ *
+ * @param {HTMLElement} pageDiv - The .page-container element.
+ */
+function applyZoomToPage(pageDiv) {
+    if (!pageDiv) return;
+    var wrapper = pageDiv.querySelector('.canvas-wrapper');
+    if (!wrapper) return;
+    var canvas = wrapper.querySelector('.pdf-canvas');
+    if (!canvas || !canvas.width) return;
+    var zoom = getPdfZoom();
+    if (zoom === 1) {
+        wrapper.style.transform = '';
+        wrapper.style.transformOrigin = '';
+        pageDiv.style.width = '';
+        pageDiv.style.height = '';
+        return;
+    }
+    wrapper.style.transformOrigin = 'top left';
+    wrapper.style.transform = 'scale(' + zoom + ')';
+    var label = pageDiv.querySelector('.page-label');
+    var labelH = label ? label.offsetHeight : 0;
+    pageDiv.style.width = (canvas.width * zoom) + 'px';
+    pageDiv.style.height = (labelH + canvas.height * zoom) + 'px';
+}
+
+/**
+ * Re-apply the current zoom level to every rendered page and refresh
+ * the toolbar percentage display.
+ */
+function applyZoomAll() {
+    document.querySelectorAll('#pdf-viewer .page-container').forEach(applyZoomToPage);
+    var pct = document.getElementById('zoom-pct');
+    if (pct) pct.textContent = Math.round(getPdfZoom() * 100) + '%';
+}
+
+/**
+ * Set and persist the PDF viewer zoom level.
+ *
+ * @param {number} zoom - Desired zoom multiplier; clamped and rounded.
+ */
+function setPdfZoom(zoom) {
+    zoom = Math.max(PDF_ZOOM_MIN, Math.min(PDF_ZOOM_MAX, zoom));
+    zoom = Math.round(zoom * 100) / 100;
+    localStorage.setItem('pdfZoom', String(zoom));
+    applyZoomAll();
+}
+
+/**
  * Draw existing redaction rectangles on a canvas overlay.
  *
  * @param {HTMLCanvasElement} overlay - The canvas element.

--- a/scanning/static/scanning/shared.js
+++ b/scanning/static/scanning/shared.js
@@ -147,19 +147,23 @@ function showToast(message, type) {
 }
 
 /**
- * Convert a mouse event into the target's natural pixel coordinates.
- * Robust to any CSS zoom or transform applied to the target's ancestors,
- * which is what the PDF viewer's zoom controls rely on.
+ * Convert a mouse event into the target's CSS-pixel layout coordinates,
+ * relative to the target's top-left corner. Robust to any CSS zoom or
+ * transform applied to ancestors, since the conversion is derived from
+ * the displayed bounding rect rather than the bitmap dimensions.
+ *
+ * For canvas targets, returns coords in the canvas's CSS layout space
+ * (matching style.width/height, or the bitmap size when style is unset).
+ * Pair with `pageScale(pageDiv)` to convert to PDF points.
  *
  * @param {MouseEvent} e - The mouse event.
- * @param {HTMLCanvasElement|HTMLElement} target - Element to map into; canvas
- *   targets use canvas.width/height, others fall back to offsetWidth/Height.
- * @returns {{x: number, y: number}} Coordinates in target natural pixels.
+ * @param {HTMLCanvasElement|HTMLElement} target - Element to map into.
+ * @returns {{x: number, y: number}} Coordinates in target CSS layout pixels.
  */
 function eventToCanvasPixels(e, target) {
     var rect = target.getBoundingClientRect();
-    var w = target.width || target.offsetWidth || rect.width || 1;
-    var h = target.height || target.offsetHeight || rect.height || 1;
+    var w = target.offsetWidth || target.width || rect.width || 1;
+    var h = target.offsetHeight || target.height || rect.height || 1;
     var sx = rect.width ? w / rect.width : 1;
     var sy = rect.height ? h / rect.height : 1;
     return {
@@ -185,12 +189,43 @@ function getPdfZoom() {
 }
 
 /**
- * Apply the current zoom level to a single rendered page container.
- * The wrapper is scaled with a CSS transform so detection boxes,
- * redaction overlays, and image overlays (all positioned absolutely
- * inside the wrapper) inherit the visual scale automatically. The
- * page-container is sized to the scaled dimensions to reserve layout
- * space without re-rendering pdf.js canvases.
+ * Effective render scale at which a page's canvas was rasterized,
+ * i.e. SCALE_base * renderedZoom. Used as the divisor when converting
+ * canvas-CSS pixels back to PDF points.
+ *
+ * @param {HTMLElement} pageDiv - The .page-container element.
+ * @param {number} [fallback=1] - Returned when the page hasn't been
+ *   rendered yet (no `data-scale` attribute).
+ * @returns {number} The effective scale.
+ */
+function pageScale(pageDiv, fallback) {
+    var v = pageDiv ? parseFloat(pageDiv.dataset.scale) : NaN;
+    return isFinite(v) && v > 0 ? v : (fallback || 1);
+}
+
+/**
+ * The zoom level at which a page was last rasterized. Used to compute
+ * the visual transform ratio when the active zoom diverges from the
+ * rendered zoom (e.g. before a re-render lands).
+ *
+ * @param {HTMLElement} pageDiv - The .page-container element.
+ * @returns {number} The rendered zoom (defaults to 1).
+ */
+function pageRenderedZoom(pageDiv) {
+    var v = pageDiv ? parseFloat(pageDiv.dataset.renderedZoom) : NaN;
+    return isFinite(v) && v > 0 ? v : 1;
+}
+
+/**
+ * Apply the active zoom level to a single rendered page container by
+ * applying a CSS `transform: scale(visualZoom)` to its canvas wrapper.
+ * `visualZoom` is the ratio between the active zoom and the zoom at
+ * which the page was last rasterized, so when a re-render lands at the
+ * new zoom the transform reduces to identity (no extra scaling).
+ *
+ * Detection boxes, redaction overlays, and image overlays all live as
+ * absolutely-positioned children of the wrapper, so they inherit the
+ * visual scale automatically.
  *
  * @param {HTMLElement} pageDiv - The .page-container element.
  */
@@ -200,8 +235,8 @@ function applyZoomToPage(pageDiv) {
     if (!wrapper) return;
     var canvas = wrapper.querySelector('.pdf-canvas');
     if (!canvas || !canvas.width) return;
-    var zoom = getPdfZoom();
-    if (zoom === 1) {
+    var visualZoom = getPdfZoom() / pageRenderedZoom(pageDiv);
+    if (Math.abs(visualZoom - 1) < 0.001) {
         wrapper.style.transform = '';
         wrapper.style.transformOrigin = '';
         pageDiv.style.width = '';
@@ -209,15 +244,17 @@ function applyZoomToPage(pageDiv) {
         return;
     }
     wrapper.style.transformOrigin = 'top left';
-    wrapper.style.transform = 'scale(' + zoom + ')';
+    wrapper.style.transform = 'scale(' + visualZoom + ')';
+    var naturalW = parseFloat(wrapper.style.width) || canvas.offsetWidth || canvas.width;
+    var naturalH = parseFloat(wrapper.style.height) || canvas.offsetHeight || canvas.height;
     var label = pageDiv.querySelector('.page-label');
     var labelH = label ? label.offsetHeight : 0;
-    pageDiv.style.width = (canvas.width * zoom) + 'px';
-    pageDiv.style.height = (labelH + canvas.height * zoom) + 'px';
+    pageDiv.style.width = (naturalW * visualZoom) + 'px';
+    pageDiv.style.height = (labelH + naturalH * visualZoom) + 'px';
 }
 
 /**
- * Re-apply the current zoom level to every rendered page and refresh
+ * Re-apply the active zoom level to every rendered page and refresh
  * the toolbar percentage display.
  */
 function applyZoomAll() {
@@ -227,7 +264,10 @@ function applyZoomAll() {
 }
 
 /**
- * Set and persist the PDF viewer zoom level.
+ * Set and persist the PDF viewer zoom level. Applies the visual
+ * transform to all rendered pages immediately for instant feedback,
+ * then asks the active viewer to re-rasterize at the new resolution
+ * (debounced inside the viewer).
  *
  * @param {number} zoom - Desired zoom multiplier; clamped and rounded.
  */
@@ -236,6 +276,9 @@ function setPdfZoom(zoom) {
     zoom = Math.round(zoom * 100) / 100;
     localStorage.setItem('pdfZoom', String(zoom));
     applyZoomAll();
+    if (typeof window.requestPdfRerender === 'function') {
+        window.requestPdfRerender();
+    }
 }
 
 /**

--- a/scanning/static/scanning/shared.js
+++ b/scanning/static/scanning/shared.js
@@ -172,10 +172,14 @@ function eventToCanvasPixels(e, target) {
     };
 }
 
-// PDF viewer zoom controls.
+// PDF viewer zoom controls. The active viewer (step1 vs step2/3) sets
+// `window.__pdfZoomKey` at script-load time so each viewer persists its
+// own zoom level independently in localStorage.
 var PDF_ZOOM_MIN = 0.5;
 var PDF_ZOOM_MAX = 3;
 var PDF_ZOOM_STEP = 0.1;
+
+function _pdfZoomKey() { return window.__pdfZoomKey || 'pdfZoom'; }
 
 /**
  * Read the persisted PDF viewer zoom level (multiplier; 1 = unzoomed).
@@ -183,7 +187,7 @@ var PDF_ZOOM_STEP = 0.1;
  * @returns {number} Zoom level clamped to [PDF_ZOOM_MIN, PDF_ZOOM_MAX].
  */
 function getPdfZoom() {
-    var v = parseFloat(localStorage.getItem('pdfZoom'));
+    var v = parseFloat(localStorage.getItem(_pdfZoomKey()));
     if (!isFinite(v) || v <= 0) return 1;
     return Math.max(PDF_ZOOM_MIN, Math.min(PDF_ZOOM_MAX, v));
 }
@@ -292,7 +296,7 @@ function applyZoomAll() {
 function setPdfZoom(zoom) {
     zoom = Math.max(PDF_ZOOM_MIN, Math.min(PDF_ZOOM_MAX, zoom));
     zoom = Math.round(zoom * 100) / 100;
-    localStorage.setItem('pdfZoom', String(zoom));
+    localStorage.setItem(_pdfZoomKey(), String(zoom));
     applyZoomAll();
     if (typeof window.requestPdfRerender === 'function') {
         window.requestPdfRerender();

--- a/scanning/static/scanning/shared.js
+++ b/scanning/static/scanning/shared.js
@@ -258,17 +258,20 @@ function applyZoomToPage(pageDiv) {
     var canvas = wrapper.querySelector('.pdf-canvas');
     if (!canvas || !canvas.width) return;
     var visualZoom = getPdfZoom() / pageRenderedZoom(pageDiv);
+    var naturalW = parseFloat(wrapper.style.width) || canvas.offsetWidth || canvas.width;
+    var naturalH = parseFloat(wrapper.style.height) || canvas.offsetHeight || canvas.height;
     if (Math.abs(visualZoom - 1) < 0.001) {
         wrapper.style.transform = '';
         wrapper.style.transformOrigin = '';
-        pageDiv.style.width = '';
+        // Pin the page-container to the canvas width so that the page-label's
+        // toolbar (Detections, Redact, etc.) cannot stretch the container
+        // wider than the rendered page at small zooms.
+        pageDiv.style.width = naturalW + 'px';
         pageDiv.style.height = '';
         return;
     }
     wrapper.style.transformOrigin = 'top left';
     wrapper.style.transform = 'scale(' + visualZoom + ')';
-    var naturalW = parseFloat(wrapper.style.width) || canvas.offsetWidth || canvas.width;
-    var naturalH = parseFloat(wrapper.style.height) || canvas.offsetHeight || canvas.height;
     var label = pageDiv.querySelector('.page-label');
     var labelH = label ? label.offsetHeight : 0;
     pageDiv.style.width = (naturalW * visualZoom) + 'px';

--- a/scanning/static/scanning/viewer_step1.js
+++ b/scanning/static/scanning/viewer_step1.js
@@ -144,6 +144,7 @@ document.addEventListener('DOMContentLoaded', function () {
             pageDiv.dataset.scale = SCALE;
             pageDiv.dataset.pdfWidth = origViewport.width;
             pageDiv.dataset.pdfHeight = origViewport.height;
+            applyZoomToPage(pageDiv);
         });
     }
 
@@ -382,16 +383,16 @@ document.addEventListener('DOMContentLoaded', function () {
 
     function onRedactStart(e, overlay, pageDiv, pageNumber) {
         isDrawing = true;
-        var rect = overlay.getBoundingClientRect();
-        startX = e.clientX - rect.left;
-        startY = e.clientY - rect.top;
+        var pt = eventToCanvasPixels(e, overlay);
+        startX = pt.x;
+        startY = pt.y;
     }
 
     function onRedactMove(e, overlay, pageNumber) {
         if (!isDrawing) return;
-        var rect = overlay.getBoundingClientRect();
-        var curX = e.clientX - rect.left;
-        var curY = e.clientY - rect.top;
+        var pt = eventToCanvasPixels(e, overlay);
+        var curX = pt.x;
+        var curY = pt.y;
 
         var ctx = overlay.getContext('2d');
         ctx.clearRect(0, 0, overlay.width, overlay.height);
@@ -414,9 +415,9 @@ document.addEventListener('DOMContentLoaded', function () {
         if (!isDrawing) return;
         isDrawing = false;
 
-        var rect = overlay.getBoundingClientRect();
-        var endX = e.clientX - rect.left;
-        var endY = e.clientY - rect.top;
+        var pt = eventToCanvasPixels(e, overlay);
+        var endX = pt.x;
+        var endY = pt.y;
 
         var scale = parseFloat(pageDiv.dataset.scale) || SCALE;
 

--- a/scanning/static/scanning/viewer_step1.js
+++ b/scanning/static/scanning/viewer_step1.js
@@ -106,10 +106,73 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     }
 
+    // --- Zoom-driven re-render ---
+    // When zoom changes, rasterize visible/nearby pages at the new resolution
+    // and discard pages outside the viewport zone so they re-render fresh
+    // when scrolled back into view.
+
+    function isPageNearViewport(pageDiv, margin) {
+        margin = margin || 800;
+        var viewer = document.querySelector('.viewer-panel');
+        if (!viewer) return false;
+        var vRect = viewer.getBoundingClientRect();
+        var pRect = pageDiv.getBoundingClientRect();
+        return pRect.bottom > vRect.top - margin && pRect.top < vRect.bottom + margin;
+    }
+
+    function discardPage(pageDiv, pdfIndex) {
+        if (pageDiv._renderTask) {
+            try { pageDiv._renderTask.cancel(); } catch (_e) {}
+            pageDiv._renderTask = null;
+        }
+        renderedPages[pdfIndex] = false;
+        delete pageDiv.dataset.scale;
+        delete pageDiv.dataset.renderedZoom;
+        var canvas = pageDiv.querySelector('.pdf-canvas');
+        if (canvas) { canvas.width = 0; canvas.height = 0; }
+        var overlay = pageDiv.querySelector('.redaction-overlay');
+        if (overlay) { overlay.width = 0; overlay.height = 0; }
+        var wrapper = pageDiv.querySelector('.canvas-wrapper');
+        if (wrapper) {
+            wrapper.style.transform = '';
+            wrapper.style.transformOrigin = '';
+            wrapper.style.width = defaultPageWidth + 'px';
+            wrapper.style.height = PLACEHOLDER_HEIGHT + 'px';
+            wrapper.style.background = '#f0f0f0';
+            wrapper.querySelectorAll('.redaction-delete-btn').forEach(function (el) { el.remove(); });
+        }
+        pageDiv.style.width = '';
+        pageDiv.style.height = '';
+    }
+
+    function rerenderForCurrentZoom() {
+        var currentZoom = getPdfZoom();
+        container.querySelectorAll('.lazy-page').forEach(function (pageDiv) {
+            var pdfIndex = parseInt(pageDiv.dataset.pdfIndex);
+            if (!renderedPages[pdfIndex]) return;
+            if (Math.abs(pageRenderedZoom(pageDiv) - currentZoom) < 0.001) return;
+            if (isPageNearViewport(pageDiv)) {
+                renderPdfPage(pageDiv, pdfIndex, parseInt(pageDiv.dataset.logicalNumber));
+            } else {
+                discardPage(pageDiv, pdfIndex);
+            }
+        });
+    }
+
+    window.requestPdfRerender = (function () {
+        var t = null;
+        return function () {
+            if (t) clearTimeout(t);
+            t = setTimeout(function () { t = null; rerenderForCurrentZoom(); }, 150);
+        };
+    })();
+
     // --- Render a single PDF page into its placeholder ---
     function renderPdfPage(pageDiv, pdfIndex, logicalNumber) {
+        var zoom = getPdfZoom();
+        var effScale = SCALE * zoom;
         pdfDoc.getPage(pdfIndex + 1).then(function (page) {
-            var viewport = page.getViewport({ scale: SCALE });
+            var viewport = page.getViewport({ scale: effScale });
             var origViewport = page.getViewport({ scale: 1 });
 
             var canvas = pageDiv.querySelector('.pdf-canvas');
@@ -121,16 +184,27 @@ document.addEventListener('DOMContentLoaded', function () {
             wrapper.style.height = viewport.height + 'px';
             wrapper.style.background = '';
 
-            // Update default width on first render
-            if (defaultPageWidth === 918 && viewport.width !== 918) {
-                defaultPageWidth = viewport.width;
+            // Update default width on first render (compare at base scale to
+            // stay consistent regardless of the current zoom).
+            var widthAtBaseScale = viewport.width / zoom;
+            if (defaultPageWidth === 918 && widthAtBaseScale !== 918) {
+                defaultPageWidth = widthAtBaseScale;
                 updatePlaceholderWidths();
             }
 
-            page.render({
+            // Cancel any in-flight render on this page before kicking off a new one.
+            if (pageDiv._renderTask) {
+                try { pageDiv._renderTask.cancel(); } catch (_e) {}
+                pageDiv._renderTask = null;
+            }
+            var task = page.render({
                 canvasContext: canvas.getContext('2d'),
                 viewport: viewport,
             });
+            pageDiv._renderTask = task;
+            task.promise.then(function () {
+                if (pageDiv._renderTask === task) pageDiv._renderTask = null;
+            }, function () { /* swallow cancel */ });
 
             // Setup redaction overlay
             var overlay = pageDiv.querySelector('.redaction-overlay');
@@ -138,10 +212,11 @@ document.addEventListener('DOMContentLoaded', function () {
             overlay.height = viewport.height;
 
             var pageRedactions = redactions[String(logicalNumber)] || [];
-            drawExistingRedactions(overlay, pageRedactions, SCALE);
+            drawExistingRedactions(overlay, pageRedactions, effScale);
             rebuildRedactionDivs(pageDiv, logicalNumber);
 
-            pageDiv.dataset.scale = SCALE;
+            pageDiv.dataset.scale = effScale;
+            pageDiv.dataset.renderedZoom = zoom;
             pageDiv.dataset.pdfWidth = origViewport.width;
             pageDiv.dataset.pdfHeight = origViewport.height;
             applyZoomToPage(pageDiv);
@@ -377,7 +452,7 @@ document.addEventListener('DOMContentLoaded', function () {
         }
 
         overlay.onmousedown = function (e) { onRedactStart(e, overlay, pageDiv, pageNumber); };
-        overlay.onmousemove = function (e) { onRedactMove(e, overlay, pageNumber); };
+        overlay.onmousemove = function (e) { onRedactMove(e, overlay, pageDiv, pageNumber); };
         overlay.onmouseup = function (e) { onRedactEnd(e, overlay, pageDiv, pageNumber); };
     }
 
@@ -388,7 +463,7 @@ document.addEventListener('DOMContentLoaded', function () {
         startY = pt.y;
     }
 
-    function onRedactMove(e, overlay, pageNumber) {
+    function onRedactMove(e, overlay, pageDiv, pageNumber) {
         if (!isDrawing) return;
         var pt = eventToCanvasPixels(e, overlay);
         var curX = pt.x;
@@ -398,7 +473,7 @@ document.addEventListener('DOMContentLoaded', function () {
         ctx.clearRect(0, 0, overlay.width, overlay.height);
 
         var pageRedactions = redactions[String(pageNumber)] || [];
-        drawExistingRedactions(overlay, pageRedactions, SCALE);
+        drawExistingRedactions(overlay, pageRedactions, pageScale(pageDiv, SCALE));
 
         ctx.fillStyle = activeRedactionFill === 'white' ? 'rgba(255, 255, 255, 0.5)' : 'rgba(255, 0, 0, 0.3)';
         ctx.strokeStyle = activeRedactionFill === 'white' ? '#3b82f6' : 'red';
@@ -429,7 +504,7 @@ document.addEventListener('DOMContentLoaded', function () {
         if (pdfW < 5 || pdfH < 5) {
             var ctx = overlay.getContext('2d');
             ctx.clearRect(0, 0, overlay.width, overlay.height);
-            drawExistingRedactions(overlay, redactions[String(pageNumber)] || [], SCALE);
+            drawExistingRedactions(overlay, redactions[String(pageNumber)] || [], scale);
             return;
         }
 
@@ -465,7 +540,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
             var ctx = overlay.getContext('2d');
             ctx.clearRect(0, 0, overlay.width, overlay.height);
-            drawExistingRedactions(overlay, redactions[String(pageNumber)], SCALE);
+            drawExistingRedactions(overlay, redactions[String(pageNumber)], scale);
             rebuildRedactionDivs(pageDiv, pageNumber);
         });
     }
@@ -478,14 +553,15 @@ document.addEventListener('DOMContentLoaded', function () {
         // Remove old buttons
         wrapper.querySelectorAll('.redaction-delete-btn').forEach(function (el) { el.remove(); });
 
+        var scale = pageScale(pageDiv, SCALE);
         var pageRedactions = redactions[String(pageNumber)] || [];
         pageRedactions.forEach(function (r, idx) {
             var btn = document.createElement('button');
             btn.className = 'redaction-delete-btn';
             btn.title = 'Remove this ' + (r.fill === 'white' ? 'whiteout' : 'redaction');
             btn.textContent = '\u00d7';
-            btn.style.left = ((r.x + r.width) * SCALE - 18) + 'px';
-            btn.style.top = (r.y * SCALE + 2) + 'px';
+            btn.style.left = ((r.x + r.width) * scale - 18) + 'px';
+            btn.style.top = (r.y * scale + 2) + 'px';
             btn.addEventListener('click', function (e) {
                 e.stopPropagation();
                 fetch('/scans/' + documentId + '/save-redaction-rect/', {
@@ -498,7 +574,7 @@ document.addEventListener('DOMContentLoaded', function () {
                         var overlay = pageDiv.querySelector('.redaction-overlay');
                         var ctx = overlay.getContext('2d');
                         ctx.clearRect(0, 0, overlay.width, overlay.height);
-                        drawExistingRedactions(overlay, redactions[String(pageNumber)], SCALE);
+                        drawExistingRedactions(overlay, redactions[String(pageNumber)], scale);
                         rebuildRedactionDivs(pageDiv, pageNumber);
                     }
                 });

--- a/scanning/static/scanning/viewer_step1.js
+++ b/scanning/static/scanning/viewer_step1.js
@@ -1,3 +1,8 @@
+// Step 1 persists its zoom level separately from steps 2/3 so that
+// reviewing page numbers at high zoom doesn't carry over to opinion
+// review (and vice versa).
+window.__pdfZoomKey = 'pdfZoom_step1';
+
 document.addEventListener('DOMContentLoaded', function () {
     const container = document.getElementById('pdf-viewer');
     if (!container) return;

--- a/scanning/static/scanning/viewer_step2.js
+++ b/scanning/static/scanning/viewer_step2.js
@@ -3,6 +3,12 @@
  * Supports switching between PDFs, redacted/unredacted toggle,
  * and drawing black/white redaction rectangles.
  */
+
+// Steps 2 and 3 share this viewer and a single persisted zoom level,
+// kept separate from step 1's zoom (page-number review benefits from
+// a different zoom than opinion review).
+window.__pdfZoomKey = 'pdfZoom_step2';
+
 document.addEventListener('DOMContentLoaded', function () {
     var container = document.getElementById('pdf-viewer');
     if (!container) return;

--- a/scanning/static/scanning/viewer_step2.js
+++ b/scanning/static/scanning/viewer_step2.js
@@ -81,10 +81,11 @@ document.addEventListener('DOMContentLoaded', function () {
     document.addEventListener('mousemove', function (e) {
         if (!detDrawDragState || !detDrawPreview || !detDrawDragInitRect) return;
         // detDrawRect is in wrapper-natural pixels; clientX deltas are in
-        // visual pixels, so divide by the active zoom to get natural deltas.
-        var zoom = getPdfZoom();
-        var dx = (e.clientX - detDrawDragStartX) / zoom;
-        var dy = (e.clientY - detDrawDragStartY) / zoom;
+        // visual pixels, so divide by the wrapper's current visual scale
+        // (which may differ from getPdfZoom() between zoom click and re-render).
+        var z = cssToVisualScale(detDrawPreview);
+        var dx = (e.clientX - detDrawDragStartX) / z;
+        var dy = (e.clientY - detDrawDragStartY) / z;
         var r = Object.assign({}, detDrawDragInitRect);
         if (detDrawDragState.type === 'move') {
             r.left += dx; r.top += dy;
@@ -1633,7 +1634,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
             function onMove(ev) {
                 hasMoved = true;
-                var z = getPdfZoom();
+                var z = cssToVisualScale(div);
                 div.style.left = (startLeft + (ev.clientX - startX) / z) + 'px';
                 div.style.top  = (startTop  + (ev.clientY - startY) / z) + 'px';
             }
@@ -1702,7 +1703,7 @@ document.addEventListener('DOMContentLoaded', function () {
         var hasMoved = false;
         function onMove(e) {
             hasMoved = true;
-            var z = getPdfZoom();
+            var z = cssToVisualScale(div);
             var dx = (e.clientX - startX) / z;
             var dy = (e.clientY - startY) / z;
             var newLeft = startLeft, newTop = startTop, newW = startW, newH = startH;
@@ -1910,7 +1911,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 var hasMoved = false;
                 function onMove(e) {
                     hasMoved = true;
-                    var z = getPdfZoom();
+                    var z = cssToVisualScale(div);
                     var dx = (e.clientX - startX) / z, dy = (e.clientY - startY) / z;
                     var newLeft = startLeft, newTop = startTop, newW = startW, newH = startH;
                     if (pos.indexOf('e') >= 0) newW = Math.max(10, startW + dx);
@@ -1953,7 +1954,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
             function onMove(e) {
                 hasMoved = true;
-                var z = getPdfZoom();
+                var z = cssToVisualScale(div);
                 div.style.left = (startLeft + (e.clientX - startX) / z) + 'px';
                 div.style.top = (startTop + (e.clientY - startY) / z) + 'px';
             }
@@ -2061,7 +2062,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 var hasMoved = false;
                 function onMove(ev) {
                     hasMoved = true;
-                    var z = getPdfZoom();
+                    var z = cssToVisualScale(div);
                     var dx = (ev.clientX - startX) / z, dy = (ev.clientY - startY) / z;
                     var nL = startLeft, nT = startTop, nW = startW, nH = startH;
                     if (pos.indexOf('e') >= 0) nW = startW + dx;

--- a/scanning/static/scanning/viewer_step2.js
+++ b/scanning/static/scanning/viewer_step2.js
@@ -359,11 +359,77 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     }
 
+    // --- Zoom-driven re-render ---
+    // When zoom changes, rasterize visible/nearby pages at the new resolution
+    // and discard pages outside the viewport zone so they re-render fresh
+    // when scrolled back into view.
+
+    function isPageNearViewport(pageDiv, margin) {
+        margin = margin || 800;
+        var viewer = document.querySelector('.viewer-panel');
+        if (!viewer) return false;
+        var vRect = viewer.getBoundingClientRect();
+        var pRect = pageDiv.getBoundingClientRect();
+        return pRect.bottom > vRect.top - margin && pRect.top < vRect.bottom + margin;
+    }
+
+    function discardPage(pageDiv, pdfIndex) {
+        if (pageDiv._renderTask) {
+            try { pageDiv._renderTask.cancel(); } catch (_e) {}
+            pageDiv._renderTask = null;
+        }
+        renderedPages[pdfIndex] = false;
+        delete pageDiv.dataset.scale;
+        delete pageDiv.dataset.renderedZoom;
+        var canvas = pageDiv.querySelector('.pdf-canvas');
+        if (canvas) { canvas.width = 0; canvas.height = 0; }
+        var overlay = pageDiv.querySelector('.redaction-overlay');
+        if (overlay) { overlay.width = 0; overlay.height = 0; }
+        var wrapper = pageDiv.querySelector('.canvas-wrapper');
+        if (wrapper) {
+            wrapper.style.transform = '';
+            wrapper.style.transformOrigin = '';
+            wrapper.style.width = defaultPageWidth + 'px';
+            wrapper.style.height = PLACEHOLDER_HEIGHT + 'px';
+            wrapper.style.background = '#f0f0f0';
+            wrapper.querySelectorAll(
+                '.detection-box, .redaction-overlay-box, .redaction-delete-btn, ' +
+                '.image-overlay, .opinion-bounds-overlay, .margin-overlay-box, .opinion-dim-overlay'
+            ).forEach(function (el) { el.remove(); });
+        }
+        pageDiv.style.width = '';
+        pageDiv.style.height = '';
+    }
+
+    function rerenderForCurrentZoom() {
+        var currentZoom = getPdfZoom();
+        container.querySelectorAll('.lazy-page').forEach(function (pageDiv) {
+            var pdfIndex = parseInt(pageDiv.dataset.pdfIndex);
+            if (!renderedPages[pdfIndex]) return;
+            if (Math.abs(pageRenderedZoom(pageDiv) - currentZoom) < 0.001) return;
+            if (isPageNearViewport(pageDiv)) {
+                renderPage(pageDiv, pdfIndex);
+            } else {
+                discardPage(pageDiv, pdfIndex);
+            }
+        });
+    }
+
+    window.requestPdfRerender = (function () {
+        var t = null;
+        return function () {
+            if (t) clearTimeout(t);
+            t = setTimeout(function () { t = null; rerenderForCurrentZoom(); }, 150);
+        };
+    })();
+
     function renderPage(pageDiv, pdfIndex) {
+        var zoom = getPdfZoom();
+        var effScale = SCALE * zoom;
         pdfDoc.getPage(pdfIndex + 1).then(function (page) {
             var pageNum = parseInt(pageDiv.dataset.pageNum);
             pdfPages[pageNum] = page;  // cache for overlay coordinate conversion
-            var viewport = page.getViewport({ scale: SCALE });
+            var viewport = page.getViewport({ scale: effScale });
             var canvas = pageDiv.querySelector('.pdf-canvas');
             canvas.width = viewport.width;
             canvas.height = viewport.height;
@@ -373,9 +439,14 @@ document.addEventListener('DOMContentLoaded', function () {
             wrapper.style.height = viewport.height + 'px';
             wrapper.style.background = '';
             pageDiv.style.width = viewport.width + 'px';
+            pageDiv.dataset.scale = effScale;
+            pageDiv.dataset.renderedZoom = zoom;
 
-            if (defaultPageWidth === 918 && viewport.width !== 918) {
-                defaultPageWidth = viewport.width;
+            // Track default page width at base scale so the comparison stays
+            // valid across zoom changes.
+            var widthAtBaseScale = viewport.width / zoom;
+            if (defaultPageWidth === 918 && widthAtBaseScale !== 918) {
+                defaultPageWidth = widthAtBaseScale;
                 container.querySelectorAll('.lazy-page').forEach(function (el) {
                     if (!renderedPages[parseInt(el.dataset.pdfIndex)]) {
                         var w = el.querySelector('.canvas-wrapper');
@@ -387,7 +458,15 @@ document.addEventListener('DOMContentLoaded', function () {
                 });
             }
 
-            page.render({ canvasContext: canvas.getContext('2d'), viewport: viewport });
+            if (pageDiv._renderTask) {
+                try { pageDiv._renderTask.cancel(); } catch (_e) {}
+                pageDiv._renderTask = null;
+            }
+            var task = page.render({ canvasContext: canvas.getContext('2d'), viewport: viewport });
+            pageDiv._renderTask = task;
+            task.promise.then(function () {
+                if (pageDiv._renderTask === task) pageDiv._renderTask = null;
+            }, function () { /* swallow cancel */ });
 
             if (!viewOnly) {
                 // Setup redaction overlay
@@ -398,7 +477,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 }
 
                 var pageRedactions = redactions[String(pageNum)] || [];
-                if (overlay) drawExistingRedactions(overlay, pageRedactions, SCALE);
+                if (overlay) drawExistingRedactions(overlay, pageRedactions, effScale);
                 rebuildRedactionDivs(pageDiv, pageNum);
 
                 // Redraw overlays (skip when viewing individual opinion PDFs)
@@ -432,8 +511,8 @@ document.addEventListener('DOMContentLoaded', function () {
                     var imgH = imgDets[0].img_height || 1;
                     var sx = canvasW / imgW;
                     var sy = canvasH / imgH;
-                    var pdfPtW = viewport.width / SCALE;
-                    var pdfPtH = viewport.height / SCALE;
+                    var pdfPtW = viewport.width / effScale;
+                    var pdfPtH = viewport.height / effScale;
                     var pxToPtX = pdfPtW / imgW;
                     var pxToPtY = pdfPtH / imgH;
 
@@ -521,7 +600,7 @@ document.addEventListener('DOMContentLoaded', function () {
             var curY = pt.y;
             var ctx = overlay.getContext('2d');
             ctx.clearRect(0, 0, overlay.width, overlay.height);
-            drawExistingRedactions(overlay, redactions[String(pageNum)] || [], SCALE);
+            drawExistingRedactions(overlay, redactions[String(pageNum)] || [], pageScale(pageDiv, SCALE));
             ctx.fillStyle = activeRedactionFill === 'white' ? 'rgba(255,255,255,0.5)' : 'rgba(255,0,0,0.3)';
             ctx.strokeStyle = activeRedactionFill === 'white' ? '#3b82f6' : 'red';
             ctx.lineWidth = 2;
@@ -536,15 +615,16 @@ document.addEventListener('DOMContentLoaded', function () {
             var pt = eventToCanvasPixels(e, overlay);
             var endX = pt.x;
             var endY = pt.y;
-            var pdfX = Math.min(startX, endX) / SCALE;
-            var pdfY = Math.min(startY, endY) / SCALE;
-            var pdfW = Math.abs(endX - startX) / SCALE;
-            var pdfH = Math.abs(endY - startY) / SCALE;
+            var scale = pageScale(pageDiv, SCALE);
+            var pdfX = Math.min(startX, endX) / scale;
+            var pdfY = Math.min(startY, endY) / scale;
+            var pdfW = Math.abs(endX - startX) / scale;
+            var pdfH = Math.abs(endY - startY) / scale;
 
             if (pdfW < 5 || pdfH < 5) {
                 var ctx = overlay.getContext('2d');
                 ctx.clearRect(0, 0, overlay.width, overlay.height);
-                drawExistingRedactions(overlay, redactions[String(pageNum)] || [], SCALE);
+                drawExistingRedactions(overlay, redactions[String(pageNum)] || [], scale);
                 return;
             }
 
@@ -584,8 +664,8 @@ document.addEventListener('DOMContentLoaded', function () {
                         }
                     }
                 }
-                var pxPerPtX = imgW / (overlay.width / SCALE);
-                var pxPerPtY = imgH / (overlay.height / SCALE);
+                var pxPerPtX = imgW / (overlay.width / scale);
+                var pxPerPtY = imgH / (overlay.height / scale);
 
                 fetch('/scans/' + documentId + '/save-redaction-rect/', {
                     method: 'POST',
@@ -622,14 +702,15 @@ document.addEventListener('DOMContentLoaded', function () {
     function rebuildRedactionDivs(pageDiv, pageNum) {
         var wrapper = pageDiv.querySelector('.canvas-wrapper');
         wrapper.querySelectorAll('.redaction-delete-btn').forEach(function (el) { el.remove(); });
+        var scale = pageScale(pageDiv, SCALE);
         var pageRedactions = redactions[String(pageNum)] || [];
         pageRedactions.forEach(function (r, idx) {
             var btn = document.createElement('button');
             btn.className = 'redaction-delete-btn';
             btn.title = 'Remove this ' + (r.fill === 'white' ? 'whiteout' : 'redaction');
             btn.textContent = '\u00d7';
-            btn.style.left = ((r.x + r.width) * SCALE - 18) + 'px';
-            btn.style.top = (r.y * SCALE + 2) + 'px';
+            btn.style.left = ((r.x + r.width) * scale - 18) + 'px';
+            btn.style.top = (r.y * scale + 2) + 'px';
             btn.addEventListener('click', function (e) {
                 e.stopPropagation();
                 fetch('/scans/' + documentId + '/redaction/' + r.id + '/delete/', {
@@ -642,7 +723,7 @@ document.addEventListener('DOMContentLoaded', function () {
                         var overlay = pageDiv.querySelector('.redaction-overlay');
                         var ctx = overlay.getContext('2d');
                         ctx.clearRect(0, 0, overlay.width, overlay.height);
-                        drawExistingRedactions(overlay, redactions[String(pageNum)], SCALE);
+                        drawExistingRedactions(overlay, redactions[String(pageNum)], scale);
                         rebuildRedactionDivs(pageDiv, pageNum);
                     }
                 });
@@ -862,7 +943,7 @@ document.addEventListener('DOMContentLoaded', function () {
             var curX = pt.x, curY = pt.y;
             var ctx = overlay.getContext('2d');
             ctx.clearRect(0, 0, overlay.width, overlay.height);
-            drawExistingRedactions(overlay, redactions[String(pageNum)] || [], SCALE);
+            drawExistingRedactions(overlay, redactions[String(pageNum)] || [], pageScale(pageDiv, SCALE));
             var x = Math.min(detDrawStartX, curX), y = Math.min(detDrawStartY, curY);
             ctx.strokeStyle = '#22c55e'; ctx.lineWidth = 2; ctx.setLineDash([6, 3]);
             ctx.strokeRect(x, y, Math.abs(curX - detDrawStartX), Math.abs(curY - detDrawStartY));
@@ -877,7 +958,7 @@ document.addEventListener('DOMContentLoaded', function () {
             var w = Math.abs(endX - detDrawStartX), h = Math.abs(endY - detDrawStartY);
             var ctx = overlay.getContext('2d');
             ctx.clearRect(0, 0, overlay.width, overlay.height);
-            drawExistingRedactions(overlay, redactions[String(pageNum)] || [], SCALE);
+            drawExistingRedactions(overlay, redactions[String(pageNum)] || [], pageScale(pageDiv, SCALE));
             if (w < 10 || h < 10) return;
             _showDetDrawPreview(pageDiv, pageNum, x, y, w, h);
         };
@@ -1192,8 +1273,8 @@ document.addEventListener('DOMContentLoaded', function () {
         if (outsideRects && outsideRects.length) {
             var canvas = pageDiv.querySelector('.pdf-canvas');
             if (canvas && canvas.width > 10) {
-                var dsx = canvas.offsetWidth / (canvas.width / SCALE);
-                var dsy = canvas.offsetHeight / (canvas.height / SCALE);
+                var dsx = canvas.offsetWidth / (canvas.width / pageScale(pageDiv, SCALE));
+                var dsy = canvas.offsetHeight / (canvas.height / pageScale(pageDiv, SCALE));
 
                 outsideRects.forEach(function(r) {
                     var color = _boundsColors[r.opIdx % _boundsColors.length];
@@ -2114,8 +2195,8 @@ document.addEventListener('DOMContentLoaded', function () {
                     var canvas = container.querySelector('.pdf-canvas');
                     if (!wrapper || !canvas) return;
 
-                    var dsx = canvas.offsetWidth / (canvas.width / SCALE);
-                    var dsy = canvas.offsetHeight / (canvas.height / SCALE);
+                    var dsx = canvas.offsetWidth / (canvas.width / pageScale(container, SCALE));
+                    var dsy = canvas.offsetHeight / (canvas.height / pageScale(container, SCALE));
 
                     var dim = document.createElement('div');
                     dim.className = 'opinion-dim-overlay';

--- a/scanning/static/scanning/viewer_step2.js
+++ b/scanning/static/scanning/viewer_step2.js
@@ -80,8 +80,11 @@ document.addEventListener('DOMContentLoaded', function () {
     // Global drag handlers for draw detection resize/move
     document.addEventListener('mousemove', function (e) {
         if (!detDrawDragState || !detDrawPreview || !detDrawDragInitRect) return;
-        var dx = e.clientX - detDrawDragStartX;
-        var dy = e.clientY - detDrawDragStartY;
+        // detDrawRect is in wrapper-natural pixels; clientX deltas are in
+        // visual pixels, so divide by the active zoom to get natural deltas.
+        var zoom = getPdfZoom();
+        var dx = (e.clientX - detDrawDragStartX) / zoom;
+        var dy = (e.clientY - detDrawDragStartY) / zoom;
         var r = Object.assign({}, detDrawDragInitRect);
         if (detDrawDragState.type === 'move') {
             r.left += dx; r.top += dy;
@@ -465,6 +468,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     });
                 }
             }
+            applyZoomToPage(pageDiv);
         });
     }
 
@@ -506,15 +510,15 @@ document.addEventListener('DOMContentLoaded', function () {
 
         overlay.onmousedown = function (e) {
             isDrawing = true;
-            var rect = overlay.getBoundingClientRect();
-            startX = e.clientX - rect.left;
-            startY = e.clientY - rect.top;
+            var pt = eventToCanvasPixels(e, overlay);
+            startX = pt.x;
+            startY = pt.y;
         };
         overlay.onmousemove = function (e) {
             if (!isDrawing) return;
-            var rect = overlay.getBoundingClientRect();
-            var curX = e.clientX - rect.left;
-            var curY = e.clientY - rect.top;
+            var pt = eventToCanvasPixels(e, overlay);
+            var curX = pt.x;
+            var curY = pt.y;
             var ctx = overlay.getContext('2d');
             ctx.clearRect(0, 0, overlay.width, overlay.height);
             drawExistingRedactions(overlay, redactions[String(pageNum)] || [], SCALE);
@@ -529,9 +533,9 @@ document.addEventListener('DOMContentLoaded', function () {
         overlay.onmouseup = function (e) {
             if (!isDrawing) return;
             isDrawing = false;
-            var rect = overlay.getBoundingClientRect();
-            var endX = e.clientX - rect.left;
-            var endY = e.clientY - rect.top;
+            var pt = eventToCanvasPixels(e, overlay);
+            var endX = pt.x;
+            var endY = pt.y;
             var pdfX = Math.min(startX, endX) / SCALE;
             var pdfY = Math.min(startY, endY) / SCALE;
             var pdfW = Math.abs(endX - startX) / SCALE;
@@ -848,14 +852,14 @@ document.addEventListener('DOMContentLoaded', function () {
         overlay.onmousedown = function (e) {
             if (detDrawPreview) return; // wait for user to confirm/cancel existing
             isDetDrawing = true;
-            var r = overlay.getBoundingClientRect();
-            detDrawStartX = e.clientX - r.left;
-            detDrawStartY = e.clientY - r.top;
+            var pt = eventToCanvasPixels(e, overlay);
+            detDrawStartX = pt.x;
+            detDrawStartY = pt.y;
         };
         overlay.onmousemove = function (e) {
             if (!isDetDrawing) return;
-            var r = overlay.getBoundingClientRect();
-            var curX = e.clientX - r.left, curY = e.clientY - r.top;
+            var pt = eventToCanvasPixels(e, overlay);
+            var curX = pt.x, curY = pt.y;
             var ctx = overlay.getContext('2d');
             ctx.clearRect(0, 0, overlay.width, overlay.height);
             drawExistingRedactions(overlay, redactions[String(pageNum)] || [], SCALE);
@@ -867,8 +871,8 @@ document.addEventListener('DOMContentLoaded', function () {
         overlay.onmouseup = function (e) {
             if (!isDetDrawing) return;
             isDetDrawing = false;
-            var r = overlay.getBoundingClientRect();
-            var endX = e.clientX - r.left, endY = e.clientY - r.top;
+            var pt = eventToCanvasPixels(e, overlay);
+            var endX = pt.x, endY = pt.y;
             var x = Math.min(detDrawStartX, endX), y = Math.min(detDrawStartY, endY);
             var w = Math.abs(endX - detDrawStartX), h = Math.abs(endY - detDrawStartY);
             var ctx = overlay.getContext('2d');
@@ -1548,8 +1552,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
             function onMove(ev) {
                 hasMoved = true;
-                div.style.left = (startLeft + ev.clientX - startX) + 'px';
-                div.style.top  = (startTop  + ev.clientY - startY) + 'px';
+                var z = getPdfZoom();
+                div.style.left = (startLeft + (ev.clientX - startX) / z) + 'px';
+                div.style.top  = (startTop  + (ev.clientY - startY) / z) + 'px';
             }
 
             function onUp() {
@@ -1616,8 +1621,9 @@ document.addEventListener('DOMContentLoaded', function () {
         var hasMoved = false;
         function onMove(e) {
             hasMoved = true;
-            var dx = e.clientX - startX;
-            var dy = e.clientY - startY;
+            var z = getPdfZoom();
+            var dx = (e.clientX - startX) / z;
+            var dy = (e.clientY - startY) / z;
             var newLeft = startLeft, newTop = startTop, newW = startW, newH = startH;
 
             if (pos.indexOf('e') >= 0) newW = startW + dx;
@@ -1823,7 +1829,8 @@ document.addEventListener('DOMContentLoaded', function () {
                 var hasMoved = false;
                 function onMove(e) {
                     hasMoved = true;
-                    var dx = e.clientX - startX, dy = e.clientY - startY;
+                    var z = getPdfZoom();
+                    var dx = (e.clientX - startX) / z, dy = (e.clientY - startY) / z;
                     var newLeft = startLeft, newTop = startTop, newW = startW, newH = startH;
                     if (pos.indexOf('e') >= 0) newW = Math.max(10, startW + dx);
                     if (pos.indexOf('s') >= 0) newH = Math.max(10, startH + dy);
@@ -1865,8 +1872,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
             function onMove(e) {
                 hasMoved = true;
-                div.style.left = (startLeft + e.clientX - startX) + 'px';
-                div.style.top = (startTop + e.clientY - startY) + 'px';
+                var z = getPdfZoom();
+                div.style.left = (startLeft + (e.clientX - startX) / z) + 'px';
+                div.style.top = (startTop + (e.clientY - startY) / z) + 'px';
             }
 
             function onUp() {
@@ -1972,7 +1980,8 @@ document.addEventListener('DOMContentLoaded', function () {
                 var hasMoved = false;
                 function onMove(ev) {
                     hasMoved = true;
-                    var dx = ev.clientX - startX, dy = ev.clientY - startY;
+                    var z = getPdfZoom();
+                    var dx = (ev.clientX - startX) / z, dy = (ev.clientY - startY) / z;
                     var nL = startLeft, nT = startTop, nW = startW, nH = startH;
                     if (pos.indexOf('e') >= 0) nW = startW + dx;
                     if (pos.indexOf('w') >= 0) { nW = startW - dx; nL = startLeft + dx; }

--- a/scanning/templates/scanning/scan_process.html
+++ b/scanning/templates/scanning/scan_process.html
@@ -323,6 +323,12 @@
     {# PDF viewer #}
     <main class="flex-1 overflow-y-auto border border-gray-200 dark:border-gray-700 rounded bg-white dark:bg-gray-900 viewer-panel">
       {% csrf_token %}
+      <div class="zoom-toolbar" role="toolbar" aria-label="PDF zoom">
+        <button type="button" class="zoom-btn" data-zoom-action="out" title="Zoom out" aria-label="Zoom out">&minus;</button>
+        <span id="zoom-pct" class="zoom-pct" aria-live="polite">100%</span>
+        <button type="button" class="zoom-btn" data-zoom-action="in" title="Zoom in" aria-label="Zoom in">+</button>
+        <button type="button" class="zoom-btn zoom-reset" data-zoom-action="reset" title="Reset zoom">Reset</button>
+      </div>
       <div id="pdf-viewer"
            data-pdf-url="{% if step == 3 %}{% else %}{% url 'serve_scan_pdf' scan.pk %}{% endif %}"
            data-document-id="{{ scan.pk }}"
@@ -365,6 +371,22 @@ var docId = SCAN_CONFIG.docId;
 var deletedPages = SCAN_CONFIG.deletedPages;
 </script>
 <script src="{% static 'scanning/viewer_sidebar.js' %}"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    var toolbar = document.querySelector('.zoom-toolbar');
+    if (!toolbar) return;
+    var pct = document.getElementById('zoom-pct');
+    if (pct) pct.textContent = Math.round(getPdfZoom() * 100) + '%';
+    toolbar.addEventListener('click', function (e) {
+        var btn = e.target.closest('[data-zoom-action]');
+        if (!btn) return;
+        var action = btn.dataset.zoomAction;
+        if (action === 'in') setPdfZoom(getPdfZoom() + PDF_ZOOM_STEP);
+        else if (action === 'out') setPdfZoom(getPdfZoom() - PDF_ZOOM_STEP);
+        else if (action === 'reset') setPdfZoom(1);
+    });
+});
+</script>
 {% if is_processing %}
 <script src="{% static 'scanning/viewer_progress.js' %}"></script>
 {% endif %}


### PR DESCRIPTION
## Summary
Closes #57.

Adds a zoom toolbar (−, %, +, Reset) to the processing PDF viewer (`scan_process.html`, used in steps 1, 2, and 3). Range 0.5x – 3x, step 0.1. Step 1 persists its zoom level independently from steps 2/3, since reviewing page numbers and reviewing opinions benefit from different zooms.

## How it works
The toolbar lives at the top-left of the viewer panel and stays visible when you scroll, even horizontally at high zoom. Each PDF page is scaled visually as a whole, so detection boxes, redactions, and image overlays all stay aligned with the page automatically. Drawing a new redaction or detection, and dragging or resizing existing ones, works the same at any zoom level.

pdf.js rasterizes each page once into a canvas at a fixed resolution, so simply CSS-scaling that bitmap to a higher zoom looks really blurry above the original render scale (the same effect as zooming into a JPEG). To avoid this, when the zoom level changes the viewer re-rasterizes visible pages at the new resolution so text stays sharp. Pages outside the viewport are dropped and re-rendered fresh when scrolled back into view, which keeps memory bounded at high zoom on long documents. Rapid zoom clicks are debounced and any in-flight render is cancelled when zoom changes again, the same pattern pdf.js's own demo viewer uses.

The page header (PDF p.n + action buttons) also got a small layout tweak: at narrow widths (low zoom or small monitors) the buttons wrap below the page identifier instead of overflowing the page width.