### PR TITLE
ci(runpod): auto-update template image after worker push

### DIFF
--- a/.github/workflows/build-runpod-worker.yml
+++ b/.github/workflows/build-runpod-worker.yml
@@ -37,3 +37,25 @@ jobs:
             freelawproject/blackletter-gpu-worker:latest
           cache-from: type=registry,ref=freelawproject/blackletter-gpu-worker:cache
           cache-to: type=registry,ref=freelawproject/blackletter-gpu-worker:cache,mode=max
+
+      - name: Update RunPod template image
+        env:
+          RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
+          RUNPOD_TEMPLATE_ID: ${{ secrets.RUNPOD_TEMPLATE_ID }}
+          IMAGE: freelawproject/blackletter-gpu-worker:${{ steps.vars.outputs.sha_short }}
+        run: |
+          set -euo pipefail
+          payload=$(jq -nc --arg img "$IMAGE" '{imageName: $img}')
+          response=$(curl -sS -w "\n%{http_code}" -X PATCH \
+            -H "Authorization: Bearer $RUNPOD_API_KEY" \
+            -H "Content-Type: application/json" \
+            --data "$payload" \
+            "https://rest.runpod.io/v1/templates/$RUNPOD_TEMPLATE_ID")
+          body=$(printf '%s\n' "$response" | sed '$d')
+          status=$(printf '%s\n' "$response" | tail -n1)
+          echo "HTTP $status"
+          echo "$body"
+          if [ "$status" -ge 400 ]; then
+            echo "::error::RunPod template update failed (HTTP $status)"
+            exit 1
+          fi

--- a/.github/workflows/build-runpod-worker.yml
+++ b/.github/workflows/build-runpod-worker.yml
@@ -45,6 +45,9 @@ jobs:
           IMAGE: freelawproject/blackletter-gpu-worker:${{ steps.vars.outputs.sha_short }}
         run: |
           set -euo pipefail
+          # Sends only `imageName`. RunPod's partial PATCH preserves other
+          # fields, but if env vars are later added to the template,
+          # re-verify they survive or switch to read-modify-write.
           payload=$(jq -nc --arg img "$IMAGE" '{imageName: $img}')
           response=$(curl -sS -w "\n%{http_code}" -X PATCH \
             -H "Authorization: Bearer $RUNPOD_API_KEY" \

--- a/README.md
+++ b/README.md
@@ -71,7 +71,13 @@ scanning/
     templates/        base.html, cotton components
     tailwind/         Config + input CSS
     static-global/    Generated CSS output
+  runpod/             GPU worker image for RunPod Serverless
 ```
+
+The GPU-heavy steps of the blackletter pipeline run on a RunPod Serverless
+worker built from `scanning/runpod/`. See
+[scanning/runpod/README.md](scanning/runpod/README.md) for the worker image,
+release workflow, endpoint configuration, and operational notes.
 
 ### Settings Pattern
 

--- a/scanning/runpod/README.md
+++ b/scanning/runpod/README.md
@@ -108,9 +108,47 @@ docker push ghcr.io/freelawproject/blackletter-gpu-worker:<tag>
 
 ## Releasing a new image version
 
-Pushing a new image tag to the registry does **not** automatically update
-the running endpoint. You must create a new release in the RunPod console
-so workers boot from the new image:
+Pushing a new image tag to the registry alone does **not** update the
+running endpoint; the RunPod template that backs the endpoint has to
+be told about the new tag. We support two ways to do this:
+
+### Automated release (default)
+
+The `Build and Push RunPod Worker` GitHub Actions workflow
+(`.github/workflows/build-runpod-worker.yml`) handles this end-to-end.
+On any push to `main` that touches `scanning/runpod/**` (or a manual
+`workflow_dispatch` run), it:
+
+1. Builds `freelawproject/blackletter-gpu-worker` and pushes both
+   `:<sha_short>` and `:latest` tags to Docker Hub.
+2. Calls `PATCH https://rest.runpod.io/v1/templates/<id>` to update
+   the endpoint's backing template `imageName` to the SHA-pinned tag.
+3. With `Min Workers = 0`, warm workers drain on the 5-min Idle
+   Timeout and the next job dispatched to the endpoint cold-starts on
+   the new image.
+
+The workflow needs two GitHub Actions repo secrets:
+
+- `RUNPOD_API_KEY` — a RunPod API key with **Restricted** permission
+  set to **GraphQL: Read/Write** (leave AI API at None). This is the
+  tightest scope RunPod allows. There is no per-template scope, so
+  this key grants full management of every template, endpoint, and
+  pod on the account; treat it as a production credential.
+- `RUNPOD_TEMPLATE_ID` — the ID of the endpoint's backing template.
+  Endpoints created without explicitly picking a template still have
+  one, hidden from the default listing. Surface it via:
+  ```bash
+  curl -sS -H "Authorization: Bearer <API_KEY>" \
+    "https://rest.runpod.io/v1/templates?includeEndpointBoundTemplates=true"
+  ```
+  Find the entry where `isServerless: true` and `name` matches the
+  endpoint (e.g. `Blackletter gpu worker`); copy its `id`.
+
+### Manual release (via the RunPod console)
+
+Useful when publishing a hotfix from a non-`main` branch, or when the
+workflow is unavailable. Create a new release by hand so workers boot
+from the new image:
 
 1. Go to the **Serverless** page and open your endpoint.
 2. Click **Manage**.


### PR DESCRIPTION
## Summary
After the `Build and Push RunPod Worker` workflow uploads a new image to Docker Hub, it PATCHes the RunPod template's `imageName` to the SHA-pinned tag via `rest.runpod.io/v1/templates/<id>`. Next cold-start workers pull the new image automatically, replacing the manual "edit image tag in the RunPod UI" step.

## Setup before merging

**RunPod**
1. Console → Settings → API Keys → **Create API Key** with **Restricted** permission. Set **GraphQL: Read/Write** and leave **AI API: None**. Copy the key.

   Why GraphQL R/W: RunPod exposes only two scopes on restricted keys, **GraphQL** (the management plane covering templates, endpoints, pods, secrets) and **AI API** (per-endpoint scope, only for *invoking* serverless jobs). Updating a template is a management operation, so it requires GraphQL R/W; the REST `/v1/templates/<id>` route used by the workflow is a thin shim over the GraphQL `saveTemplate` mutation internally. There is no per-template scope, so GraphQL R/W is the tightest setting that lets us do this. It does, however, grant full management of every template, endpoint, and pod on the account, so treat the key as a production credential: store only in GitHub Actions secrets, never echo to logs, and rotate if it leaks.
2. Find the template ID. Endpoints created manually still have a backing template, hidden from the default listing, surface it with the `includeEndpointBoundTemplates` flag:
   ```bash
   curl -sS -H "Authorization: Bearer <API_KEY>" \
     "https://rest.runpod.io/v1/templates?includeEndpointBoundTemplates=true"
   ```
   Find the entry where `isServerless: true` and `name` matches your endpoint (e.g. `Blackletter gpu worker`). Its `id` is the template ID.

**GitHub**
3. Repo → Settings → Secrets and variables → Actions → **New repository secret**. Add both:
   - `RUNPOD_API_KEY` from step 1
   - `RUNPOD_TEMPLATE_ID` from step 2

## Verifying after merge
Run the workflow manually (Actions → **Build and Push RunPod Worker** → Run workflow) and confirm the `Update RunPod template image` step logs `HTTP 200`. The template in the RunPod UI should then show the new `freelawproject/blackletter-gpu-worker:<sha>` tag, and the next job dispatched to the endpoint will cold-start on the new image.

## Notes
- This relies on `Min Workers = 0`: warm workers drain on the 5-min idle timeout and the next job picks up the new image. If we raise `Min Workers > 0` later, we'll need to add an explicit roll step to force existing workers to recycle.
- The workflow still triggers only on changes under `scanning/runpod/**` (plus `workflow_dispatch`), unchanged from before.

Closes #55