### PR TITLE
feat(scanning): keep Volume.queue_status in sync with scan lifecycle

### DIFF
--- a/scanning/admin.py
+++ b/scanning/admin.py
@@ -11,6 +11,7 @@ from scanning.models import (
     Status,
     Volume,
 )
+from scanning.services import refresh_volume_queue_status
 
 
 class RetryCapFilter(admin.SimpleListFilter):
@@ -71,6 +72,35 @@ class ScanAdmin(admin.ModelAdmin):
     readonly_fields = ["date_created", "date_modified", "processed_at"]
     date_hierarchy = "date_created"
     actions = ["reset_to_queued", "requeue_retry_cap_scans"]
+
+    def delete_model(self, request, obj):
+        """Delete a Scan and refresh its parent Volume's queue_status.
+
+        Without this, the volume can drift (e.g. stay at COMPLETE after
+        its only approved scan is deleted from the admin).
+
+        :param request: The admin HTTP request.
+        :param obj: The Scan to delete.
+        """
+        volume = obj.volume_obj
+        super().delete_model(request, obj)
+        if volume is not None:
+            refresh_volume_queue_status(volume)
+
+    def delete_queryset(self, request, queryset):
+        """Bulk-delete Scans and refresh affected Volumes.
+
+        :param request: The admin HTTP request.
+        :param queryset: Scans selected for deletion.
+        """
+        volume_ids = list(
+            queryset.exclude(volume_obj__isnull=True)
+            .values_list("volume_obj_id", flat=True)
+            .distinct()
+        )
+        super().delete_queryset(request, queryset)
+        for volume in Volume.objects.filter(pk__in=volume_ids):
+            refresh_volume_queue_status(volume)
 
     @admin.action(
         description=(

--- a/scanning/admin.py
+++ b/scanning/admin.py
@@ -11,7 +11,10 @@ from scanning.models import (
     Status,
     Volume,
 )
-from scanning.services import refresh_volume_queue_status
+from scanning.services import (
+    refresh_volume_queue_status,
+    refresh_volume_queue_status_for_scan,
+)
 
 
 class RetryCapFilter(admin.SimpleListFilter):
@@ -72,6 +75,33 @@ class ScanAdmin(admin.ModelAdmin):
     readonly_fields = ["date_created", "date_modified", "processed_at"]
     date_hierarchy = "date_created"
     actions = ["reset_to_queued", "requeue_retry_cap_scans"]
+
+    def save_model(self, request, obj, form, change):
+        """Save a Scan and refresh affected Volume(s) queue_status.
+
+        Covers admin edits that the lifecycle helper would normally see
+        elsewhere: flipping ``status`` (e.g. PENDING_REVIEW → APPROVED)
+        and reassigning ``volume_obj`` to a different volume. In the
+        reassignment case both the old and new volumes are refreshed.
+
+        :param request: The admin HTTP request.
+        :param obj: The Scan being saved.
+        :param form: The admin form instance.
+        :param change: True for an edit, False for a new object.
+        """
+        old_volume_id = None
+        if change and obj.pk:
+            old_volume_id = (
+                Scan.objects.filter(pk=obj.pk)
+                .values_list("volume_obj_id", flat=True)
+                .first()
+            )
+        super().save_model(request, obj, form, change)
+        refresh_volume_queue_status_for_scan(obj)
+        if old_volume_id and old_volume_id != obj.volume_obj_id:
+            old_volume = Volume.objects.filter(pk=old_volume_id).first()
+            if old_volume is not None:
+                refresh_volume_queue_status(old_volume)
 
     def delete_model(self, request, obj):
         """Delete a Scan and refresh its parent Volume's queue_status.

--- a/scanning/factories.py
+++ b/scanning/factories.py
@@ -8,6 +8,7 @@ from scanning.models import (
     Scan,
     Source,
     Status,
+    Volume,
 )
 
 
@@ -59,6 +60,26 @@ class ReporterFactory(factory.django.DjangoModelFactory):
 
     short_name = "a"
     full_name = "Atlantic Reporter"
+
+
+class VolumeFactory(factory.django.DjangoModelFactory):
+    """Factory for creating Volume instances.
+
+    Default declarations:
+
+    - ``reporter``: auto-created via ``ReporterFactory``.
+    - ``volume_number``: sequential starting at 1.
+    - ``expected_start_page``: 1.
+    - ``expected_end_page``: 100.
+    """
+
+    class Meta:
+        model = Volume
+
+    reporter = factory.SubFactory(ReporterFactory)
+    volume_number = factory.Sequence(lambda n: n + 1)
+    expected_start_page = 1
+    expected_end_page = 100
 
 
 class ScanFactory(factory.django.DjangoModelFactory):

--- a/scanning/services.py
+++ b/scanning/services.py
@@ -75,6 +75,13 @@ def _volume_fully_uploaded(volume: Volume, scan_count: int) -> bool:
     that a volume is "done", so we return False and leave it to a
     curator to mark via the manual dropdown.
 
+    Trade-off in the count fallback: when only ``expected_parts`` is
+    set, this returns True as soon as the scan count meets the
+    expectation, without verifying that the scans actually span
+    distinct page ranges. Two scans covering the same pages will look
+    "fully uploaded". The accurate path is the coverage check above;
+    set ``expected_start_page`` / ``expected_end_page`` when possible.
+
     :param volume: The Volume to check.
     :param scan_count: Pre-computed count of scans on the volume.
     :returns: True when every expected scan is present.
@@ -129,12 +136,16 @@ def refresh_volume_queue_status(volume: Volume) -> None:
 def refresh_volume_queue_status_for_scan(scan: Scan) -> None:
     """Convenience: refresh the parent Volume's queue_status from a Scan.
 
-    No-op when the scan is not attached to a Volume.
+    No-op when the scan is not attached to a Volume. Looks the volume
+    up by ``volume_obj_id`` rather than going through the FK descriptor
+    so the intent (and the resulting query) are explicit.
 
     :param scan: The scan whose parent volume should be refreshed.
     """
-    if scan.volume_obj_id:
-        refresh_volume_queue_status(scan.volume_obj)
+    if not scan.volume_obj_id:
+        return
+    volume = Volume.objects.get(pk=scan.volume_obj_id)
+    refresh_volume_queue_status(volume)
 
 
 def _update_progress(

--- a/scanning/services.py
+++ b/scanning/services.py
@@ -51,9 +51,11 @@ from scanning.models import (
     Issue,
     OpinionScan,
     OpinionStatus,
+    QueueStatus,
     Scan,
     Stage,
     Status,
+    Volume,
 )
 from scanning.utils import ensure_output_dir, find_ocr_pdf, has_s3_credentials
 
@@ -62,6 +64,77 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _volume_fully_uploaded(volume: Volume, scan_count: int) -> bool:
+    """Whether a Volume has all its expected scans uploaded.
+
+    Coverage takes precedence when ``expected_start_page`` /
+    ``expected_end_page`` are set, then ``expected_parts`` as a count
+    fallback. When neither expectation is recorded we cannot decide
+    that a volume is "done", so we return False and leave it to a
+    curator to mark via the manual dropdown.
+
+    :param volume: The Volume to check.
+    :param scan_count: Pre-computed count of scans on the volume.
+    :returns: True when every expected scan is present.
+    :rtype: bool
+    """
+    if volume.expected_start_page and volume.expected_end_page:
+        return volume.is_fully_covered
+    if volume.expected_parts:
+        return scan_count >= volume.expected_parts
+    return False
+
+
+def _compute_volume_queue_status(volume: Volume, scans: list[Scan]) -> str:
+    """Derive the queue status a Volume should have from its scans.
+
+    :param volume: The Volume to inspect.
+    :param scans: The Volume's current scans.
+    :returns: A ``QueueStatus`` value.
+    :rtype: str
+    """
+    if not scans:
+        if volume.assigned_to_id:
+            return QueueStatus.ASSIGNED
+        return QueueStatus.NEEDS_SCANNING
+    all_approved = all(s.status == Status.APPROVED for s in scans)
+    fully_uploaded = _volume_fully_uploaded(volume, len(scans))
+    if all_approved and fully_uploaded:
+        return QueueStatus.COMPLETE
+    if fully_uploaded:
+        return QueueStatus.SCANNED
+    return QueueStatus.SCANNING
+
+
+def refresh_volume_queue_status(volume: Volume) -> None:
+    """Recompute and persist a Volume's queue_status from its scans.
+
+    Manual ``UNAVAILABLE`` is preserved (it's a curator decision, not
+    derivable from observable state). All other states are recomputed
+    so callers don't have to track transitions individually.
+
+    :param volume: The Volume to refresh in place.
+    """
+    if volume.queue_status == QueueStatus.UNAVAILABLE:
+        return
+    scans = list(volume.scans.all())
+    new_status = _compute_volume_queue_status(volume, scans)
+    if new_status != volume.queue_status:
+        volume.queue_status = new_status
+        volume.save(update_fields=["queue_status"])
+
+
+def refresh_volume_queue_status_for_scan(scan: Scan) -> None:
+    """Convenience: refresh the parent Volume's queue_status from a Scan.
+
+    No-op when the scan is not attached to a Volume.
+
+    :param scan: The scan whose parent volume should be refreshed.
+    """
+    if scan.volume_obj_id:
+        refresh_volume_queue_status(scan.volume_obj)
 
 
 def _update_progress(
@@ -2088,6 +2161,7 @@ def run_generate_files(scan_pk: int) -> None:
         scan.progress_message = f"Generated {opinion_count} opinions"
         scan.progress_log = ""
         scan.save()
+        refresh_volume_queue_status_for_scan(scan)
 
         OpinionScan.objects.filter(scan=scan).delete()
         for i, op in enumerate(existing_opinions):

--- a/scanning/templates/scanning/queue.html
+++ b/scanning/templates/scanning/queue.html
@@ -96,7 +96,7 @@
           <span class="badge-priority-{{ vol.priority }}">{{ vol.get_priority_display }}</span>
         </td>
         <td class="px-4 py-3 text-sm">
-          <span class="badge-{{ vol.queue_status }}">{{ vol.get_queue_status_display }}</span>
+          <span class="badge-{{ vol.queue_status }}" title="Volume queue status: {{ vol.get_queue_status_display }}">{{ vol.get_queue_status_display }}</span>
         </td>
         <td class="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
           {% if vol.assigned_to %}
@@ -129,8 +129,8 @@
         </td>
         <td class="py-1.5 text-xs"></td>
         <td class="py-1.5 text-xs">
-          <span class="badge-{{ scan.status }}">{{ scan.get_status_display }}</span>
-          {% if scan.s3_uploaded %}<span class="badge-s3">S3</span>{% endif %}
+          <span class="badge-{{ scan.status }}" title="Scan status: {{ scan.get_status_display }}">{{ scan.get_status_display }}</span>
+          {% if scan.s3_uploaded %}<span class="badge-s3" title="Final files uploaded to S3">S3</span>{% endif %}
         </td>
         <td class="py-1.5 text-xs text-gray-400 dark:text-gray-500">
           {{ scan.date_created|date:"M j" }}

--- a/scanning/templates/scanning/queue.html
+++ b/scanning/templates/scanning/queue.html
@@ -96,7 +96,7 @@
           <span class="badge-priority-{{ vol.priority }}">{{ vol.get_priority_display }}</span>
         </td>
         <td class="px-4 py-3 text-sm">
-          <span class="badge-{{ vol.queue_status }}" title="Volume queue status: {{ vol.get_queue_status_display }}">{{ vol.get_queue_status_display }}</span>
+          <span class="badge-{{ vol.queue_status }}" title="Volume queue status">{{ vol.get_queue_status_display }}</span>
         </td>
         <td class="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
           {% if vol.assigned_to %}
@@ -129,7 +129,7 @@
         </td>
         <td class="py-1.5 text-xs"></td>
         <td class="py-1.5 text-xs">
-          <span class="badge-{{ scan.status }}" title="Scan status: {{ scan.get_status_display }}">{{ scan.get_status_display }}</span>
+          <span class="badge-{{ scan.status }}" title="Scan status">{{ scan.get_status_display }}</span>
           {% if scan.s3_uploaded %}<span class="badge-s3" title="Final files uploaded to S3">S3</span>{% endif %}
         </td>
         <td class="py-1.5 text-xs text-gray-400 dark:text-gray-500">

--- a/scanning/templates/scanning/scan_list.html
+++ b/scanning/templates/scanning/scan_list.html
@@ -91,8 +91,8 @@
         <td class="px-4 py-3 text-sm">{{ scan.get_source_display }}</td>
         <td class="px-4 py-3 text-sm">{{ scan.opinion_count }}</td>
         <td class="px-4 py-3 text-sm">
-          <span class="badge-{{ scan.status }}">{{ scan.get_status_display }}</span>
-          {% if scan.s3_uploaded %}<span class="badge-s3">S3</span>{% endif %}
+          <span class="badge-{{ scan.status }}" title="Scan status: {{ scan.get_status_display }}">{{ scan.get_status_display }}</span>
+          {% if scan.s3_uploaded %}<span class="badge-s3" title="Final files uploaded to S3">S3</span>{% endif %}
         </td>
         <td class="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{{ scan.date_created|date:"M j, Y g:i A" }}{% if scan.uploaded_by %} by {{ scan.uploaded_by.username }}{% endif %}</td>
         <td class="px-4 py-3 text-sm">
@@ -110,8 +110,8 @@
   <a href="{% url 'scan_detail' pk=scan.pk %}" class="card block hover:shadow-md transition-shadow">
     <div class="flex items-center justify-between mb-2">
       <span class="font-medium text-sm">{{ scan.reporter }}</span>
-      <span class="badge-{{ scan.status }}">{{ scan.get_status_display }}</span>
-      {% if scan.s3_uploaded %}<span class="badge-s3">S3</span>{% endif %}
+      <span class="badge-{{ scan.status }}" title="Scan status: {{ scan.get_status_display }}">{{ scan.get_status_display }}</span>
+      {% if scan.s3_uploaded %}<span class="badge-s3" title="Final files uploaded to S3">S3</span>{% endif %}
     </div>
     <div class="text-sm text-gray-500 dark:text-gray-400">
       Vol. {{ scan.volume }} &middot; {{ scan.get_source_display }} &middot; {{ scan.number_of_pages }} pages &middot; {{ scan.opinion_count }} opinion{{ scan.opinion_count|pluralize }} &middot; {{ scan.date_created|date:"M j, Y g:i A" }}{% if scan.uploaded_by %} by {{ scan.uploaded_by.username }}{% endif %}

--- a/scanning/templates/scanning/scan_list.html
+++ b/scanning/templates/scanning/scan_list.html
@@ -91,7 +91,7 @@
         <td class="px-4 py-3 text-sm">{{ scan.get_source_display }}</td>
         <td class="px-4 py-3 text-sm">{{ scan.opinion_count }}</td>
         <td class="px-4 py-3 text-sm">
-          <span class="badge-{{ scan.status }}" title="Scan status: {{ scan.get_status_display }}">{{ scan.get_status_display }}</span>
+          <span class="badge-{{ scan.status }}" title="Scan status">{{ scan.get_status_display }}</span>
           {% if scan.s3_uploaded %}<span class="badge-s3" title="Final files uploaded to S3">S3</span>{% endif %}
         </td>
         <td class="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{{ scan.date_created|date:"M j, Y g:i A" }}{% if scan.uploaded_by %} by {{ scan.uploaded_by.username }}{% endif %}</td>
@@ -110,7 +110,7 @@
   <a href="{% url 'scan_detail' pk=scan.pk %}" class="card block hover:shadow-md transition-shadow">
     <div class="flex items-center justify-between mb-2">
       <span class="font-medium text-sm">{{ scan.reporter }}</span>
-      <span class="badge-{{ scan.status }}" title="Scan status: {{ scan.get_status_display }}">{{ scan.get_status_display }}</span>
+      <span class="badge-{{ scan.status }}" title="Scan status">{{ scan.get_status_display }}</span>
       {% if scan.s3_uploaded %}<span class="badge-s3" title="Final files uploaded to S3">S3</span>{% endif %}
     </div>
     <div class="text-sm text-gray-500 dark:text-gray-400">

--- a/scanning/tests/test_services.py
+++ b/scanning/tests/test_services.py
@@ -13,7 +13,13 @@ from django.db.models import F
 from django.test import TestCase, override_settings
 
 from scanning.factories import ReporterFactory, ScanFactory, UserFactory
-from scanning.models import Detection, Stage, Status
+from scanning.models import (
+    Detection,
+    QueueStatus,
+    Stage,
+    Status,
+    Volume,
+)
 
 FIXTURE_DIR = pathlib.Path(__file__).parent / "fixtures"
 PDF_PATH = FIXTURE_DIR / "a3d.332.1.1.pdf"
@@ -957,3 +963,112 @@ class TestHandlePipelineExceptionRetryCap(TestCase):
         self.assertEqual(scan.status, Status.ERROR_MAX_RETRIES)
         self.assertEqual(scan.retry_count, 6)
         self.assertIn("Max retries exceeded", scan.progress_message)
+
+
+class TestRefreshVolumeQueueStatus(TestCase):
+    """Test ``refresh_volume_queue_status`` and its derivation logic."""
+
+    def _make_volume(self, **kwargs):
+        defaults = {
+            "reporter": ReporterFactory(),
+            "volume_number": 1,
+            "expected_start_page": 1,
+            "expected_end_page": 100,
+        }
+        defaults.update(kwargs)
+        return Volume.objects.create(**defaults)
+
+    def _make_scan(self, volume, start=1, end=100, status=Status.UPLOADED):
+        return ScanFactory(
+            volume_obj=volume,
+            reporter=volume.reporter,
+            volume=volume.volume_number,
+            start_page=start,
+            end_page=end,
+            number_of_pages=end - start + 1,
+            status=status,
+        )
+
+    def test_no_scans_unassigned(self):
+        from scanning.services import refresh_volume_queue_status
+
+        volume = self._make_volume()
+        refresh_volume_queue_status(volume)
+        volume.refresh_from_db()
+        self.assertEqual(volume.queue_status, QueueStatus.NEEDS_SCANNING)
+
+    def test_no_scans_assigned_user(self):
+        from scanning.services import refresh_volume_queue_status
+
+        user = UserFactory()
+        volume = self._make_volume(assigned_to=user)
+        refresh_volume_queue_status(volume)
+        volume.refresh_from_db()
+        self.assertEqual(volume.queue_status, QueueStatus.ASSIGNED)
+
+    def test_partial_coverage_is_scanning(self):
+        from scanning.services import refresh_volume_queue_status
+
+        volume = self._make_volume()
+        self._make_scan(volume, start=1, end=50)
+        refresh_volume_queue_status(volume)
+        volume.refresh_from_db()
+        self.assertEqual(volume.queue_status, QueueStatus.SCANNING)
+
+    def test_full_coverage_not_approved_is_scanned(self):
+        from scanning.services import refresh_volume_queue_status
+
+        volume = self._make_volume()
+        self._make_scan(volume, start=1, end=100, status=Status.PENDING_REVIEW)
+        refresh_volume_queue_status(volume)
+        volume.refresh_from_db()
+        self.assertEqual(volume.queue_status, QueueStatus.SCANNED)
+
+    def test_full_coverage_all_approved_is_complete(self):
+        from scanning.services import refresh_volume_queue_status
+
+        volume = self._make_volume()
+        self._make_scan(volume, start=1, end=100, status=Status.APPROVED)
+        refresh_volume_queue_status(volume)
+        volume.refresh_from_db()
+        self.assertEqual(volume.queue_status, QueueStatus.COMPLETE)
+
+    def test_unavailable_status_preserved(self):
+        from scanning.services import refresh_volume_queue_status
+
+        volume = self._make_volume(queue_status=QueueStatus.UNAVAILABLE)
+        self._make_scan(volume, start=1, end=100, status=Status.APPROVED)
+        refresh_volume_queue_status(volume)
+        volume.refresh_from_db()
+        self.assertEqual(volume.queue_status, QueueStatus.UNAVAILABLE)
+
+    def test_expected_parts_fallback_complete(self):
+        """All approved + expected_parts met → COMPLETE even without page range."""
+        from scanning.services import refresh_volume_queue_status
+
+        volume = self._make_volume(
+            expected_start_page=None,
+            expected_end_page=None,
+            expected_parts=2,
+        )
+        self._make_scan(volume, start=1, end=50, status=Status.APPROVED)
+        self._make_scan(volume, start=51, end=100, status=Status.APPROVED)
+        refresh_volume_queue_status(volume)
+        volume.refresh_from_db()
+        self.assertEqual(volume.queue_status, QueueStatus.COMPLETE)
+
+    def test_no_expectations_stays_scanning(self):
+        """Volumes without expected_*_page or expected_parts can't be
+        auto-completed: the helper has no way to know all work is in,
+        so it leaves them at SCANNING until a curator marks otherwise.
+        """
+        from scanning.services import refresh_volume_queue_status
+
+        volume = self._make_volume(
+            expected_start_page=None,
+            expected_end_page=None,
+        )
+        self._make_scan(volume, start=1, end=100, status=Status.APPROVED)
+        refresh_volume_queue_status(volume)
+        volume.refresh_from_db()
+        self.assertEqual(volume.queue_status, QueueStatus.SCANNING)

--- a/scanning/tests/test_services.py
+++ b/scanning/tests/test_services.py
@@ -12,14 +12,19 @@ from unittest.mock import patch
 from django.db.models import F
 from django.test import TestCase, override_settings
 
-from scanning.factories import ReporterFactory, ScanFactory, UserFactory
+from scanning.factories import (
+    ReporterFactory,
+    ScanFactory,
+    UserFactory,
+    VolumeFactory,
+)
 from scanning.models import (
     Detection,
     QueueStatus,
     Stage,
     Status,
-    Volume,
 )
+from scanning.services import refresh_volume_queue_status
 
 FIXTURE_DIR = pathlib.Path(__file__).parent / "fixtures"
 PDF_PATH = FIXTURE_DIR / "a3d.332.1.1.pdf"
@@ -965,94 +970,74 @@ class TestHandlePipelineExceptionRetryCap(TestCase):
         self.assertIn("Max retries exceeded", scan.progress_message)
 
 
+def _make_scan_for_volume(volume, start=1, end=100, status=Status.UPLOADED):
+    """Create a Scan attached to ``volume`` with sensible defaults."""
+    return ScanFactory(
+        volume_obj=volume,
+        reporter=volume.reporter,
+        volume=volume.volume_number,
+        start_page=start,
+        end_page=end,
+        number_of_pages=end - start + 1,
+        status=status,
+    )
+
+
 class TestRefreshVolumeQueueStatus(TestCase):
     """Test ``refresh_volume_queue_status`` and its derivation logic."""
 
-    def _make_volume(self, **kwargs):
-        defaults = {
-            "reporter": ReporterFactory(),
-            "volume_number": 1,
-            "expected_start_page": 1,
-            "expected_end_page": 100,
-        }
-        defaults.update(kwargs)
-        return Volume.objects.create(**defaults)
-
-    def _make_scan(self, volume, start=1, end=100, status=Status.UPLOADED):
-        return ScanFactory(
-            volume_obj=volume,
-            reporter=volume.reporter,
-            volume=volume.volume_number,
-            start_page=start,
-            end_page=end,
-            number_of_pages=end - start + 1,
-            status=status,
-        )
-
     def test_no_scans_unassigned(self):
-        from scanning.services import refresh_volume_queue_status
-
-        volume = self._make_volume()
+        volume = VolumeFactory()
         refresh_volume_queue_status(volume)
         volume.refresh_from_db()
         self.assertEqual(volume.queue_status, QueueStatus.NEEDS_SCANNING)
 
     def test_no_scans_assigned_user(self):
-        from scanning.services import refresh_volume_queue_status
-
         user = UserFactory()
-        volume = self._make_volume(assigned_to=user)
+        volume = VolumeFactory(assigned_to=user)
         refresh_volume_queue_status(volume)
         volume.refresh_from_db()
         self.assertEqual(volume.queue_status, QueueStatus.ASSIGNED)
 
     def test_partial_coverage_is_scanning(self):
-        from scanning.services import refresh_volume_queue_status
-
-        volume = self._make_volume()
-        self._make_scan(volume, start=1, end=50)
+        volume = VolumeFactory()
+        _make_scan_for_volume(volume, start=1, end=50)
         refresh_volume_queue_status(volume)
         volume.refresh_from_db()
         self.assertEqual(volume.queue_status, QueueStatus.SCANNING)
 
     def test_full_coverage_not_approved_is_scanned(self):
-        from scanning.services import refresh_volume_queue_status
-
-        volume = self._make_volume()
-        self._make_scan(volume, start=1, end=100, status=Status.PENDING_REVIEW)
+        volume = VolumeFactory()
+        _make_scan_for_volume(
+            volume, start=1, end=100, status=Status.PENDING_REVIEW
+        )
         refresh_volume_queue_status(volume)
         volume.refresh_from_db()
         self.assertEqual(volume.queue_status, QueueStatus.SCANNED)
 
     def test_full_coverage_all_approved_is_complete(self):
-        from scanning.services import refresh_volume_queue_status
-
-        volume = self._make_volume()
-        self._make_scan(volume, start=1, end=100, status=Status.APPROVED)
+        volume = VolumeFactory()
+        _make_scan_for_volume(volume, start=1, end=100, status=Status.APPROVED)
         refresh_volume_queue_status(volume)
         volume.refresh_from_db()
         self.assertEqual(volume.queue_status, QueueStatus.COMPLETE)
 
     def test_unavailable_status_preserved(self):
-        from scanning.services import refresh_volume_queue_status
-
-        volume = self._make_volume(queue_status=QueueStatus.UNAVAILABLE)
-        self._make_scan(volume, start=1, end=100, status=Status.APPROVED)
+        volume = VolumeFactory(queue_status=QueueStatus.UNAVAILABLE)
+        _make_scan_for_volume(volume, start=1, end=100, status=Status.APPROVED)
         refresh_volume_queue_status(volume)
         volume.refresh_from_db()
         self.assertEqual(volume.queue_status, QueueStatus.UNAVAILABLE)
 
     def test_expected_parts_fallback_complete(self):
         """All approved + expected_parts met → COMPLETE even without page range."""
-        from scanning.services import refresh_volume_queue_status
-
-        volume = self._make_volume(
+        volume = VolumeFactory(
             expected_start_page=None,
             expected_end_page=None,
             expected_parts=2,
         )
-        self._make_scan(volume, start=1, end=50, status=Status.APPROVED)
-        self._make_scan(volume, start=51, end=100, status=Status.APPROVED)
+        _make_scan_for_volume(volume, start=1, end=50, status=Status.APPROVED)
+        _make_scan_for_volume(volume, start=51, end=100, status=Status.APPROVED)
         refresh_volume_queue_status(volume)
         volume.refresh_from_db()
         self.assertEqual(volume.queue_status, QueueStatus.COMPLETE)
@@ -1062,13 +1047,11 @@ class TestRefreshVolumeQueueStatus(TestCase):
         auto-completed: the helper has no way to know all work is in,
         so it leaves them at SCANNING until a curator marks otherwise.
         """
-        from scanning.services import refresh_volume_queue_status
-
-        volume = self._make_volume(
+        volume = VolumeFactory(
             expected_start_page=None,
             expected_end_page=None,
         )
-        self._make_scan(volume, start=1, end=100, status=Status.APPROVED)
+        _make_scan_for_volume(volume, start=1, end=100, status=Status.APPROVED)
         refresh_volume_queue_status(volume)
         volume.refresh_from_db()
         self.assertEqual(volume.queue_status, QueueStatus.SCANNING)

--- a/scanning/tests/test_services.py
+++ b/scanning/tests/test_services.py
@@ -1037,7 +1037,9 @@ class TestRefreshVolumeQueueStatus(TestCase):
             expected_parts=2,
         )
         _make_scan_for_volume(volume, start=1, end=50, status=Status.APPROVED)
-        _make_scan_for_volume(volume, start=51, end=100, status=Status.APPROVED)
+        _make_scan_for_volume(
+            volume, start=51, end=100, status=Status.APPROVED
+        )
         refresh_volume_queue_status(volume)
         volume.refresh_from_db()
         self.assertEqual(volume.queue_status, QueueStatus.COMPLETE)

--- a/scanning/tests/test_views.py
+++ b/scanning/tests/test_views.py
@@ -1014,8 +1014,6 @@ class TestQueueUploadS3(ScanningTestCase):
         :returns: The HTTP response.
         """
 
-        from scanning.models import Volume
-
         user = self.make_user()
         self.client.force_login(user)
         reporter = ReporterFactory(short_name="tu")

--- a/scanning/tests/test_views.py
+++ b/scanning/tests/test_views.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db import models
-from django.test import TestCase, override_settings
+from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 from PIL import Image
@@ -20,6 +20,7 @@ from scanning.factories import (
     ReporterFactory,
     ScanFactory,
     UserFactory,
+    VolumeFactory,
 )
 from scanning.models import (
     Detection,
@@ -271,28 +272,22 @@ class TestStaffReview(ScanningTestCase):
 class TestVolumeQueueStatusIntegration(ScanningTestCase):
     """Volume.queue_status updates when scans change state."""
 
-    def _make_volume(self, **kwargs):
-        defaults = {
-            "reporter": ReporterFactory(short_name="vq"),
-            "volume_number": 1,
-            "expected_start_page": 1,
-            "expected_end_page": 100,
-        }
-        defaults.update(kwargs)
-        return Volume.objects.create(**defaults)
+    def _make_scan(self, volume, start=1, end=100, status=Status.UPLOADED):
+        return ScanFactory(
+            volume_obj=volume,
+            reporter=volume.reporter,
+            volume=volume.volume_number,
+            start_page=start,
+            end_page=end,
+            number_of_pages=end - start + 1,
+            status=status,
+        )
 
     def test_approval_bumps_volume_to_complete(self):
         staff = self.make_staff_user()
         self.client.force_login(staff)
-        volume = self._make_volume(queue_status=QueueStatus.SCANNED)
-        scan = ScanFactory(
-            volume_obj=volume,
-            reporter=volume.reporter,
-            volume=volume.volume_number,
-            start_page=1,
-            end_page=100,
-            status=Status.PENDING_REVIEW,
-        )
+        volume = VolumeFactory(queue_status=QueueStatus.SCANNED)
+        scan = self._make_scan(volume, status=Status.PENDING_REVIEW)
         response = self.client.post(
             reverse("scan_detail", kwargs={"pk": scan.pk}),
             {"status": Status.APPROVED, "notes": "ok"},
@@ -304,15 +299,8 @@ class TestVolumeQueueStatusIntegration(ScanningTestCase):
     def test_rejection_moves_volume_back_to_scanning(self):
         staff = self.make_staff_user()
         self.client.force_login(staff)
-        volume = self._make_volume(queue_status=QueueStatus.SCANNED)
-        scan = ScanFactory(
-            volume_obj=volume,
-            reporter=volume.reporter,
-            volume=volume.volume_number,
-            start_page=1,
-            end_page=50,
-            status=Status.PENDING_REVIEW,
-        )
+        volume = VolumeFactory(queue_status=QueueStatus.SCANNED)
+        scan = self._make_scan(volume, end=50, status=Status.PENDING_REVIEW)
         response = self.client.post(
             reverse("scan_detail", kwargs={"pk": scan.pk}),
             {"status": Status.UPLOADED, "notes": "needs rescan"},
@@ -324,15 +312,8 @@ class TestVolumeQueueStatusIntegration(ScanningTestCase):
     def test_unavailable_volume_is_not_recomputed(self):
         staff = self.make_staff_user()
         self.client.force_login(staff)
-        volume = self._make_volume(queue_status=QueueStatus.UNAVAILABLE)
-        scan = ScanFactory(
-            volume_obj=volume,
-            reporter=volume.reporter,
-            volume=volume.volume_number,
-            start_page=1,
-            end_page=100,
-            status=Status.PENDING_REVIEW,
-        )
+        volume = VolumeFactory(queue_status=QueueStatus.UNAVAILABLE)
+        scan = self._make_scan(volume, status=Status.PENDING_REVIEW)
         self.client.post(
             reverse("scan_detail", kwargs={"pk": scan.pk}),
             {"status": Status.APPROVED, "notes": "ok"},
@@ -346,17 +327,12 @@ class TestVolumeQueueStatusIntegration(ScanningTestCase):
 
         from scanning.admin import ScanAdmin
 
-        volume = self._make_volume(queue_status=QueueStatus.COMPLETE)
-        scan = ScanFactory(
-            volume_obj=volume,
-            reporter=volume.reporter,
-            volume=volume.volume_number,
-            start_page=1,
-            end_page=100,
-            status=Status.APPROVED,
-        )
+        volume = VolumeFactory(queue_status=QueueStatus.COMPLETE)
+        scan = self._make_scan(volume, status=Status.APPROVED)
         admin_instance = ScanAdmin(Scan, AdminSite())
-        admin_instance.delete_model(request=None, obj=scan)
+        request = RequestFactory().post("/admin/scanning/scan/")
+        request.user = self.make_staff_user(is_superuser=True)
+        admin_instance.delete_model(request=request, obj=scan)
         volume.refresh_from_db()
         self.assertEqual(volume.queue_status, QueueStatus.NEEDS_SCANNING)
         self.assertFalse(Scan.objects.filter(pk=scan.pk).exists())
@@ -367,18 +343,13 @@ class TestVolumeQueueStatusIntegration(ScanningTestCase):
 
         from scanning.admin import ScanAdmin
 
-        volume = self._make_volume(queue_status=QueueStatus.COMPLETE)
-        ScanFactory(
-            volume_obj=volume,
-            reporter=volume.reporter,
-            volume=volume.volume_number,
-            start_page=1,
-            end_page=100,
-            status=Status.APPROVED,
-        )
+        volume = VolumeFactory(queue_status=QueueStatus.COMPLETE)
+        self._make_scan(volume, status=Status.APPROVED)
         admin_instance = ScanAdmin(Scan, AdminSite())
+        request = RequestFactory().post("/admin/scanning/scan/")
+        request.user = self.make_staff_user(is_superuser=True)
         admin_instance.delete_queryset(
-            request=None, queryset=Scan.objects.filter(volume_obj=volume)
+            request=request, queryset=Scan.objects.filter(volume_obj=volume)
         )
         volume.refresh_from_db()
         self.assertEqual(volume.queue_status, QueueStatus.NEEDS_SCANNING)
@@ -388,7 +359,7 @@ class TestVolumeQueueStatusIntegration(ScanningTestCase):
     def test_upload_bumps_assigned_to_scanning(self):
         user = self.make_user()
         self.client.force_login(user)
-        volume = self._make_volume(
+        volume = VolumeFactory(
             queue_status=QueueStatus.ASSIGNED,
             assigned_to=user,
             assigned_at=timezone.now(),

--- a/scanning/tests/test_views.py
+++ b/scanning/tests/test_views.py
@@ -340,6 +340,50 @@ class TestVolumeQueueStatusIntegration(ScanningTestCase):
         volume.refresh_from_db()
         self.assertEqual(volume.queue_status, QueueStatus.UNAVAILABLE)
 
+    def test_admin_delete_refreshes_volume_queue_status(self):
+        """Deleting a Scan via admin should refresh its parent Volume."""
+        from django.contrib.admin.sites import AdminSite
+
+        from scanning.admin import ScanAdmin
+
+        volume = self._make_volume(queue_status=QueueStatus.COMPLETE)
+        scan = ScanFactory(
+            volume_obj=volume,
+            reporter=volume.reporter,
+            volume=volume.volume_number,
+            start_page=1,
+            end_page=100,
+            status=Status.APPROVED,
+        )
+        admin_instance = ScanAdmin(Scan, AdminSite())
+        admin_instance.delete_model(request=None, obj=scan)
+        volume.refresh_from_db()
+        self.assertEqual(volume.queue_status, QueueStatus.NEEDS_SCANNING)
+        self.assertFalse(Scan.objects.filter(pk=scan.pk).exists())
+
+    def test_admin_bulk_delete_refreshes_volumes(self):
+        """Bulk-deleting Scans via admin should refresh each parent Volume."""
+        from django.contrib.admin.sites import AdminSite
+
+        from scanning.admin import ScanAdmin
+
+        volume = self._make_volume(queue_status=QueueStatus.COMPLETE)
+        ScanFactory(
+            volume_obj=volume,
+            reporter=volume.reporter,
+            volume=volume.volume_number,
+            start_page=1,
+            end_page=100,
+            status=Status.APPROVED,
+        )
+        admin_instance = ScanAdmin(Scan, AdminSite())
+        admin_instance.delete_queryset(
+            request=None, queryset=Scan.objects.filter(volume_obj=volume)
+        )
+        volume.refresh_from_db()
+        self.assertEqual(volume.queue_status, QueueStatus.NEEDS_SCANNING)
+        self.assertEqual(Scan.objects.filter(volume_obj=volume).count(), 0)
+
     @override_settings(DEVELOPMENT=True)
     def test_upload_bumps_assigned_to_scanning(self):
         user = self.make_user()

--- a/scanning/tests/test_views.py
+++ b/scanning/tests/test_views.py
@@ -25,10 +25,12 @@ from scanning.models import (
     Detection,
     OpinionScan,
     OpinionStatus,
+    QueueStatus,
     Scan,
     Source,
     Stage,
     Status,
+    Volume,
 )
 
 MEDIA_ROOT = tempfile.mkdtemp()
@@ -264,6 +266,110 @@ class TestStaffReview(ScanningTestCase):
         self.assertIsNone(response.context["review_form"])
         self.assertContains(response, "Review Decision")
         self.assertContains(response, "Approved")
+
+
+class TestVolumeQueueStatusIntegration(ScanningTestCase):
+    """Volume.queue_status updates when scans change state."""
+
+    def _make_volume(self, **kwargs):
+        defaults = {
+            "reporter": ReporterFactory(short_name="vq"),
+            "volume_number": 1,
+            "expected_start_page": 1,
+            "expected_end_page": 100,
+        }
+        defaults.update(kwargs)
+        return Volume.objects.create(**defaults)
+
+    def test_approval_bumps_volume_to_complete(self):
+        staff = self.make_staff_user()
+        self.client.force_login(staff)
+        volume = self._make_volume(queue_status=QueueStatus.SCANNED)
+        scan = ScanFactory(
+            volume_obj=volume,
+            reporter=volume.reporter,
+            volume=volume.volume_number,
+            start_page=1,
+            end_page=100,
+            status=Status.PENDING_REVIEW,
+        )
+        response = self.client.post(
+            reverse("scan_detail", kwargs={"pk": scan.pk}),
+            {"status": Status.APPROVED, "notes": "ok"},
+        )
+        self.assertEqual(response.status_code, 302)
+        volume.refresh_from_db()
+        self.assertEqual(volume.queue_status, QueueStatus.COMPLETE)
+
+    def test_rejection_moves_volume_back_to_scanning(self):
+        staff = self.make_staff_user()
+        self.client.force_login(staff)
+        volume = self._make_volume(queue_status=QueueStatus.SCANNED)
+        scan = ScanFactory(
+            volume_obj=volume,
+            reporter=volume.reporter,
+            volume=volume.volume_number,
+            start_page=1,
+            end_page=50,
+            status=Status.PENDING_REVIEW,
+        )
+        response = self.client.post(
+            reverse("scan_detail", kwargs={"pk": scan.pk}),
+            {"status": Status.UPLOADED, "notes": "needs rescan"},
+        )
+        self.assertEqual(response.status_code, 302)
+        volume.refresh_from_db()
+        self.assertEqual(volume.queue_status, QueueStatus.SCANNING)
+
+    def test_unavailable_volume_is_not_recomputed(self):
+        staff = self.make_staff_user()
+        self.client.force_login(staff)
+        volume = self._make_volume(queue_status=QueueStatus.UNAVAILABLE)
+        scan = ScanFactory(
+            volume_obj=volume,
+            reporter=volume.reporter,
+            volume=volume.volume_number,
+            start_page=1,
+            end_page=100,
+            status=Status.PENDING_REVIEW,
+        )
+        self.client.post(
+            reverse("scan_detail", kwargs={"pk": scan.pk}),
+            {"status": Status.APPROVED, "notes": "ok"},
+        )
+        volume.refresh_from_db()
+        self.assertEqual(volume.queue_status, QueueStatus.UNAVAILABLE)
+
+    @override_settings(DEVELOPMENT=True)
+    def test_upload_bumps_assigned_to_scanning(self):
+        user = self.make_user()
+        self.client.force_login(user)
+        volume = self._make_volume(
+            queue_status=QueueStatus.ASSIGNED,
+            assigned_to=user,
+            assigned_at=timezone.now(),
+        )
+        pdf = SimpleUploadedFile(
+            "scan.pdf", b"%PDF-1.4 body", content_type="application/pdf"
+        )
+        response = self.client.post(
+            reverse(
+                "queue_upload",
+                kwargs={
+                    "reporter_slug": volume.reporter.short_name,
+                    "vol": volume.volume_number,
+                },
+            ),
+            {
+                "new_scan": "1",
+                "first_page": "1",
+                "last_page": "50",
+                "original_pdf": pdf,
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        volume.refresh_from_db()
+        self.assertEqual(volume.queue_status, QueueStatus.SCANNING)
 
 
 class TestScanModel(ScanningTestCase):

--- a/scanning/views.py
+++ b/scanning/views.py
@@ -36,6 +36,7 @@ from scanning.models import (
     Status,
     Volume,
 )
+from scanning.services import refresh_volume_queue_status_for_scan
 from scanning.utils import get_volume, has_s3_credentials
 
 logger = logging.getLogger(__name__)
@@ -183,6 +184,7 @@ def scan_detail(request: HttpRequest, pk: int) -> HttpResponse:
                         "Scan rejected, status reset to Uploaded.",
                     )
                 updated_scan.save()
+                refresh_volume_queue_status_for_scan(updated_scan)
                 return redirect("scan_detail", pk=scan.pk)
         else:
             review_form = ScanReviewForm(instance=scan)
@@ -447,6 +449,11 @@ def claim_scan(request, reporter_slug, vol):
     """
     volume = get_volume(reporter_slug, vol)
 
+    # The two transitions handled here (NEEDS_SCANNING ↔ ASSIGNED) only
+    # apply to scan-less volumes, which the filter conditions enforce.
+    # In that state the inline values match what
+    # ``refresh_volume_queue_status`` would compute, so we set them
+    # directly and skip the extra query.
     if request.POST.get("unclaim") == "1":
         unclaimed = Volume.objects.filter(
             pk=volume.pk, assigned_to=request.user
@@ -624,8 +631,10 @@ def queue_upload(request, reporter_slug, vol):
         scan.queued_action = QueuedAction.FULL_PIPELINE
         scan.progress_message = "Queued for processing..."
         scan.save()
+        refresh_volume_queue_status_for_scan(scan)
         return redirect("scan_process", pk=scan.pk)
 
+    refresh_volume_queue_status_for_scan(scan)
     messages.success(request, "PDF uploaded successfully.")
     return redirect(
         "queue_detail",
@@ -647,6 +656,10 @@ def update_scan_status(request, reporter_slug, vol):
     volume = get_volume(reporter_slug, vol)
     new_status = request.POST.get("status")
 
+    # Curator manual-override path: intentionally bypasses
+    # ``refresh_volume_queue_status`` so a reviewer can force any value
+    # (e.g. UNAVAILABLE, or SCANNED before approval) regardless of
+    # what the helper would otherwise derive from the scans.
     if new_status and new_status in dict(QueueStatus.choices):
         volume.queue_status = new_status
         if new_status == QueueStatus.NEEDS_SCANNING:

--- a/scanning/views_api.py
+++ b/scanning/views_api.py
@@ -398,7 +398,10 @@ def approve_scan(request: HttpRequest, pk: int) -> HttpResponse:
     :param pk: Scan primary key.
     :return: Redirect to the process page.
     """
-    from scanning.services import upload_approved_files
+    from scanning.services import (
+        refresh_volume_queue_status_for_scan,
+        upload_approved_files,
+    )
 
     scan = get_object_or_404(Scan, pk=pk)
 
@@ -409,6 +412,7 @@ def approve_scan(request: HttpRequest, pk: int) -> HttpResponse:
 
     scan.stage = Stage.APPROVED
     scan.save(update_fields=["stage"])
+    refresh_volume_queue_status_for_scan(scan)
     messages.success(request, result)
     return redirect("scan_process", pk=scan.pk)
 


### PR DESCRIPTION
## Summary
Addresses issue #58:

- **Approval → `complete`**: `Volume.queue_status` now advances automatically when its scans are approved, instead of staying at `scanning` / `scanned` indefinitely.
- **Lifecycle**: A single helper in `services.py` derives `queue_status` from observable scan state and is called from every touchpoint (upload, manual review, auto-approval, admin deletion). Manual `unavailable` is preserved as a curator override.
- **Badges**: Hover tooltips on the three Status-column badges on `/queue/` (`Volume.queue_status`, `Scan.status`, `S3`) so it's clear what each one represents.

14 new tests; full suite passing.

Closes #58