### PR TITLE
feat(runpod): allow local end-to-end testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,110 @@ automatically.
 Custom component classes: `.btn-primary`, `.btn-outline`, `.btn-danger`,
 `.btn-ghost`, `.card`, `.input-text`, `.alert-*`, `.badge-*` (status badges).
 
+### Testing RunPod Locally
+
+The daemon can offload the two GPU-heavy blackletter steps (`detect` and
+`analyze_pdf`) to a [RunPod Serverless](https://docs.runpod.io/serverless/overview)
+endpoint. When `RUNPOD_ENABLED=False` (the default) the daemon runs
+blackletter in-process, so most local development needs no RunPod
+configuration. Flip the flag when you want to exercise the remote path
+end-to-end.
+
+#### Required environment variables
+
+RunPod settings go in `.env.dev`:
+
+```bash
+RUNPOD_ENABLED=True
+RUNPOD_ENDPOINT_ID=<your-endpoint-id>
+RUNPOD_API_KEY=<your-runpod-api-key>
+```
+
+The daemon also needs AWS credentials so it can upload the local PDF
+to the dev private bucket and hand the worker a presigned GET URL.
+Two options:
+
+**Option A — paste the AWS console export block into your shell, then
+start the containers.** This is the easiest path when you're using
+temporary SSO / STS credentials that rotate. The docker-compose file
+forwards `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` /
+`AWS_SESSION_TOKEN` from your shell into the containers and maps them
+onto `AWS_DEV_*` automatically:
+
+```bash
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_SESSION_TOKEN=...
+docker compose -f docker/scanning/docker-compose.yml up --build
+```
+
+**Option B — hard-code dev credentials in `.env.dev`.** Use this for
+long-lived IAM user keys:
+
+```bash
+AWS_DEV_ACCESS_KEY_ID=<your-aws-key>
+AWS_DEV_SECRET_ACCESS_KEY=<your-aws-secret>
+```
+
+Either way, the dev S3 buckets (`dev-com-freelawproject-scanning-storage`
+and `dev-com-freelawproject-scanning-private-storage`) are selected
+automatically when `DEVELOPMENT=True`; you do not need to set
+`AWS_PRIVATE_STORAGE_BUCKET_NAME`.
+
+Optional tuning knobs (all have sensible defaults, see
+`scanning/settings/project/runpod.py`):
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `RUNPOD_REQUEST_TIMEOUT` | `1800` | Wall-clock ceiling (s) for submit + poll. |
+| `RUNPOD_MAX_RETRIES` | `2` | Transport-error retries on `/run`. |
+| `RUNPOD_PRESIGNED_TTL` | `86400` | Lifetime (s) of the GET URL handed to the worker. |
+| `RUNPOD_MAX_TRANSIENT_RETRIES` | `5` | Re-queues on `NO_GPU` before escalating to `ERROR`. |
+
+#### Why `make_dev_data` is a no-op in this mode
+
+`python manage.py make_dev_data` (run automatically by the `web-dev`
+entrypoint) normally seeds two users (`staff` / `scanner`) and a
+handful of `Scan` rows with placeholder PDF bytes
+(`b"%PDF-1.4 test"`). Those placeholder bytes are not valid PDFs and
+will fail the moment YOLO or PaddleOCR tries to read them on the
+worker, polluting the DB and burning endpoint quota on guaranteed
+errors.
+
+When `RUNPOD_ENABLED=True`, the command short-circuits before doing
+anything. Create your own user with `createsuperuser` and upload a
+real PDF through the UI to drive the pipeline; the daemon will push
+it to the dev private bucket on demand and dispatch the GPU steps to
+RunPod.
+
+Setting `RUNPOD_ENABLED=True` also activates the full S3 artifact
+sync (`scanning/s3_sync.py`), which is otherwise skipped in
+`DEVELOPMENT=True`. Intermediate processing files (`detections.json`,
+`redacted/*.pdf`, etc.) get pushed to `dev-com-freelawproject-scanning-private-storage`
+and pulled back on reprocess, so a local end-to-end run exercises
+the same recovery path as production.
+
+#### Quick recipe
+
+1. Set the RunPod variables in `.env.dev`.
+2. Export AWS credentials in your shell (Option A) or add `AWS_DEV_*`
+   to `.env.dev` (Option B).
+3. `docker compose -f docker/scanning/docker-compose.yml up --build`.
+4. Create a user:
+   `docker compose -f docker/scanning/docker-compose.yml exec scanning-django python manage.py createsuperuser`.
+5. Log in at http://localhost:8002/login/ and upload a real PDF.
+6. Watch the daemon container logs. You should see:
+   - `uploading <name>.pdf to s3://dev-com-freelawproject-scanning-private-storage/<key> before presign`
+     from `runpod_client._ensure_presigned_url`, immediately before
+     the GPU step is dispatched.
+   - RunPod poll ticks while the worker runs.
+   - `Uploaded N processing file(s) for scan <pk> to s3://...`
+     from `s3_sync.upload_processing_files` once the pipeline
+     completes — the artifact sync that's now active in the dev
+     RunPod path.
+
+   Set `SCANNING_LOG_LEVEL=DEBUG` for per-poll detail.
+
 ### Management Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -520,9 +520,9 @@ Two options:
 **Option A — paste the AWS console export block into your shell, then
 start the containers.** This is the easiest path when you're using
 temporary SSO / STS credentials that rotate. The docker-compose file
-forwards `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` /
-`AWS_SESSION_TOKEN` from your shell into the containers and maps them
-onto `AWS_DEV_*` automatically:
+(`docker/scanning/docker-compose.yml`) forwards `AWS_ACCESS_KEY_ID` /
+`AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` from your shell into the
+containers and maps them onto `AWS_DEV_*` automatically:
 
 ```bash
 export AWS_ACCESS_KEY_ID=...
@@ -551,7 +551,7 @@ Optional tuning knobs (all have sensible defaults, see
 |---|---|---|
 | `RUNPOD_REQUEST_TIMEOUT` | `1800` | Wall-clock ceiling (s) for submit + poll. |
 | `RUNPOD_MAX_RETRIES` | `2` | Transport-error retries on `/run`. |
-| `RUNPOD_PRESIGNED_TTL` | `86400` | Lifetime (s) of the GET URL handed to the worker. |
+| `RUNPOD_PRESIGNED_TTL` | `86400` (1 day) | Lifetime (s) of the GET URL handed to the worker. |
 | `RUNPOD_MAX_TRANSIENT_RETRIES` | `5` | Re-queues on `NO_GPU` before escalating to `ERROR`. |
 
 #### Why `make_dev_data` is a no-op in this mode
@@ -595,8 +595,7 @@ the same recovery path as production.
      from `s3_sync.upload_processing_files` once the pipeline
      completes — the artifact sync that's now active in the dev
      RunPod path.
-
-   Set `SCANNING_LOG_LEVEL=DEBUG` for per-poll detail.
+7. Set `SCANNING_LOG_LEVEL=DEBUG` for per-poll detail.
 
 ### Management Commands
 

--- a/scanning/management/commands/make_dev_data.py
+++ b/scanning/management/commands/make_dev_data.py
@@ -1,5 +1,3 @@
-import sys
-
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
@@ -20,9 +18,9 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        if not settings.DEVELOPMENT:
-            self.stderr.write("Refusing to seed: DEVELOPMENT is not True.")
-            sys.exit(1)
+        if not settings.DEVELOPMENT or settings.RUNPOD_ENABLED:
+            self.stdout.write("Skipping dev seeding.")
+            return
 
         staff, created = User.objects.get_or_create(
             username="staff",

--- a/scanning/management/commands/make_dev_data.py
+++ b/scanning/management/commands/make_dev_data.py
@@ -18,8 +18,19 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        if not settings.DEVELOPMENT or settings.RUNPOD_ENABLED:
-            self.stdout.write("Skipping dev seeding.")
+        # Soft return (not sys.exit) so entrypoint/CI hooks that call
+        # this command unconditionally don't blow up outside dev. No
+        # data is written either way; the goal is just a quiet no-op.
+        if not settings.DEVELOPMENT:
+            self.stdout.write("Skipping dev seeding: DEVELOPMENT is not True.")
+            return
+        if settings.RUNPOD_ENABLED:
+            # Placeholder PDF bytes (b"%PDF-1.4 test") would fail the
+            # moment YOLO or PaddleOCR tries to read them on the worker,
+            # polluting the DB and burning endpoint quota on errors.
+            self.stdout.write(
+                "Skipping dev seeding: RUNPOD_ENABLED is True."
+            )
             return
 
         staff, created = User.objects.get_or_create(

--- a/scanning/management/commands/make_dev_data.py
+++ b/scanning/management/commands/make_dev_data.py
@@ -28,9 +28,7 @@ class Command(BaseCommand):
             # Placeholder PDF bytes (b"%PDF-1.4 test") would fail the
             # moment YOLO or PaddleOCR tries to read them on the worker,
             # polluting the DB and burning endpoint quota on errors.
-            self.stdout.write(
-                "Skipping dev seeding: RUNPOD_ENABLED is True."
-            )
+            self.stdout.write("Skipping dev seeding: RUNPOD_ENABLED is True.")
             return
 
         staff, created = User.objects.get_or_create(

--- a/scanning/s3_sync.py
+++ b/scanning/s3_sync.py
@@ -7,9 +7,11 @@ Pushing them to S3 lets us recover after pod redeploys without a full
 re-run. Pulling them to /tmp/ when the viewer opens gives editing
 code fast local-filesystem access (PyMuPDF, Pillow, blackletter).
 
-All sync helpers short-circuit when ``settings.DEVELOPMENT`` is True
-or AWS credentials are missing, so local development keeps working
-against MEDIA_ROOT alone.
+All sync helpers short-circuit when running under ``TESTING``, when
+AWS credentials are missing, and during ``DEVELOPMENT`` unless
+``RUNPOD_ENABLED`` is also True. The RunPod-enabled dev path needs
+the full sync so a local end-to-end test exercises the same recovery
+behavior as prod.
 """
 
 from __future__ import annotations
@@ -37,13 +39,17 @@ APPROVED_FILE_SUFFIXES = (".original.pdf", ".redacted.pdf")
 def _s3_enabled() -> bool:
     """Return True when we should actually use S3.
 
-    Skipped during DEVELOPMENT, during TESTING (so unit tests don't
-    reach live AWS), and when AWS credentials are missing.
+    Skipped during TESTING (so unit tests don't reach live AWS) and
+    when AWS credentials are missing. Also skipped during DEVELOPMENT
+    unless RUNPOD_ENABLED is True, since the RunPod-enabled dev path
+    needs full S3 sync to mirror the prod recovery behavior.
 
     :returns: Whether S3 sync is active in the current environment.
     :rtype: bool
     """
-    if settings.DEVELOPMENT or getattr(settings, "TESTING", False):
+    if getattr(settings, "TESTING", False):
+        return False
+    if settings.DEVELOPMENT and not settings.RUNPOD_ENABLED:
         return False
     return has_s3_credentials()
 

--- a/scanning/tests/test_s3_sync.py
+++ b/scanning/tests/test_s3_sync.py
@@ -265,23 +265,17 @@ class TestS3EnabledBranches(SimpleTestCase):
 
     @override_settings(DEVELOPMENT=True, RUNPOD_ENABLED=True, TESTING=False)
     def test_dev_with_runpod_enabled_returns_true(self):
-        with patch(
-            "scanning.s3_sync.has_s3_credentials", return_value=True
-        ):
+        with patch("scanning.s3_sync.has_s3_credentials", return_value=True):
             self.assertTrue(s3_sync._s3_enabled())
 
     @override_settings(DEVELOPMENT=True, RUNPOD_ENABLED=False, TESTING=False)
     def test_dev_without_runpod_returns_false(self):
-        with patch(
-            "scanning.s3_sync.has_s3_credentials", return_value=True
-        ):
+        with patch("scanning.s3_sync.has_s3_credentials", return_value=True):
             self.assertFalse(s3_sync._s3_enabled())
 
     @override_settings(DEVELOPMENT=False, RUNPOD_ENABLED=False, TESTING=True)
     def test_testing_short_circuits_regardless_of_runpod(self):
-        with patch(
-            "scanning.s3_sync.has_s3_credentials", return_value=True
-        ):
+        with patch("scanning.s3_sync.has_s3_credentials", return_value=True):
             self.assertFalse(s3_sync._s3_enabled())
         with self.settings(RUNPOD_ENABLED=True):
             with patch(

--- a/scanning/tests/test_s3_sync.py
+++ b/scanning/tests/test_s3_sync.py
@@ -5,7 +5,7 @@ import pathlib
 import tempfile
 from unittest.mock import MagicMock, patch
 
-from django.test import TestCase, override_settings
+from django.test import SimpleTestCase, TestCase, override_settings
 
 from scanning import s3_sync
 from scanning.factories import ReporterFactory, ScanFactory
@@ -252,3 +252,39 @@ class TestSyncHelpersWithCredentials(TestCase):
         _, bucket, key = mock_s3.upload_file.call_args.args
         self.assertEqual(bucket, "test-bucket")
         self.assertEqual(key, f"processing/{scan.pk}/tc/164/1/detections.json")
+
+
+class TestS3EnabledBranches(SimpleTestCase):
+    """Coverage for the ``_s3_enabled()`` branch matrix.
+
+    ``TESTING`` is auto-set during the test run, so each case overrides
+    it explicitly to exercise the intended branch. ``has_s3_credentials``
+    is patched to keep the result independent of the developer's
+    environment.
+    """
+
+    @override_settings(DEVELOPMENT=True, RUNPOD_ENABLED=True, TESTING=False)
+    def test_dev_with_runpod_enabled_returns_true(self):
+        with patch(
+            "scanning.s3_sync.has_s3_credentials", return_value=True
+        ):
+            self.assertTrue(s3_sync._s3_enabled())
+
+    @override_settings(DEVELOPMENT=True, RUNPOD_ENABLED=False, TESTING=False)
+    def test_dev_without_runpod_returns_false(self):
+        with patch(
+            "scanning.s3_sync.has_s3_credentials", return_value=True
+        ):
+            self.assertFalse(s3_sync._s3_enabled())
+
+    @override_settings(DEVELOPMENT=False, RUNPOD_ENABLED=False, TESTING=True)
+    def test_testing_short_circuits_regardless_of_runpod(self):
+        with patch(
+            "scanning.s3_sync.has_s3_credentials", return_value=True
+        ):
+            self.assertFalse(s3_sync._s3_enabled())
+        with self.settings(RUNPOD_ENABLED=True):
+            with patch(
+                "scanning.s3_sync.has_s3_credentials", return_value=True
+            ):
+                self.assertFalse(s3_sync._s3_enabled())


### PR DESCRIPTION
## Summary

Three small changes that let a developer flip `RUNPOD_ENABLED=True` in `.env.dev` and exercise the full pipeline end-to-end against a real RunPod endpoint, with the same S3 recovery behavior as production.

- `make_dev_data` now skips seeding when `RUNPOD_ENABLED=True` (placeholder PDFs would fail on the worker). The non-DEVELOPMENT guard also softens from `sys.exit(1)` to a silent `return`, so the `web-dev` entrypoint chain keeps starting the container cleanly even when seeding is intentionally a no-op (RunPod mode, or anywhere `DEVELOPMENT` is False).
- `s3_sync._s3_enabled()` now activates in `DEVELOPMENT=True` when `RUNPOD_ENABLED=True`, so processing artifacts round-trip to the dev bucket. Regular dev is unchanged.
- New "Testing RunPod Locally" section in `README.md` with required env vars, two AWS-credential options, tuning knobs, and a Quick Recipe.