### PR TITLE
fix(scanning): guard pending page changes and refresh action bar in place

### DIFF
--- a/scanning/static/scanning/shared.js
+++ b/scanning/static/scanning/shared.js
@@ -30,6 +30,9 @@ function deletePage(csrfToken, docId, pdfPage, pageDiv, labelPrefix, onDelete) {
     .then(function (data) {
         if (data.status === 'ok') {
             markPageAsDeleted(pageDiv, pdfPage, labelPrefix, csrfToken, docId, onDelete);
+            if (typeof window.refreshProcessActionBar === 'function') {
+                window.refreshProcessActionBar();
+            }
         }
     });
 }
@@ -99,6 +102,9 @@ function undoDeletePage(csrfToken, docId, pdfPage, pageDiv, labelPrefix, onDelet
                         onDelete(pdfPage, pageDiv);
                     });
                 }
+            }
+            if (typeof window.refreshProcessActionBar === 'function') {
+                window.refreshProcessActionBar();
             }
         }
     });

--- a/scanning/templates/scanning/_process_actions.html
+++ b/scanning/templates/scanning/_process_actions.html
@@ -1,0 +1,63 @@
+{% comment %}
+Step action bar for the scan processing page.
+
+Rendered both inline by scan_process.html and standalone by the
+process_actions view (fetched by the step-1/step-2 viewers to refresh the
+buttons in place after a page is marked for or restored from deletion).
+{% endcomment %}
+{% if is_processing %}
+
+{% elif step == 1 %}
+  {% if has_pending_changes %}
+  <form method="post" action="{% url 'reprocess' scan.pk %}" class="inline">
+    {% csrf_token %}
+    {% if has_pending_inserts %}
+    <button type="submit" class="btn-primary text-sm" style="background:#7c3aed" title="Apply pending page inserts and deletions, then re-run OCR and validation. Inserted pages are OCR'd and validated on RunPod (incurs costs $$$)." onclick="return confirm('Pending page inserts will run OCR and validation on RunPod for each inserted page. This will incur costs $$$. Continue?');">{% include "scanning/_runpod_icon.html" %}Rebuild &amp; Validate</button>
+    {% else %}
+    <button type="submit" class="btn-primary text-sm" style="background:#7c3aed" title="Apply pending page deletions and rebuild issues (no RunPod, no extra cost)">Rebuild &amp; Validate</button>
+    {% endif %}
+  </form>
+  {% elif not scan.page_count %}
+  <form method="post" action="{% url 'start_validate' scan.pk %}" class="inline">
+    {% csrf_token %}
+    <button type="submit" class="btn-primary text-sm" title="Run the full processing pipeline: bitonal conversion, OCR, detection, and page number validation on RunPod (incurs costs $$$)" onclick="return confirm('Validate will run YOLO detection and PaddleOCR validation on RunPod. This will incur costs $$$. Continue?');">{% include "scanning/_runpod_icon.html" %}Validate</button>
+  </form>
+  {% else %}
+  <form method="post" action="{% url 'recalculate' scan.pk %}" class="inline">
+    {% csrf_token %}
+    <button type="submit" class="btn-primary text-sm" title="Re-check page numbers and issues using existing OCR results without re-running the pipeline">Recheck</button>
+  </form>
+  <form method="post" action="{% url 'start_validate' scan.pk %}" class="inline">
+    {% csrf_token %}
+    <button type="submit" class="btn-outline text-sm" title="Re-run the full pipeline from scratch: bitonal, OCR, detection, and validation on RunPod (incurs costs $$$)" onclick="return confirm('Re-validate will run YOLO detection and PaddleOCR validation on RunPod. This will incur costs $$$. Continue?');">{% include "scanning/_runpod_icon.html" %}Re-validate</button>
+  </form>
+  {% if not issues and not missing_pages %}
+  <form method="post" action="{% url 'start_detect' scan.pk %}" class="inline">
+    {% csrf_token %}
+    {% if has_detections %}
+    <button type="submit" class="btn-primary text-sm" title="Detections already exist. Skip directly to review (no RunPod, no cost).">Next: Detect &rarr;</button>
+    {% else %}
+    <button type="submit" class="btn-primary text-sm" title="Run YOLO detection on RunPod to find opinions, captions, and key icons (incurs costs $$$)" onclick="return confirm('This will run YOLO detection on RunPod. This will incur costs $$$. Continue?');">{% include "scanning/_runpod_icon.html" %}Next: Detect &rarr;</button>
+    {% endif %}
+  </form>
+  {% endif %}
+  {% endif %}
+
+{% elif step == 2 %}
+  <button class="btn-primary text-sm" id="pair-btn" onclick="pairOpinions()" title="Match detected captions and key icons to identify individual opinions">Re-pair Opinions</button>
+  {% if opinions %}
+  <a href="?step=3" class="btn-primary text-sm no-underline" style="background:#059669" title="Proceed to generate the final redacted and split opinion files">Next: Generate &rarr;</a>
+  {% endif %}
+
+{% elif step == 3 %}
+  <form method="post" action="{% url 'generate_files' scan.pk %}" class="inline">
+    {% csrf_token %}
+    <button type="submit" class="btn-primary text-sm" style="background:#7c3aed" title="Create redacted and unredacted PDF files for each opinion">{% if opinion_scans %}Regenerate{% else %}Generate{% endif %} Files</button>
+  </form>
+  {% if opinion_scans %}
+  <form method="post" action="{% url 'approve_scan' scan.pk %}" class="inline">
+    {% csrf_token %}
+    <button type="submit" class="btn-primary text-sm" title="Mark this scan as approved">Approve</button>
+  </form>
+  {% endif %}
+{% endif %}

--- a/scanning/templates/scanning/scan_process.html
+++ b/scanning/templates/scanning/scan_process.html
@@ -43,68 +43,13 @@
       <span class="text-base font-bold">{% if scan.reporter %}{{ scan.reporter.short_name|upper }} vol. {{ scan.volume }}{% else %}Scan #{{ scan.pk }}{% endif %}</span>
       <span class="text-xs text-gray-500 dark:text-gray-400">{{ scan.page_count }} pages</span>
       {% if missing_pages %}<span class="badge-error text-xs">{{ missing_pages|length }} missing</span>{% endif %}
-      {% if has_pending_changes %}<span class="badge-warning text-xs">Pending Changes</span>{% endif %}
+      <span id="pending-badge" class="badge-warning text-xs"{% if not has_pending_changes %} hidden{% endif %}>Pending Changes</span>
       {% if scan.s3_uploaded %}<span class="badge-s3 text-xs" title="Files uploaded to S3">S3</span>{% endif %}
     </div>
   </div>
   {# Right: actions #}
-  <div class="flex flex-wrap gap-2">
-    {% if is_processing %}
-
-    {% elif step == 1 %}
-      {% if has_pending_changes %}
-      <form method="post" action="{% url 'reprocess' scan.pk %}" class="inline">
-        {% csrf_token %}
-        {% if has_pending_inserts %}
-        <button type="submit" class="btn-primary text-sm" style="background:#7c3aed" title="Apply pending page inserts and deletions, then re-run OCR and validation. Inserted pages are OCR'd and validated on RunPod (incurs costs $$$)." onclick="return confirm('Pending page inserts will run OCR and validation on RunPod for each inserted page. This will incur costs $$$. Continue?');">{% include "scanning/_runpod_icon.html" %}Rebuild &amp; Validate</button>
-        {% else %}
-        <button type="submit" class="btn-primary text-sm" style="background:#7c3aed" title="Apply pending page deletions and rebuild issues (no RunPod, no extra cost)">Rebuild &amp; Validate</button>
-        {% endif %}
-      </form>
-      {% elif not scan.page_count %}
-      <form method="post" action="{% url 'start_validate' scan.pk %}" class="inline">
-        {% csrf_token %}
-        <button type="submit" class="btn-primary text-sm" title="Run the full processing pipeline: bitonal conversion, OCR, detection, and page number validation on RunPod (incurs costs $$$)" onclick="return confirm('Validate will run YOLO detection and PaddleOCR validation on RunPod. This will incur costs $$$. Continue?');">{% include "scanning/_runpod_icon.html" %}Validate</button>
-      </form>
-      {% else %}
-      <form method="post" action="{% url 'recalculate' scan.pk %}" class="inline">
-        {% csrf_token %}
-        <button type="submit" class="btn-primary text-sm" title="Re-check page numbers and issues using existing OCR results without re-running the pipeline">Recheck</button>
-      </form>
-      <form method="post" action="{% url 'start_validate' scan.pk %}" class="inline">
-        {% csrf_token %}
-        <button type="submit" class="btn-outline text-sm" title="Re-run the full pipeline from scratch: bitonal, OCR, detection, and validation on RunPod (incurs costs $$$)" onclick="return confirm('Re-validate will run YOLO detection and PaddleOCR validation on RunPod. This will incur costs $$$. Continue?');">{% include "scanning/_runpod_icon.html" %}Re-validate</button>
-      </form>
-      {% if not issues and not missing_pages %}
-      <form method="post" action="{% url 'start_detect' scan.pk %}" class="inline">
-        {% csrf_token %}
-        {% if has_detections %}
-        <button type="submit" class="btn-primary text-sm" title="Detections already exist. Skip directly to review (no RunPod, no cost).">Next: Detect &rarr;</button>
-        {% else %}
-        <button type="submit" class="btn-primary text-sm" title="Run YOLO detection on RunPod to find opinions, captions, and key icons (incurs costs $$$)" onclick="return confirm('This will run YOLO detection on RunPod. This will incur costs $$$. Continue?');">{% include "scanning/_runpod_icon.html" %}Next: Detect &rarr;</button>
-        {% endif %}
-      </form>
-      {% endif %}
-      {% endif %}
-
-    {% elif step == 2 %}
-      <button class="btn-primary text-sm" id="pair-btn" onclick="pairOpinions()" title="Match detected captions and key icons to identify individual opinions">Re-pair Opinions</button>
-      {% if opinions %}
-      <a href="?step=3" class="btn-primary text-sm no-underline" style="background:#059669" title="Proceed to generate the final redacted and split opinion files">Next: Generate &rarr;</a>
-      {% endif %}
-
-    {% elif step == 3 %}
-      <form method="post" action="{% url 'generate_files' scan.pk %}" class="inline">
-        {% csrf_token %}
-        <button type="submit" class="btn-primary text-sm" style="background:#7c3aed" title="Create redacted and unredacted PDF files for each opinion">{% if opinion_scans %}Regenerate{% else %}Generate{% endif %} Files</button>
-      </form>
-      {% if opinion_scans %}
-      <form method="post" action="{% url 'approve_scan' scan.pk %}" class="inline">
-        {% csrf_token %}
-        <button type="submit" class="btn-primary text-sm" title="Mark this scan as approved">Approve</button>
-      </form>
-      {% endif %}
-    {% endif %}
+  <div id="action-bar" class="flex flex-wrap gap-2">
+    {% include "scanning/_process_actions.html" %}
   </div>
 </div>
 {% endblock %}
@@ -127,11 +72,9 @@
       {% elif step == 1 %}
       {# Step 1: Build - issues first, then collapsible pages #}
 
-      {% if has_pending_changes %}
-      <div class="bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-200 text-xs rounded px-2 py-1 mb-2">
+      <div id="pending-banner" class="bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-200 text-xs rounded px-2 py-1 mb-2"{% if not has_pending_changes %} hidden{% endif %}>
         Pending changes &mdash; rebuild to apply
       </div>
-      {% endif %}
 
       {% if issues %}
       <h2 class="text-sm font-bold mb-2">Issues ({{ issues|length }})</h2>
@@ -368,6 +311,24 @@ var SCAN_CONFIG = {
 var csrfToken = SCAN_CONFIG.csrfToken;
 var docId = SCAN_CONFIG.docId;
 var deletedPages = SCAN_CONFIG.deletedPages;
+
+// Refresh the step action bar in place after a page deletion/undo so the
+// correct buttons (e.g. "Rebuild & Validate") appear without a full reload.
+window.refreshProcessActionBar = function () {
+    fetch('/scans/' + SCAN_CONFIG.docId + '/actions/?step=' + SCAN_CONFIG.step, {
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+    })
+    .then(function (r) { return r.json(); })
+    .then(function (data) {
+        var bar = document.getElementById('action-bar');
+        if (bar) bar.innerHTML = data.html;
+        var badge = document.getElementById('pending-badge');
+        if (badge) badge.hidden = !data.has_pending_changes;
+        var banner = document.getElementById('pending-banner');
+        if (banner) banner.hidden = !data.has_pending_changes;
+    })
+    .catch(function () { /* keep the stale bar; a manual reload still works */ });
+};
 </script>
 <script src="{% static 'scanning/viewer_sidebar.js' %}"></script>
 <script>

--- a/scanning/tests/test_views.py
+++ b/scanning/tests/test_views.py
@@ -26,6 +26,8 @@ from scanning.models import (
     Detection,
     OpinionScan,
     OpinionStatus,
+    PageDeletion,
+    QueuedAction,
     QueueStatus,
     Scan,
     Source,
@@ -1556,3 +1558,94 @@ class TestApproveDetection(ScanningTestCase):
         self.assertEqual(response.status_code, 404)
         body = json.loads(response.content)
         self.assertEqual(body["status"], "error")
+
+
+@override_settings(MEDIA_ROOT=MEDIA_ROOT)
+class TestPendingChangesGuard(ScanningTestCase):
+    """The validate/detect/recheck actions are blocked while page
+    changes are pending, so a deletion can't be silently stranded
+    behind an action that ignores it (and a full re-validation can't
+    burn a RunPod run for nothing)."""
+
+    def setUp(self):
+        self.user = self.make_user()
+        self.client.force_login(self.user)
+        self.scan = ScanFactory(
+            uploaded_by=self.user, status=Status.PENDING_REVIEW
+        )
+        PageDeletion.objects.create(scan=self.scan, pdf_page=2)
+
+    def _assert_blocked(self, url_name):
+        response = self.client.post(
+            reverse(url_name, kwargs={"pk": self.scan.pk})
+        )
+        self.assertRedirects(
+            response,
+            reverse("scan_process", kwargs={"pk": self.scan.pk}) + "?step=1",
+            fetch_redirect_response=False,
+        )
+        self.scan.refresh_from_db()
+        # The action must NOT have queued the scan.
+        self.assertEqual(self.scan.status, Status.PENDING_REVIEW)
+        # The pending deletion is untouched.
+        self.assertTrue(self.scan.deletions.exists())
+
+    def test_start_validate_blocked(self):
+        """Re-validate is blocked while a deletion is pending."""
+        self._assert_blocked("start_validate")
+
+    def test_start_detect_blocked(self):
+        """Next: Detect is blocked while a deletion is pending."""
+        self._assert_blocked("start_detect")
+
+    def test_recalculate_blocked(self):
+        """Recheck is blocked while a deletion is pending."""
+        self._assert_blocked("recalculate")
+
+    def test_start_validate_allowed_without_pending(self):
+        """With no pending changes, Re-validate queues the scan."""
+        self.scan.deletions.all().delete()
+        response = self.client.post(
+            reverse("start_validate", kwargs={"pk": self.scan.pk})
+        )
+        self.assertEqual(response.status_code, 302)
+        self.scan.refresh_from_db()
+        self.assertEqual(self.scan.status, Status.QUEUED)
+        self.assertEqual(self.scan.queued_action, QueuedAction.FULL_PIPELINE)
+
+
+@override_settings(MEDIA_ROOT=MEDIA_ROOT)
+class TestProcessActionsFragment(ScanningTestCase):
+    """The process_actions endpoint renders the step action bar so the
+    viewer can refresh it in place after a deletion/undo."""
+
+    def setUp(self):
+        self.user = self.make_user()
+        self.client.force_login(self.user)
+        self.scan = ScanFactory(
+            uploaded_by=self.user, status=Status.PENDING_REVIEW, page_count=5
+        )
+
+    def test_no_pending_changes(self):
+        """Without pending changes the bar has no Rebuild button."""
+        response = self.client.get(
+            reverse("process_actions", kwargs={"pk": self.scan.pk}) + "?step=1"
+        )
+        self.assertEqual(response.status_code, 200)
+        body = json.loads(response.content)
+        self.assertFalse(body["has_pending_changes"])
+        self.assertNotIn("Rebuild &amp; Validate", body["html"])
+
+    def test_pending_deletion_shows_rebuild(self):
+        """A pending deletion makes the bar show Rebuild & Validate."""
+        PageDeletion.objects.create(scan=self.scan, pdf_page=2)
+        response = self.client.get(
+            reverse("process_actions", kwargs={"pk": self.scan.pk}) + "?step=1"
+        )
+        self.assertEqual(response.status_code, 200)
+        body = json.loads(response.content)
+        self.assertTrue(body["has_pending_changes"])
+        self.assertIn("Rebuild &amp; Validate", body["html"])
+        self.assertIn(
+            reverse("reprocess", kwargs={"pk": self.scan.pk}), body["html"]
+        )

--- a/scanning/urls.py
+++ b/scanning/urls.py
@@ -53,6 +53,7 @@ from scanning.views_process import (
     cancel_processing,
     delete_page,
     dismiss_issue,
+    process_actions,
     progress_api,
     recalculate,
     reprocess,
@@ -100,6 +101,7 @@ urlpatterns = [
     ),
     # views_process.py
     path("scans/<int:pk>/process/", scan_process_view, name="scan_process"),
+    path("scans/<int:pk>/actions/", process_actions, name="process_actions"),
     path("scans/<int:pk>/progress/", progress_api, name="progress_api"),
     path("scans/<int:pk>/pdf/", serve_scan_pdf, name="serve_scan_pdf"),
     path(

--- a/scanning/views_process.py
+++ b/scanning/views_process.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 
 import fitz
+from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.http import (
     FileResponse,
@@ -15,6 +16,7 @@ from django.http import (
     JsonResponse,
 )
 from django.shortcuts import get_object_or_404, redirect, render
+from django.template.loader import render_to_string
 from django.urls import reverse
 from django.views.decorators.http import require_POST
 
@@ -489,6 +491,82 @@ def serve_original_crop(request: HttpRequest, pk: int) -> HttpResponse:
     return resp
 
 
+def _block_if_pending_changes(
+    request: HttpRequest, scan: Scan
+) -> HttpResponse | None:
+    """Redirect back to step 1 when the scan has unapplied page changes.
+
+    The validate, detect, and recheck actions ignore pending
+    ``PageDeletion`` / ``PageInsert`` rows, so running them would
+    silently strand the user's edits (and, for a full re-validation,
+    spend a RunPod run for nothing). Pending changes must be applied via
+    "Rebuild & Validate" (the ``reprocess`` view).
+
+    :param request: The HTTP request.
+    :type request: HttpRequest
+    :param scan: The scan to check for pending changes.
+    :type scan: Scan
+    :returns: A redirect response if there are pending changes, else
+        ``None``.
+    :rtype: HttpResponse | None
+    """
+    if scan.deletions.exists() or scan.inserts.exists():
+        messages.warning(
+            request,
+            'Apply your pending page changes with "Rebuild & Validate" '
+            "before running this.",
+        )
+        return redirect(
+            reverse("scan_process", kwargs={"pk": scan.pk}) + "?step=1"
+        )
+    return None
+
+
+@login_required
+def process_actions(request: HttpRequest, pk: int) -> JsonResponse:
+    """Render the step action bar as an HTML fragment.
+
+    Lets the step-1/step-2 viewers refresh the action buttons in place
+    after a page is marked for (or restored from) deletion, so the
+    correct buttons appear without a full page reload.
+
+    :param request: The HTTP request (optional ``step`` query param).
+    :type request: HttpRequest
+    :param pk: Scan primary key.
+    :type pk: int
+    :returns: JSON with the rendered ``html`` and the current
+        ``has_pending_changes`` flag.
+    :rtype: JsonResponse
+    """
+    scan = get_object_or_404(Scan, pk=pk)
+    try:
+        step = int(request.GET.get("step", 1))
+    except ValueError:
+        step = 1
+    if step < 1 or step > 3:
+        step = 1
+
+    has_pending_inserts = scan.inserts.exists()
+    has_pending_changes = scan.deletions.exists() or has_pending_inserts
+    context = {
+        "scan": scan,
+        "step": step,
+        "is_processing": scan.status in (Status.PROCESSING, Status.QUEUED),
+        "has_pending_changes": has_pending_changes,
+        "has_pending_inserts": has_pending_inserts,
+        "issues": scan.issues.all(),
+        "missing_pages": scan.missing_pages,
+        "has_detections": Detection.objects.filter(scan=scan).exists(),
+        "opinions": scan.opinions_json,
+    }
+    html = render_to_string(
+        "scanning/_process_actions.html", context, request=request
+    )
+    return JsonResponse(
+        {"html": html, "has_pending_changes": has_pending_changes}
+    )
+
+
 @login_required
 @require_POST
 def start_validate(request: HttpRequest, pk: int) -> HttpResponse:
@@ -499,6 +577,9 @@ def start_validate(request: HttpRequest, pk: int) -> HttpResponse:
     :return: Redirect to the scan processing page.
     """
     scan = get_object_or_404(Scan, pk=pk)
+    guard = _block_if_pending_changes(request, scan)
+    if guard:
+        return guard
     scan.status = Status.QUEUED
     scan.stage = Stage.VALIDATE
     scan.queued_action = QueuedAction.FULL_PIPELINE
@@ -518,6 +599,9 @@ def start_detect(request: HttpRequest, pk: int) -> HttpResponse:
     :return: Redirect to the scan processing page (step 2).
     """
     scan = get_object_or_404(Scan, pk=pk)
+    guard = _block_if_pending_changes(request, scan)
+    if guard:
+        return guard
     if Detection.objects.filter(scan=scan).exists():
         # Detections already exist (from full pipeline). Skip to review.
         return redirect(
@@ -573,6 +657,9 @@ def recalculate(request: HttpRequest, pk: int) -> HttpResponse:
     :return: Redirect to the scan processing page.
     """
     scan = get_object_or_404(Scan, pk=pk)
+    guard = _block_if_pending_changes(request, scan)
+    if guard:
+        return guard
     if not scan.ocr_results:
         return redirect("scan_process", pk=pk)
     from scanning import services


### PR DESCRIPTION
## Summary

After deleting a page in the process viewer, the action bar still showed the stale "Recheck" / "Re-validate" / "Next: Detect" buttons until a manual reload. None of those actions apply pending page changes (only "Rebuild & Validate" does), so clicking them silently stranded the deletion, and "Re-validate" would spend a full RunPod run while ignoring it. This adds a server-side guard and refreshes the action bar in place.

## Context

A pending page change is recorded the instant a page is marked for deletion (a `PageDeletion` row), but only `run_reprocess` ("Rebuild & Validate") ever applies it. To clear up a related report: page **deletions never trigger RunPod** (they run locally). RunPod is only invoked for page **insertions**, which OCR/validate each inserted page on the GPU. Pure deletions going back through the daemon queue is the local, no-cost path.

## Changes

- Block validate/detect/recheck when page changes are pending, redirecting to step 1 with a warning.
- Extract the action bar into a partial and add a `process_actions` JSON endpoint.
- Refresh the action bar and Pending Changes badge/banner in place after delete/undo.
- Add tests for the guard and the fragment.
