### PR TITLE
fix(runpod): make presigned-URL PDF downloads resumable and validate before processing

### DIFF
--- a/scanning/runpod/handler.py
+++ b/scanning/runpod/handler.py
@@ -425,17 +425,83 @@ def _download_pdf(url: str, dest: Path) -> None:
             )
 
 
-def _page_count(pdf_path: Path) -> int:
-    """Return the number of pages in a PDF.
+# Trailer window scanned for the %%EOF marker. A conforming PDF ends with
+# %%EOF (optionally followed by whitespace); incrementally-updated files
+# carry several, and only the last one matters. 2 KB comfortably covers
+# trailing newlines and a final cross-reference stream.
+_PDF_EOF_WINDOW = 2048
 
-    :param pdf_path: Path to the PDF on disk.
+
+def _validate_pdf(pdf_path: Path) -> int:
+    """Validate that ``pdf_path`` is a complete, openable PDF and return
+    its page count.
+
+    Defense-in-depth against a truncated download slipping through: the
+    resumable ``_download_pdf`` already checks the byte count against the
+    server's advertised size, but that only fires when the server sends a
+    size. The real hazard is a partial PDF that PyMuPDF can still *open*
+    by rebuilding a broken xref, reporting far fewer pages than the real
+    document — which would then silently produce wrong detections / page
+    analysis. Checking the header and the ``%%EOF`` trailer turns that
+    silent corruption into a hard failure.
+
+    A raised error propagates out of the action and (via ``handler()``)
+    marks the RunPod job FAILED with no ``error_code``; the daemon treats
+    a bare FAILED as transient and re-queues the scan with a freshly
+    signed URL. So a truncated download is re-fetched automatically; a
+    genuinely corrupt source PDF loops until the daemon's retry ceiling
+    and then surfaces as an error.
+
+    Checks run cheapest-first so a bad file fails before the fitz open.
+
+    :param pdf_path: Path to the downloaded PDF on disk.
     :returns: Page count.
     :rtype: int
+    :raises ValueError: If the file is empty, lacks a ``%PDF-`` header or
+        an ``%%EOF`` trailer, or cannot be opened as a PDF with at least
+        one page.
     """
     import fitz
 
-    with fitz.open(str(pdf_path)) as doc:
-        return doc.page_count
+    size = pdf_path.stat().st_size if pdf_path.exists() else 0
+    if size == 0:
+        raise ValueError(f"downloaded PDF is empty: {pdf_path}")
+
+    with pdf_path.open("rb") as f:
+        header = f.read(1024)
+        f.seek(max(0, size - _PDF_EOF_WINDOW))
+        trailer = f.read()
+
+    if b"%PDF-" not in header:
+        raise ValueError(
+            f"downloaded file is not a PDF (no %PDF- header): {pdf_path}"
+        )
+    if b"%%EOF" not in trailer:
+        raise ValueError(
+            "downloaded PDF is truncated (no %%EOF trailer in last "
+            f"{_PDF_EOF_WINDOW} bytes): {pdf_path}"
+        )
+
+    try:
+        with fitz.open(str(pdf_path)) as doc:
+            page_count = doc.page_count
+            # A rebuilt xref usually means damage; the %%EOF check above
+            # catches the common (truncation) cause, so this is just a
+            # breadcrumb rather than a hard failure.
+            if getattr(doc, "is_repaired", False):
+                logger.warning(
+                    "PyMuPDF repaired %s on open; proceeding", pdf_path
+                )
+    except ValueError:
+        raise
+    except Exception as exc:
+        raise ValueError(
+            f"downloaded file could not be opened as a PDF: {exc}"
+        ) from exc
+
+    if page_count < 1:
+        raise ValueError(f"downloaded PDF has no pages: {pdf_path}")
+    return page_count
 
 
 # ── Actions ─────────────────────────────────────────────────────────
@@ -517,7 +583,7 @@ def _action_detect(inputs: dict, tmp_dir: Path) -> dict:
     pdf_path = tmp_dir / "input.pdf"
     _download_pdf(pdf_url, pdf_path)
 
-    pages = _page_count(pdf_path)
+    pages = _validate_pdf(pdf_path)
     if pages > MAX_PAGES:
         raise ValueError(
             f"PDF has {pages} pages, exceeds MAX_PAGES={MAX_PAGES}"
@@ -574,7 +640,7 @@ def _action_analyze(inputs: dict, tmp_dir: Path) -> dict:
     pdf_path = tmp_dir / "input.pdf"
     _download_pdf(pdf_url, pdf_path)
 
-    pages = _page_count(pdf_path)
+    pages = _validate_pdf(pdf_path)
     if pages > MAX_PAGES:
         raise ValueError(
             f"PDF has {pages} pages, exceeds MAX_PAGES={MAX_PAGES}"

--- a/scanning/runpod/handler.py
+++ b/scanning/runpod/handler.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import io
 import logging
 import os
+import random
 import re
 import shutil
 import sys
@@ -29,6 +30,7 @@ from typing import Any
 
 import requests
 import runpod
+from urllib3.exceptions import IncompleteRead, ProtocolError
 
 # Capture worker boot start as early as possible so ``_WORKER_BOOT_MS``
 # covers the full cold-start cost (module imports + model preload).
@@ -65,7 +67,35 @@ if sentry_sdk is not None and _SENTRY_DSN:
 
 # ── Tunables ────────────────────────────────────────────────────────
 MAX_PAGES = int(os.environ.get("HANDLER_MAX_PAGES", "5000"))
+# Read timeout: max seconds to wait for the next chunk of body. A single
+# value would also bound connect; we split connect/read so a stalled
+# socket mid-download raises a ReadTimeout promptly and triggers a
+# resume instead of hanging for the whole budget.
 DOWNLOAD_TIMEOUT = int(os.environ.get("HANDLER_DOWNLOAD_TIMEOUT", "300"))
+DOWNLOAD_CONNECT_TIMEOUT = int(
+    os.environ.get("HANDLER_DOWNLOAD_CONNECT_TIMEOUT", "10")
+)
+# How many times to (re)issue the GET before giving up. Each retry
+# resumes from the last byte written via a Range request.
+DOWNLOAD_MAX_ATTEMPTS = int(
+    os.environ.get("HANDLER_DOWNLOAD_MAX_ATTEMPTS", "5")
+)
+# Upper bound (seconds) on the exponential backoff between retries.
+DOWNLOAD_BACKOFF_CAP = int(
+    os.environ.get("HANDLER_DOWNLOAD_BACKOFF_CAP", "30")
+)
+
+# Stream errors that mean "the connection died mid-transfer" — safe to
+# reconnect and resume from the last byte written. Anything else (a 4xx
+# other than the handled 403/416, a 5xx, a malformed URL) is not in here
+# and propagates so the daemon can re-queue or fail the scan.
+_TRANSIENT_DOWNLOAD_ERRORS = (
+    requests.exceptions.ChunkedEncodingError,
+    requests.exceptions.ConnectionError,
+    requests.exceptions.Timeout,
+    ProtocolError,
+    IncompleteRead,
+)
 
 
 # ── Cold-start preload ──────────────────────────────────────────────
@@ -239,8 +269,56 @@ def _tag_sentry(job: dict, action: str, scan_pk: Any) -> None:
         sentry_sdk.set_tag("runpod_job_id", str(job_id))
 
 
+def _expected_total(resp: requests.Response) -> int | None:
+    """Best-effort total file size, in bytes, from a download response.
+
+    On a ``206 Partial Content`` the ``Content-Length`` header is only
+    the size of *this* chunk, so the full size has to come from the
+    ``Content-Range`` total (the value after the slash in
+    ``bytes 0-1023/2048`` -> ``2048``). On a plain ``200 OK`` the
+    ``Content-Length`` is the full size.
+
+    :param resp: A streamed download response.
+    :returns: Total size in bytes, or ``None`` if no header is present
+        or parseable (in which case the caller skips the completeness
+        check rather than failing a download that may be fine).
+    :rtype: int | None
+    """
+    content_range = resp.headers.get("Content-Range")
+    if content_range and "/" in content_range:
+        total = content_range.rsplit("/", 1)[1].strip()
+        if total.isdigit():
+            return int(total)
+    content_length = resp.headers.get("Content-Length")
+    if content_length and content_length.strip().isdigit():
+        return int(content_length)
+    return None
+
+
 def _download_pdf(url: str, dest: Path) -> None:
-    """Download a PDF from a presigned GET URL to ``dest``.
+    """Download a PDF from a presigned GET URL to ``dest``, resuming
+    across dropped connections.
+
+    Large scans (multi-GB, 1000+ pages) take long enough that a single
+    streamed GET routinely dies mid-transfer: the socket stalls, S3
+    resets the connection, or urllib3 raises ``IncompleteRead``. Rather
+    than restart the whole transfer (or fail the job) on every blip,
+    this retries with an HTTP ``Range`` request and appends to the
+    partial file from the last byte written, with exponential backoff
+    between attempts.
+
+    Range-response handling:
+
+    - **206 Partial Content** — server honoured ``Range``; append.
+    - **200 OK** (on a resume) — server ignored ``Range`` and is
+      resending the whole body; truncate and restart from byte 0.
+      Appending here would write a second copy of the head and corrupt
+      the PDF, so this guard is load-bearing.
+    - **416 Range Not Satisfiable** — our offset is at/past EOF, i.e.
+      we already hold the whole file; treat as complete.
+    - **403 Forbidden** — the presigned URL has expired or is invalid.
+      Not retryable here (the URL is dead): raise so RunPod marks the
+      job FAILED and the daemon re-queues the scan with a fresh URL.
 
     Only accepts ``http://`` or ``https://`` URLs. Rejects everything
     else (``file://``, ``gopher://``, bare paths, etc.) defensively:
@@ -252,18 +330,99 @@ def _download_pdf(url: str, dest: Path) -> None:
     :param url: PDF URL (typically a presigned S3 GET URL).
     :param dest: Local filesystem target.
     :raises ValueError: If ``url`` is not http(s).
-    :raises requests.HTTPError: On non-2xx response.
+    :raises requests.HTTPError: On a non-2xx response other than the
+        handled 403/416 cases.
+    :raises RuntimeError: If the presigned URL is expired (403), or if
+        the file on disk is still short of the expected size after
+        ``DOWNLOAD_MAX_ATTEMPTS`` attempts.
     """
     if not isinstance(url, str) or not url.startswith(("http://", "https://")):
         raise ValueError(
             f"refusing to download PDF from non-http(s) URL: {url!r}"
         )
-    with requests.get(url, stream=True, timeout=DOWNLOAD_TIMEOUT) as r:
-        r.raise_for_status()
-        with dest.open("wb") as f:
-            for chunk in r.iter_content(chunk_size=1024 * 1024):
-                if chunk:
-                    f.write(chunk)
+
+    timeout = (DOWNLOAD_CONNECT_TIMEOUT, DOWNLOAD_TIMEOUT)
+    offset = 0
+    total: int | None = None
+
+    for attempt in range(DOWNLOAD_MAX_ATTEMPTS):
+        headers = {"Range": f"bytes={offset}-"} if offset else {}
+        try:
+            with requests.get(
+                url, headers=headers, stream=True, timeout=timeout
+            ) as r:
+                # Expired/invalid presigned URL. Retrying the same URL is
+                # pointless; raise so the daemon re-signs and re-queues.
+                if r.status_code == 403:
+                    raise RuntimeError(
+                        "presigned URL expired or invalid (HTTP 403); "
+                        "daemon will re-queue with a fresh URL"
+                    )
+                # We asked to resume past EOF -> already have it all.
+                if offset and r.status_code == 416:
+                    logger.info(
+                        "resume at byte %d returned 416; file already "
+                        "complete",
+                        offset,
+                    )
+                    break
+                # Server ignored Range and is resending from the start.
+                # Discard the partial file and restart, or we'd append a
+                # second copy of the head and corrupt the PDF.
+                if offset and r.status_code == 200:
+                    logger.warning(
+                        "server ignored Range (HTTP 200); restarting "
+                        "download from byte 0"
+                    )
+                    offset = 0
+                    total = None
+                r.raise_for_status()
+
+                if total is None:
+                    total = _expected_total(r)
+
+                mode = "ab" if offset else "wb"
+                with dest.open(mode) as f:
+                    for chunk in r.iter_content(chunk_size=1024 * 1024):
+                        if chunk:
+                            f.write(chunk)
+                            offset += len(chunk)
+            # Stream drained without raising: this attempt finished.
+            break
+        except _TRANSIENT_DOWNLOAD_ERRORS as exc:
+            # Re-derive the offset from disk: a partial write may have
+            # landed bytes the in-memory counter didn't account for.
+            offset = dest.stat().st_size if dest.exists() else 0
+            if attempt == DOWNLOAD_MAX_ATTEMPTS - 1:
+                logger.error(
+                    "download failed after %d attempts at byte %d: %s",
+                    DOWNLOAD_MAX_ATTEMPTS,
+                    offset,
+                    exc,
+                )
+                raise
+            backoff = min(2**attempt, DOWNLOAD_BACKOFF_CAP)
+            backoff += random.uniform(0, backoff / 2)  # jitter
+            logger.warning(
+                "download interrupted at byte %d (attempt %d/%d): %s; "
+                "resuming in %.1fs",
+                offset,
+                attempt + 1,
+                DOWNLOAD_MAX_ATTEMPTS,
+                exc,
+                backoff,
+            )
+            time.sleep(backoff)
+
+    # Hand analyze_pdf/detect a complete file or nothing: a truncated PDF
+    # silently produces wrong page counts and detections. Raising re-queues.
+    if total is not None:
+        actual = dest.stat().st_size if dest.exists() else 0
+        if actual != total:
+            raise RuntimeError(
+                f"incomplete download: {actual}/{total} bytes after "
+                f"{DOWNLOAD_MAX_ATTEMPTS} attempts"
+            )
 
 
 def _page_count(pdf_path: Path) -> int:

--- a/scanning/tests/test_runpod_handler.py
+++ b/scanning/tests/test_runpod_handler.py
@@ -1,0 +1,274 @@
+"""Tests for the standalone RunPod GPU-worker handler.
+
+``scanning/runpod/handler.py`` is a separate deploy artifact: only that
+one file is copied into the worker image, and it imports the GPU stack
+(``runpod``/``torch``/``blackletter``) at module scope and calls
+``_preload()`` on import. None of that is installed in the scanning test
+environment, so :func:`_load_handler` injects lightweight stubs into
+``sys.modules`` before importing the module from its file path. The
+torch stub reports no CUDA, which makes ``_preload()`` return early
+before it touches any real model code.
+
+These exercise the resumable download path in ``_download_pdf`` without
+real sockets: ``requests.get`` is replaced with a fake that yields chunks
+and can simulate a connection drop, a Range-ignoring server, an expired
+URL, and a short body.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest import mock
+
+import requests
+from django.test import SimpleTestCase
+
+_HANDLER_PATH = (
+    Path(__file__).resolve().parent.parent / "runpod" / "handler.py"
+)
+
+
+def _load_handler():
+    """Import the handler module with its GPU-only deps stubbed."""
+    stub_torch = mock.MagicMock()
+    stub_torch.cuda.is_available.return_value = False
+    stubs = {
+        "runpod": mock.MagicMock(),
+        "torch": stub_torch,
+        "blackletter": mock.MagicMock(),
+        "blackletter.api": mock.MagicMock(),
+    }
+    with mock.patch.dict(sys.modules, stubs):
+        spec = importlib.util.spec_from_file_location(
+            "_runpod_handler_under_test", _HANDLER_PATH
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    return module
+
+
+handler = _load_handler()
+
+
+class _FakeResponse:
+    """Minimal stand-in for a streamed ``requests`` response.
+
+    Yields ``chunks`` from ``iter_content`` and, if ``then_raise`` is
+    set, raises it after the last chunk to simulate a dropped
+    connection mid-transfer.
+    """
+
+    def __init__(
+        self, status_code=200, headers=None, chunks=(), then_raise=None
+    ):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self._chunks = list(chunks)
+        self._then_raise = then_raise
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(str(self.status_code))
+
+    def iter_content(self, chunk_size=None):
+        yield from self._chunks
+        if self._then_raise is not None:
+            raise self._then_raise
+
+
+class DownloadPdfTest(SimpleTestCase):
+    """Resumable-download behaviour of ``handler._download_pdf``."""
+
+    URL = "https://example.com/presigned/scan.pdf"
+
+    def setUp(self):
+        import tempfile
+
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.dest = Path(self._tmpdir.name) / "input.pdf"
+        # No real sleeps / jitter during tests.
+        self._sleep = mock.patch.object(handler.time, "sleep").start()
+        mock.patch.object(handler.random, "uniform", return_value=0.0).start()
+        self.addCleanup(mock.patch.stopall)
+
+    def _patch_get(self, responses):
+        """Patch ``requests.get`` to return ``responses`` in order and
+        record the headers each call was made with."""
+        calls = []
+        it = iter(responses)
+
+        def fake_get(url, headers=None, stream=None, timeout=None):
+            calls.append({"url": url, "headers": headers or {}})
+            return next(it)
+
+        patcher = mock.patch.object(
+            handler.requests, "get", side_effect=fake_get
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        return calls
+
+    def test_simple_download(self):
+        body = b"%PDF-1.7\n" + b"x" * 100
+        self._patch_get(
+            [_FakeResponse(200, {"Content-Length": str(len(body))}, [body])]
+        )
+
+        handler._download_pdf(self.URL, self.dest)
+
+        self.assertEqual(self.dest.read_bytes(), body)
+
+    def test_resume_after_dropped_connection(self):
+        head, tail = b"%PDF-1.7\nfirst-half", b"second-half-EOF"
+        full = head + tail
+        calls = self._patch_get(
+            [
+                # Drops after sending the head.
+                _FakeResponse(
+                    200,
+                    {"Content-Length": str(len(full))},
+                    [head],
+                    then_raise=requests.exceptions.ChunkedEncodingError(
+                        "boom"
+                    ),
+                ),
+                # Resume: 206 with the remaining bytes.
+                _FakeResponse(
+                    206,
+                    {
+                        "Content-Range": f"bytes {len(head)}-{len(full) - 1}/{len(full)}",
+                        "Content-Length": str(len(tail)),
+                    },
+                    [tail],
+                ),
+            ]
+        )
+
+        handler._download_pdf(self.URL, self.dest)
+
+        self.assertEqual(self.dest.read_bytes(), full)
+        # Second request resumed from where the first left off.
+        self.assertNotIn("Range", calls[0]["headers"])
+        self.assertEqual(
+            calls[1]["headers"].get("Range"), f"bytes={len(head)}-"
+        )
+        self._sleep.assert_called_once()
+
+    def test_server_ignores_range_restarts_clean(self):
+        head = b"%PDF-1.7\nhead"
+        full = head + b"-rest-of-file-EOF"
+        self._patch_get(
+            [
+                _FakeResponse(
+                    200,
+                    {"Content-Length": str(len(full))},
+                    [head],
+                    then_raise=requests.exceptions.ConnectionError("reset"),
+                ),
+                # Server ignored Range and re-sent the WHOLE body as 200.
+                _FakeResponse(200, {"Content-Length": str(len(full))}, [full]),
+            ]
+        )
+
+        handler._download_pdf(self.URL, self.dest)
+
+        # File must be the body exactly once, not head + full.
+        self.assertEqual(self.dest.read_bytes(), full)
+
+    def test_416_treated_as_complete(self):
+        full = b"%PDF-1.7\ncomplete-body"
+        self._patch_get(
+            [
+                # Drops right at the end, after all bytes are on disk.
+                _FakeResponse(
+                    200,
+                    {"Content-Length": str(len(full))},
+                    [full],
+                    then_raise=requests.exceptions.ChunkedEncodingError(
+                        "late"
+                    ),
+                ),
+                # Resume past EOF -> 416.
+                _FakeResponse(416, {}, []),
+            ]
+        )
+
+        handler._download_pdf(self.URL, self.dest)
+
+        self.assertEqual(self.dest.read_bytes(), full)
+
+    def test_403_fails_fast_without_retry(self):
+        calls = self._patch_get([_FakeResponse(403, {}, [])])
+
+        with self.assertRaisesRegex(RuntimeError, "403"):
+            handler._download_pdf(self.URL, self.dest)
+
+        # No retry, no backoff sleep on a dead URL.
+        self.assertEqual(len(calls), 1)
+        self._sleep.assert_not_called()
+
+    def test_incomplete_download_raises(self):
+        # 200 advertises 100 bytes but the stream ends cleanly at 50.
+        self._patch_get(
+            [_FakeResponse(200, {"Content-Length": "100"}, [b"x" * 50])]
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError, r"incomplete download: 50/100"
+        ):
+            handler._download_pdf(self.URL, self.dest)
+
+    def test_gives_up_after_max_attempts(self):
+        drop = requests.exceptions.ChunkedEncodingError("always drops")
+        responses = [
+            _FakeResponse(
+                200, {"Content-Length": "10"}, [b"x"], then_raise=drop
+            )
+            for _ in range(handler.DOWNLOAD_MAX_ATTEMPTS)
+        ]
+        calls = self._patch_get(responses)
+
+        with self.assertRaises(requests.exceptions.ChunkedEncodingError):
+            handler._download_pdf(self.URL, self.dest)
+
+        self.assertEqual(len(calls), handler.DOWNLOAD_MAX_ATTEMPTS)
+
+    def test_rejects_non_http_url(self):
+        with self.assertRaisesRegex(ValueError, "non-http"):
+            handler._download_pdf("file:///etc/passwd", self.dest)
+
+
+class ExpectedTotalTest(SimpleTestCase):
+    """``handler._expected_total`` header parsing."""
+
+    def _resp(self, headers):
+        return _FakeResponse(headers=headers)
+
+    def test_content_range_total_wins_on_206(self):
+        resp = self._resp(
+            {"Content-Range": "bytes 100-199/2048", "Content-Length": "100"}
+        )
+        self.assertEqual(handler._expected_total(resp), 2048)
+
+    def test_content_length_used_on_200(self):
+        self.assertEqual(
+            handler._expected_total(self._resp({"Content-Length": "512"})), 512
+        )
+
+    def test_returns_none_when_unparseable(self):
+        self.assertIsNone(handler._expected_total(self._resp({})))
+        self.assertIsNone(
+            handler._expected_total(self._resp({"Content-Length": "??"}))
+        )
+        self.assertIsNone(
+            handler._expected_total(self._resp({"Content-Range": "bytes */*"}))
+        )

--- a/scanning/tests/test_runpod_handler.py
+++ b/scanning/tests/test_runpod_handler.py
@@ -272,3 +272,53 @@ class ExpectedTotalTest(SimpleTestCase):
         self.assertIsNone(
             handler._expected_total(self._resp({"Content-Range": "bytes */*"}))
         )
+
+
+class ValidatePdfTest(SimpleTestCase):
+    """``handler._validate_pdf`` structural validation."""
+
+    def setUp(self):
+        import tempfile
+
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.path = Path(self._tmpdir.name) / "input.pdf"
+
+    @staticmethod
+    def _pdf_bytes(pages=1):
+        """Build a real, complete PDF of ``pages`` pages."""
+        import fitz
+
+        doc = fitz.open()
+        for _ in range(pages):
+            doc.new_page()
+        data = doc.tobytes()
+        doc.close()
+        return data
+
+    def test_valid_single_page(self):
+        self.path.write_bytes(self._pdf_bytes(1))
+        self.assertEqual(handler._validate_pdf(self.path), 1)
+
+    def test_valid_multi_page(self):
+        self.path.write_bytes(self._pdf_bytes(5))
+        self.assertEqual(handler._validate_pdf(self.path), 5)
+
+    def test_truncated_pdf_missing_eof(self):
+        full = self._pdf_bytes(3)
+        # Lop off the tail so the %%EOF trailer is gone, simulating a
+        # download that died mid-transfer.
+        self.path.write_bytes(full[: len(full) // 2])
+
+        with self.assertRaisesRegex(ValueError, "truncated"):
+            handler._validate_pdf(self.path)
+
+    def test_empty_file(self):
+        self.path.write_bytes(b"")
+        with self.assertRaisesRegex(ValueError, "empty"):
+            handler._validate_pdf(self.path)
+
+    def test_not_a_pdf(self):
+        self.path.write_bytes(b"<html>nope</html>\n%%EOF")
+        with self.assertRaisesRegex(ValueError, "not a PDF"):
+            handler._validate_pdf(self.path)


### PR DESCRIPTION
Solves #82

Large scan PDFs (multi-GB, 1000+ pages) take long enough that a single streamed download may die mid-transfer, failing the whole RunPod job. This makes the download
resilient and adds a structural integrity check before the file is handed to detect/analyze.

Resumable download (_download_pdf)
- Retry loop (default 5 attempts) with exponential backoff + jitter; resumes via Range: bytes=<offset>- instead of restarting.
- Handles all Range outcomes: 206 → append, 200-on-resume → server ignored Range, truncate and restart from 0 (prevents file corruption), 416 → already complete, 403 →
expired URL, fail fast so the daemon re-queues with a freshly-signed URL.
- Split connect/read timeouts so a stalled socket raises promptly and triggers a resume instead of hanging.
- Captures the expected total (Content-Length, or Content-Range total on 206) and raises if the file is short after the loop — a truncated PDF is never processed.

PDF validation (_validate_pdf, defense-in-depth)
- Replaces _page_count; called after download in both actions.
- Cheapest-first checks: non-empty → %PDF- header → %%EOF trailer in the last 2 KB (the truncation signal) → fitz.open with page_count >= 1.
- Guards the silent-corruption case where PyMuPDF opens a truncated PDF via a rebuilt xref and reports far fewer pages than the real document.
- On failure raises ValueError, which marks the job FAILED with no error_code so the daemon re-queues with a fresh URL.

Tests
- New scanning/tests/test_runpod_handler.py (16 tests) covering resume-after-drop, server-ignores-Range, 416-complete, 403 fast-fail, incomplete-body, give-up-after-max,
and PDF validation (valid single/multi-page, truncated, empty, non-PDF).
- Loads the standalone handler with its GPU-only imports stubbed; runs in the docker compose env. Full scanning.tests suite (222 tests) passes.

Notes
- No blackletter change needed: the presigned TTL is already 86400s, and a raised handler exception already maps to the daemon's transient/re-queue path. Validation is
scoped to the handler (where the download-truncation risk lives); blackletter's local-mode callers read a locally-produced bitonal.pdf.
- Still pending (not in this PR): manual end-to-end rerun of scan 1835 (~1.8 GB / 1307 pages) on a real GPU worker.
