### PR TITLE
fix(scanning): serve processed PDF in viewer and persist bitonal/OCR to S3

### DIFF
--- a/scanning/services.py
+++ b/scanning/services.py
@@ -291,6 +291,9 @@ def _ensure_bitonal(scan: "Scan", output_dir: Path) -> Path:
             str(output_dir),
             progress_callback=_bitonal_progress,
         )
+        # Persist as soon as it exists so a later crash, or a reprocess
+        # that skips the end-of-pipeline push, still leaves it in S3.
+        _push_generated_file_to_s3(scan.pk, "bitonal.pdf")
 
     with fitz.open(str(bitonal_path)) as pdf:
         page_count = pdf.page_count
@@ -324,7 +327,7 @@ def _run_ocr(
         current=0,
         total=total_pages,
     )
-    return _ocr(
+    ocr_path = _ocr(
         scan_pk,
         bitonal_path,
         output_dir,
@@ -333,6 +336,9 @@ def _run_ocr(
         first_page=first_page,
         total_pages=total_pages,
     )
+    # Persist the OCR PDF as soon as it exists (see _ensure_bitonal).
+    _push_generated_file_to_s3(scan_pk, Path(ocr_path).name)
+    return ocr_path
 
 
 def _ocr(
@@ -721,6 +727,48 @@ def _push_processing_files_to_s3(scan_pk: int) -> None:
     except Exception:
         logger.exception(
             "Failed to push processing files to S3 for scan %s", scan_pk
+        )
+
+
+def _push_generated_file_to_s3(scan_pk: int, relative_path: str) -> None:
+    """Upload a single just-generated processing file to S3 immediately.
+
+    Persists derived artifacts (``bitonal.pdf``, the OCR PDF) the moment
+    they are produced rather than only at the end-of-pipeline push, so a
+    later crash, or a ``reprocess`` run that never does the full push,
+    still leaves them in S3. Mirrors the credential guard in
+    ``_push_processing_files_to_s3`` so a missing-creds misconfiguration
+    in prod surfaces a distinct Sentry error.
+
+    Prod-only in practice: in local dev ``upload_file_to_s3`` is a no-op
+    (S3 disabled), and the file is already on disk under ``output_dir``,
+    so it is served locally without any upload.
+
+    :param scan_pk: Primary key of the scan the file belongs to.
+    :param relative_path: Path relative to the scan's output dir.
+    :return: None.
+    """
+    from scanning import s3_sync
+    from scanning.utils import has_s3_credentials
+
+    if (
+        not settings.DEVELOPMENT
+        and not getattr(settings, "TESTING", False)
+        and not has_s3_credentials()
+    ):
+        logger.error(
+            "Skipping S3 push of %s for scan %s: AWS credentials not "
+            "configured",
+            relative_path,
+            scan_pk,
+        )
+        return
+    try:
+        scan = Scan.objects.get(pk=scan_pk)
+        s3_sync.upload_file_to_s3(scan, relative_path)
+    except Exception:
+        logger.exception(
+            "Failed to push %s to S3 for scan %s", relative_path, scan_pk
         )
 
 

--- a/scanning/tests/test_services.py
+++ b/scanning/tests/test_services.py
@@ -1052,3 +1052,99 @@ class TestRefreshVolumeQueueStatus(TestCase):
         refresh_volume_queue_status(volume)
         volume.refresh_from_db()
         self.assertEqual(volume.queue_status, QueueStatus.SCANNING)
+
+
+@override_settings(MEDIA_ROOT=MEDIA_ROOT)
+class TestImmediateS3PushOnGeneration(TestCase):
+    """Bitonal and OCR PDFs are pushed to S3 the moment they're generated."""
+
+    def test_push_generated_delegates_to_upload(self):
+        """The helper forwards to s3_sync.upload_file_to_s3."""
+        from scanning import services
+
+        scan = ScanFactory(start_page=1, end_page=2)
+        with patch("scanning.s3_sync.upload_file_to_s3") as up:
+            services._push_generated_file_to_s3(scan.pk, "bitonal.pdf")
+
+        up.assert_called_once_with(scan, "bitonal.pdf")
+
+    def test_push_generated_skips_in_prod_without_creds(self):
+        """In prod with no AWS creds, skip the upload (don't raise)."""
+        from scanning import services
+
+        scan = ScanFactory(start_page=1, end_page=2)
+        with (
+            override_settings(DEVELOPMENT=False, TESTING=False),
+            patch.dict("os.environ", {}, clear=True),
+            patch("scanning.s3_sync.upload_file_to_s3") as up,
+        ):
+            services._push_generated_file_to_s3(scan.pk, "bitonal.pdf")
+
+        up.assert_not_called()
+
+    def test_ensure_bitonal_pushes_on_fresh_generation(self):
+        """A newly converted bitonal is uploaded immediately."""
+        from scanning import services
+
+        scan = ScanFactory(start_page=1, end_page=2)
+        output = pathlib.Path(scan.output_dir)
+        output.mkdir(parents=True, exist_ok=True)
+
+        def _fake_bitonal(src, out, progress_callback=None):
+            (pathlib.Path(out) / "bitonal.pdf").write_bytes(b"%PDF-1.4 bw")
+
+        with (
+            patch.object(services, "bl_bitonal", side_effect=_fake_bitonal),
+            patch.object(services, "_push_generated_file_to_s3") as push,
+            patch.object(services.fitz, "open") as fitz_open,
+        ):
+            fitz_open.return_value.__enter__.return_value.page_count = 2
+            services._ensure_bitonal(scan, output)
+
+        push.assert_called_once_with(scan.pk, "bitonal.pdf")
+
+    def test_ensure_bitonal_skips_push_when_already_present(self):
+        """An existing bitonal is neither reconverted nor re-uploaded."""
+        from scanning import services
+
+        scan = ScanFactory(start_page=1, end_page=2)
+        output = pathlib.Path(scan.output_dir)
+        output.mkdir(parents=True, exist_ok=True)
+        (output / "bitonal.pdf").write_bytes(b"%PDF-1.4 existing")
+
+        with (
+            patch.object(services, "bl_bitonal") as bitonal,
+            patch.object(services, "_push_generated_file_to_s3") as push,
+            patch.object(services.fitz, "open") as fitz_open,
+        ):
+            fitz_open.return_value.__enter__.return_value.page_count = 2
+            services._ensure_bitonal(scan, output)
+
+        bitonal.assert_not_called()
+        push.assert_not_called()
+
+    def test_run_ocr_pushes_generated_pdf(self):
+        """The OCR PDF is uploaded immediately after it's produced."""
+        from scanning import services
+
+        scan = ScanFactory(start_page=1, end_page=2)
+        output = pathlib.Path(scan.output_dir)
+        output.mkdir(parents=True, exist_ok=True)
+        ocr_pdf = output / "rep.1.1.2.pdf"
+
+        with (
+            patch.object(services, "_ocr", return_value=ocr_pdf),
+            patch.object(services, "_push_generated_file_to_s3") as push,
+            patch.object(services.fitz, "open") as fitz_open,
+        ):
+            fitz_open.return_value.__enter__.return_value.page_count = 2
+            services._run_ocr(
+                scan.pk,
+                "in.pdf",
+                str(output),
+                reporter="rep",
+                volume="1",
+                first_page=1,
+            )
+
+        push.assert_called_once_with(scan.pk, "rep.1.1.2.pdf")

--- a/scanning/tests/test_views.py
+++ b/scanning/tests/test_views.py
@@ -1256,6 +1256,53 @@ class TestServeScanPdfLazyPull(ScanningTestCase):
         self.assertEqual(response.status_code, 200)
         mock_pull.assert_called_once()
 
+    def test_processed_pdf_preferred_over_local_original(self):
+        """A local original must not pre-empt a bitonal fetchable from S3.
+
+        Regression: the original being on disk used to short-circuit the
+        response before the S3 pull ran, so the viewer streamed the huge
+        original even though a tiny bitonal existed in S3.
+        """
+        user = self.make_user()
+        self.client.force_login(user)
+
+        tmp_root = tempfile.mkdtemp()
+        reporter = ReporterFactory(short_name="bt2d")
+        scan = ScanFactory(
+            reporter=reporter, volume=12, start_page=1, end_page=2
+        )
+        # The original is resolvable locally via the FileField, so without
+        # the fix _try_local would serve it and skip the pull entirely.
+        self.assertTrue(os.path.exists(scan.original_pdf.path))
+
+        bitonal_bytes = b"%PDF-1.4 pulled bitonal"
+
+        def _fake_download(scan_arg):
+            output = pathlib.Path(scan_arg.output_dir)
+            output.mkdir(parents=True, exist_ok=True)
+            (output / "bitonal.pdf").write_bytes(bitonal_bytes)
+
+        with (
+            override_settings(
+                DEVELOPMENT=False,
+                TESTING=False,
+                PROCESSING_TMP_DIR=tmp_root,
+            ),
+            patch(
+                "scanning.s3_sync.download_processing_files",
+                side_effect=_fake_download,
+            ) as mock_pull,
+        ):
+            response = self.client.get(
+                reverse("serve_scan_pdf", kwargs={"pk": scan.pk})
+            )
+
+        self.assertEqual(response.status_code, 200)
+        mock_pull.assert_called_once()
+        # The bitonal was served, not the (different) original.
+        served = b"".join(response.streaming_content)
+        self.assertEqual(served, bitonal_bytes)
+
     def test_returns_404_when_nothing_available(self):
         """When local is empty and S3 pull yields nothing, return 404."""
         user = self.make_user()

--- a/scanning/views_process.py
+++ b/scanning/views_process.py
@@ -407,32 +407,47 @@ def progress_api(request: HttpRequest, pk: int) -> JsonResponse:
 def serve_scan_pdf(request: HttpRequest, pk: int) -> FileResponse:
     """Serve the best available PDF for a scan (OCR, bitonal, or original).
 
-    Resolves the local file in three passes: try the cached ``output_dir``,
-    fall back to the original ``pdf_path``, and if neither is on disk,
-    lazy-pull processing files from S3 and try once more. The pull covers
-    prod where the daemon and web run in separate containers with separate
-    ``/tmp/`` volumes.
+    Prefers the small processed PDF (OCR text layer, else bitonal) over
+    the original, which for multi-GB scans is an order of magnitude
+    larger. The order is load-bearing: serving the original whenever it
+    happens to be on disk would short-circuit before the S3 pull that
+    fetches the processed PDF, so the viewer would keep streaming the
+    huge original even though a tiny bitonal exists in S3.
+
+    Resolution:
+
+    1. Serve the processed PDF (OCR > bitonal) if it is already local.
+    2. Otherwise pull the scan's processing files from S3 and look
+       again. This covers prod, where the daemon and web run in
+       separate containers with separate ephemeral ``/tmp/`` volumes, so
+       the web side typically only holds the original (or nothing).
+    3. Only if no processed PDF can be found locally or in S3 do we fall
+       back to the original.
 
     :param request: The HTTP request.
     :param pk: Scan primary key.
     :return: File response streaming the PDF.
-    :raises Http404: When no local copy exists and S3 has nothing to pull.
+    :raises Http404: When no PDF exists locally and S3 has nothing to pull.
     """
     scan = get_object_or_404(Scan, pk=pk)
 
-    def _try_local() -> FileResponse | None:
+    def _processed_local() -> FileResponse | None:
+        """Return the OCR pdf, else ``bitonal.pdf``, from ``output_dir``."""
         output = Path(scan.output_dir)
-        if output.is_dir():
-            ocr = find_ocr_pdf(scan.output_dir)
-            if ocr:
-                return FileResponse(
-                    ocr.open("rb"), content_type="application/pdf"
-                )
-            bitonal = output / "bitonal.pdf"
-            if bitonal.exists():
-                return FileResponse(
-                    bitonal.open("rb"), content_type="application/pdf"
-                )
+        if not output.is_dir():
+            return None
+        ocr = find_ocr_pdf(scan.output_dir)
+        if ocr:
+            return FileResponse(ocr.open("rb"), content_type="application/pdf")
+        bitonal = output / "bitonal.pdf"
+        if bitonal.exists():
+            return FileResponse(
+                bitonal.open("rb"), content_type="application/pdf"
+            )
+        return None
+
+    def _original_local() -> FileResponse | None:
+        """Return the original PDF if a local copy is resolvable."""
         try:
             return FileResponse(
                 Path(scan.pdf_path).open("rb"),
@@ -441,10 +456,15 @@ def serve_scan_pdf(request: HttpRequest, pk: int) -> FileResponse:
         except FileNotFoundError:
             return None
 
-    response = _try_local()
+    # 1. Prefer the small processed PDF if it is already on disk.
+    response = _processed_local()
     if response is not None:
         return response
 
+    # 2. Not local: pull processing files from S3 (also lands the
+    #    original for the fallback below) and re-check for the processed
+    #    PDF. Runs even when the original is already local, so the big
+    #    original never pre-empts a fetchable bitonal.
     try:
         from scanning import s3_sync
 
@@ -452,7 +472,12 @@ def serve_scan_pdf(request: HttpRequest, pk: int) -> FileResponse:
     except Exception:
         logger.exception("Lazy S3 pull failed for scan %s", scan.pk)
 
-    response = _try_local()
+    response = _processed_local()
+    if response is not None:
+        return response
+
+    # 3. No processed PDF anywhere: fall back to the original.
+    response = _original_local()
     if response is not None:
         return response
     raise Http404


### PR DESCRIPTION
## Problem

The scan viewer (`serve_scan_pdf`) was streaming the full original PDF even when a much smaller processed copy existed. For multi-GB / 1000+ page scans that is an order-of-magnitude larger download than necessary (e.g. 20 MB original vs ~2.4 MB bitonal).

Two root causes:

1. `serve_scan_pdf` already intended to prefer the OCR/bitonal PDF, but it returned the original as soon as a local copy was resolvable, short-circuiting before the S3 lazy-pull that fetches the processed PDF. So whenever the original was on disk but the bitonal/OCR weren't co-located, it served the big original.
2. The bitonal and OCR PDFs were only uploaded to S3 by the end-of-pipeline push. A crash, or a `reprocess` run (which never does the full push), left them out of S3 entirely, so there was nothing for the viewer to pull.

## Changes

`serve_scan_pdf` now prefers the processed PDF and only falls back to the original after attempting the pull: serve OCR/bitonal if local, otherwise pull processing files from S3 and re-check, and only then fall back to the original. The big original can no longer pre-empt a fetchable bitonal.

`_ensure_bitonal` and `_run_ocr` now upload their output to S3 the moment it is generated, via a new `_push_generated_file_to_s3` helper (same credential guard as `_push_processing_files_to_s3`). This makes the derived files resilient to a later crash and available to any reprocess/viewer pull. In local dev the upload is a no-op and the file is already on the shared media mount, so it is served locally without S3.

Together this closes the loop: generate → push immediately, and re-entry/viewer → pull if missing → serve the small file in preference to the original.

## Notes

This applies to future generations. Scans whose bitonal/OCR were never produced by a prod-mode run still need a full Re-validate to populate S3 before the viewer can serve the small file; the pull only fetches what is actually in S3.