### PR TITLE
feat(scanning): show upload progress on queue uploads

### DIFF
--- a/scanning/templates/scanning/queue_detail.html
+++ b/scanning/templates/scanning/queue_detail.html
@@ -82,7 +82,7 @@
 <!-- Upload form -->
 <div class="card mb-6">
   <h2 class="text-sm font-bold mb-3">Upload a scan</h2>
-  <form method="post" action="{% url 'queue_upload' reporter_slug=volume.reporter.short_name vol=volume.volume_number %}" enctype="multipart/form-data">
+  <form id="upload-form" method="post" action="{% url 'queue_upload' reporter_slug=volume.reporter.short_name vol=volume.volume_number %}" enctype="multipart/form-data">
     {% csrf_token %}
     <input type="hidden" name="new_scan" value="1">
     <div class="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-3">
@@ -117,6 +117,16 @@
       <button type="submit" name="action" value="upload_validate" class="btn-primary text-sm">Upload &amp; Validate</button>
       <button type="submit" name="action" value="upload_only" class="btn-outline text-sm">Upload Only</button>
     </div>
+    <div id="upload-progress" class="hidden mt-3">
+      <div class="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400 mb-1">
+        <span id="upload-progress-label">Uploading&hellip;</span>
+        <span id="upload-progress-pct">0%</span>
+      </div>
+      <div class="w-full h-2 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden">
+        <div id="upload-progress-bar" class="h-2 rounded-full bg-primary-600 transition-all duration-300" style="width: 0%"></div>
+      </div>
+    </div>
+    <p id="upload-error" class="hidden mt-2 text-sm text-red-600"></p>
   </form>
 </div>
 
@@ -154,4 +164,103 @@
   {% endfor %}
 </div>
 {% endif %}
+{% endblock %}
+
+{% block footer_scripts %}
+<script>
+(function () {
+  var form = document.getElementById('upload-form');
+  if (!form) return;
+  var progressWrap = document.getElementById('upload-progress');
+  var progressBar = document.getElementById('upload-progress-bar');
+  var progressPct = document.getElementById('upload-progress-pct');
+  var progressLabel = document.getElementById('upload-progress-label');
+  var errorEl = document.getElementById('upload-error');
+  var buttons = form.querySelectorAll('button[type="submit"]');
+
+  var uploading = false;
+
+  // Fallback for browsers without SubmitEvent.submitter.
+  var lastClickedButton = null;
+  buttons.forEach(function (btn) {
+    btn.addEventListener('click', function () { lastClickedButton = btn; });
+  });
+
+  function warnBeforeUnload(e) {
+    if (!uploading) return;
+    e.preventDefault();
+    // Required for the confirmation dialog in some browsers.
+    e.returnValue = '';
+  }
+  window.addEventListener('beforeunload', warnBeforeUnload);
+
+  function setButtonsDisabled(disabled) {
+    buttons.forEach(function (btn) {
+      btn.disabled = disabled;
+      btn.classList.toggle('opacity-50', disabled);
+      btn.classList.toggle('cursor-not-allowed', disabled);
+    });
+  }
+
+  function showError(message) {
+    uploading = false;
+    progressWrap.classList.add('hidden');
+    errorEl.textContent = message;
+    errorEl.classList.remove('hidden');
+    setButtonsDisabled(false);
+  }
+
+  form.addEventListener('submit', function (e) {
+    e.preventDefault();
+
+    var formData = new FormData(form);
+    var submitter = e.submitter || lastClickedButton;
+    if (submitter && submitter.name) {
+      formData.append(submitter.name, submitter.value);
+    }
+
+    errorEl.classList.add('hidden');
+    progressLabel.textContent = 'Uploading…';
+    progressBar.style.width = '0%';
+    progressPct.textContent = '0%';
+    progressWrap.classList.remove('hidden');
+    setButtonsDisabled(true);
+    uploading = true;
+
+    var xhr = new XMLHttpRequest();
+    // form.action would resolve to the submit buttons (name="action"),
+    // which shadow the form's action property, so read the attribute.
+    xhr.open('POST', form.getAttribute('action'));
+    xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+    xhr.responseType = 'json';
+
+    xhr.upload.addEventListener('progress', function (ev) {
+      if (!ev.lengthComputable) return;
+      var pct = Math.round((ev.loaded / ev.total) * 100);
+      progressBar.style.width = pct + '%';
+      progressPct.textContent = pct + '%';
+      if (pct >= 100) {
+        // The browser is done sending; the server is still saving the
+        // file (and pushing it to S3 in prod) before it responds.
+        progressLabel.textContent = 'Processing upload, this may take a while…';
+      }
+    });
+
+    xhr.addEventListener('load', function () {
+      if (xhr.status >= 200 && xhr.status < 300 && xhr.response && xhr.response.redirect) {
+        uploading = false;
+        window.location.assign(xhr.response.redirect);
+      } else {
+        showError('Upload failed (status ' + xhr.status + '). Please try again.');
+      }
+    });
+
+    xhr.addEventListener('error', function () {
+      showError('Upload failed: network error. Please check your connection and try again.');
+    });
+
+    xhr.send(formData);
+  });
+})();
+</script>
 {% endblock %}

--- a/scanning/tests/test_views.py
+++ b/scanning/tests/test_views.py
@@ -324,6 +324,114 @@ class TestVolumeQueueStatusIntegration(ScanningTestCase):
         self.assertEqual(volume.queue_status, QueueStatus.SCANNING)
 
 
+class TestQueueUploadXhr(ScanningTestCase):
+    """XHR uploads get a JSON redirect instead of a 302."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = self.make_user()
+        self.client.force_login(self.user)
+        self.volume = VolumeFactory()
+        self.url = reverse(
+            "queue_upload",
+            kwargs={
+                "reporter_slug": self.volume.reporter.short_name,
+                "vol": self.volume.volume_number,
+            },
+        )
+        self.queue_url = reverse(
+            "queue_detail",
+            kwargs={
+                "reporter_slug": self.volume.reporter.short_name,
+                "vol": self.volume.volume_number,
+            },
+        )
+
+    @override_settings(DEVELOPMENT=True)
+    def test_xhr_upload_returns_json_redirect(self):
+        pdf = SimpleUploadedFile(
+            "scan.pdf", b"%PDF-1.4 body", content_type="application/pdf"
+        )
+        response = self.client.post(
+            self.url,
+            {"new_scan": "1", "original_pdf": pdf},
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["redirect"], self.queue_url)
+
+    @override_settings(DEVELOPMENT=True)
+    def test_xhr_upload_validate_redirects_to_process(self):
+        pdf = SimpleUploadedFile(
+            "scan.pdf", b"%PDF-1.4 body", content_type="application/pdf"
+        )
+        response = self.client.post(
+            self.url,
+            {
+                "new_scan": "1",
+                "original_pdf": pdf,
+                "action": "upload_validate",
+            },
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        self.assertEqual(response.status_code, 200)
+        scan = Scan.objects.get(volume_obj=self.volume)
+        self.assertEqual(
+            response.json()["redirect"],
+            reverse("scan_process", kwargs={"pk": scan.pk}),
+        )
+
+    def test_xhr_invalid_pdf_returns_json_redirect(self):
+        fake = SimpleUploadedFile(
+            "scan.pdf", b"not a pdf", content_type="application/pdf"
+        )
+        response = self.client.post(
+            self.url,
+            {"new_scan": "1", "original_pdf": fake},
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["redirect"], self.queue_url)
+        self.assertFalse(Scan.objects.filter(volume_obj=self.volume).exists())
+
+    @override_settings(DEVELOPMENT=False)
+    def test_xhr_prod_upload_returns_json_redirect(self):
+        pdf = SimpleUploadedFile(
+            "scan.pdf", b"%PDF-1.4 body", content_type="application/pdf"
+        )
+        with (
+            patch("scanning.views.has_s3_credentials", return_value=True),
+            patch(
+                "scanning.s3_sync.upload_file_to_s3", return_value=True
+            ) as mock_upload,
+        ):
+            response = self.client.post(
+                self.url,
+                {"new_scan": "1", "original_pdf": pdf},
+                HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["redirect"], self.queue_url)
+        mock_upload.assert_called_once()
+        scan = Scan.objects.get(volume_obj=self.volume)
+        self.assertTrue(scan.original_pdf.name)
+
+    @override_settings(DEVELOPMENT=False)
+    def test_xhr_prod_upload_without_credentials_returns_json_redirect(self):
+        pdf = SimpleUploadedFile(
+            "scan.pdf", b"%PDF-1.4 body", content_type="application/pdf"
+        )
+        with patch("scanning.views.has_s3_credentials", return_value=False):
+            response = self.client.post(
+                self.url,
+                {"new_scan": "1", "original_pdf": pdf},
+                HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["redirect"], self.queue_url)
+        self.assertFalse(Scan.objects.filter(volume_obj=self.volume).exists())
+
+
 class TestQueueView(ScanningTestCase):
     """The queue page renders and paginates volumes."""
 

--- a/scanning/views.py
+++ b/scanning/views.py
@@ -12,8 +12,9 @@ from django.contrib.auth.forms import PasswordChangeForm
 from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator
 from django.db.models import Count, Q
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.http import require_POST
 
@@ -433,6 +434,23 @@ def claim_scan(request, reporter_slug, vol):
     )
 
 
+def _upload_redirect(request: HttpRequest, url: str) -> HttpResponse:
+    """Send the post-upload destination to the client.
+
+    XHR uploads get the URL as JSON so the progress script can navigate
+    after the response arrives (a plain redirect would consume any queued
+    messages before the browser shows the page). Regular form posts get
+    an ordinary redirect.
+
+    :param request: The HTTP request.
+    :param url: Destination URL.
+    :return: A JSON payload for XHR requests, otherwise a redirect.
+    """
+    if request.headers.get("X-Requested-With") == "XMLHttpRequest":
+        return JsonResponse({"redirect": url})
+    return redirect(url)
+
+
 @login_required
 @require_POST
 def queue_upload(request, reporter_slug, vol):
@@ -444,6 +462,10 @@ def queue_upload(request, reporter_slug, vol):
     :return: Redirect to queue detail or scan processing page.
     """
     volume = get_volume(reporter_slug, vol)
+    queue_url = reverse(
+        "queue_detail",
+        kwargs={"reporter_slug": reporter_slug, "vol": vol},
+    )
 
     if request.POST.get("new_scan") == "1":
         # Create a new scan under this volume
@@ -459,38 +481,22 @@ def queue_upload(request, reporter_slug, vol):
         scan_pk = request.POST.get("scan_pk")
         if not scan_pk:
             messages.error(request, "No scan specified.")
-            return redirect(
-                "queue_detail",
-                reporter_slug=reporter_slug,
-                vol=vol,
-            )
+            return _upload_redirect(request, queue_url)
         scan = get_object_or_404(Scan, pk=scan_pk, volume_obj=volume)
     pdf = request.FILES.get("original_pdf")
     if not pdf:
         messages.error(request, "No PDF file provided.")
-        return redirect(
-            "queue_detail",
-            reporter_slug=reporter_slug,
-            vol=vol,
-        )
+        return _upload_redirect(request, queue_url)
 
     if not pdf.name.lower().endswith(".pdf"):
         messages.error(request, "Only PDF files are accepted.")
-        return redirect(
-            "queue_detail",
-            reporter_slug=reporter_slug,
-            vol=vol,
-        )
+        return _upload_redirect(request, queue_url)
 
     header = pdf.read(5)
     pdf.seek(0)
     if header != b"%PDF-":
         messages.error(request, "The uploaded file is not a valid PDF.")
-        return redirect(
-            "queue_detail",
-            reporter_slug=reporter_slug,
-            vol=vol,
-        )
+        return _upload_redirect(request, queue_url)
 
     # Update page range if provided
     first_page = request.POST.get("first_page", "").strip()
@@ -544,11 +550,7 @@ def queue_upload(request, reporter_slug, vol):
                 request,
                 "Storage is not configured; contact an administrator.",
             )
-            return redirect(
-                "queue_detail",
-                reporter_slug=reporter_slug,
-                vol=vol,
-            )
+            return _upload_redirect(request, queue_url)
 
         try:
             uploaded = s3_sync.upload_file_to_s3(scan, original_name)
@@ -563,11 +565,7 @@ def queue_upload(request, reporter_slug, vol):
                 request,
                 "Upload to storage failed. Please try again in a moment.",
             )
-            return redirect(
-                "queue_detail",
-                reporter_slug=reporter_slug,
-                vol=vol,
-            )
+            return _upload_redirect(request, queue_url)
         scan.original_pdf.name = original_name
         scan.save(update_fields=["original_pdf"])
 
@@ -579,15 +577,13 @@ def queue_upload(request, reporter_slug, vol):
         scan.progress_message = "Queued for processing..."
         scan.save()
         refresh_volume_queue_status_for_scan(scan)
-        return redirect("scan_process", pk=scan.pk)
+        return _upload_redirect(
+            request, reverse("scan_process", kwargs={"pk": scan.pk})
+        )
 
     refresh_volume_queue_status_for_scan(scan)
     messages.success(request, "PDF uploaded successfully.")
-    return redirect(
-        "queue_detail",
-        reporter_slug=reporter_slug,
-        vol=vol,
-    )
+    return _upload_redirect(request, queue_url)
 
 
 @login_required


### PR DESCRIPTION
Fixes #86

Scan uploads are 1-2 GB PDFs submitted through a plain form POST, so the page just hung with no feedback for the several minutes the transfer takes.

The upload form on the queue detail page now submits via `XMLHttpRequest` and renders a progress bar with a live percentage from the browser's upload progress events. Once the file finishes sending, the label switches to "Processing upload, this may take a while…" to cover the server-side phase (writing the file to disk, and pushing it to S3 in prod), which previously looked like a freeze at 100%.

Details:

- `queue_upload` returns `{"redirect": url}` as JSON when the request comes from the XHR (detected via `X-Requested-With`), and the script navigates with `window.location.assign()`. If the XHR followed the normal 302 itself, Django's success/error messages would be consumed by the throwaway XHR response and never shown to the user. Non-JS form posts still get the regular redirect, so the form keeps working without JavaScript.
- The clicked submit button's `action` value is appended to the `FormData` manually, so Upload & Validate vs Upload Only still works (with a fallback for browsers without `SubmitEvent.submitter`).
- Submit buttons are disabled while an upload is in flight, and a `beforeunload` guard warns before leaving the page mid-upload, since refreshing aborts the request and silently loses the upload.
- Network and HTTP failures show an inline error and re-enable the form.

Verified locally against the dev server with 1 GB and 2.2 GB files (the latter to rule out 2 GiB content-length issues); both completed and returned the JSON redirect, and queued messages render on the page after navigation.

<img width="1308" height="457" alt="Captura desde 2026-06-10 17-04-06" src="https://github.com/user-attachments/assets/edb5958a-f6c9-4a44-bc05-b648ba905620" />

<img width="1308" height="457" alt="Captura desde 2026-06-10 17-04-10" src="https://github.com/user-attachments/assets/77ff55ee-9ed2-464f-ae64-1bd56b87c492" />

