### PR TITLE
fix(scanning): downgrade expected NO_GPU logs, error only on exhausted retries

### DIFF
--- a/scanning/runpod/handler.py
+++ b/scanning/runpod/handler.py
@@ -136,7 +136,12 @@ def _preload() -> None:
         # the scanning daemon classifies as transient and re-queues the
         # scan (up to RUNPOD_MAX_TRANSIENT_RETRIES attempts) for the next
         # tick to resubmit to a different worker.
-        logger.error(
+        #
+        # Logged at warning, not error: this is expected and fully
+        # self-healing, so it must not raise a Sentry event. The daemon
+        # escalates to error only if a scan actually exhausts its
+        # transient retries.
+        logger.warning(
             "GPU not available; skipping weight/model preload. Jobs "
             "will return error_code=NO_GPU; scans are re-queued "
             "automatically by the daemon."
@@ -719,8 +724,10 @@ def handler(job: dict) -> dict:
     if not _CUDA_AVAILABLE:
         # error_code=NO_GPU is in scanning's _TRANSIENT_ERROR_CODES, so
         # the daemon re-queues the scan (up to RUNPOD_MAX_TRANSIENT_RETRIES
-        # attempts) and the next tick lands on a different worker.
-        logger.error(
+        # attempts) and the next tick lands on a different worker. Logged
+        # at warning, not error: expected and self-healing, so no Sentry
+        # event (the daemon escalates only on exhausted retries).
+        logger.warning(
             "rejecting %s job for scan %s: no GPU on this worker; "
             "daemon will re-queue.",
             action,

--- a/scanning/services.py
+++ b/scanning/services.py
@@ -237,7 +237,10 @@ def _handle_pipeline_exception(
         except Scan.DoesNotExist:
             return
         if scan.status == Status.ERROR_MAX_RETRIES:
-            logger.warning(
+            # Error level (raises a Sentry event): the transient retries
+            # are exhausted, so this is no longer self-healing and likely
+            # signals a real RunPod capacity shortage worth investigating.
+            logger.error(
                 "[%s] scan %s transient RunPod failure, max retries (%d) exceeded: %s",
                 context,
                 scan_pk,


### PR DESCRIPTION
The `NO_GPU` path is expected and fully self-healing: the worker fitness check (`_require_gpu`) keeps GPU-less workers out of the pool, and any job that slips through returns `error_code=NO_GPU`, which the daemon classifies as transient and auto re-queues (up to `RUNPOD_MAX_TRANSIENT_RETRIES`). Despite that, the worker logged it at `error` level, so it surfaced in Sentry (SCANNING-1M: 707 events over 18 days, 0 users impacted) as pure noise.

This shifts the log levels so Sentry only fires when something is actually actionable:

- `_preload` and the per-job reject in the handler now log at `warning` (expected and self-healing, breadcrumb only, no Sentry event).
- The daemon's `ERROR_MAX_RETRIES` branch now logs at `error`, so Sentry alerts exactly once when a scan exhausts its transient retries, which is the signal for a real RunPod capacity shortage worth investigating.

Verified against Sentry that no `ERROR_MAX_RETRIES` or per-job-reject issues exist today, confirming the self-healing works and this was log noise rather than a correctness problem.

Closes #89