### PR TITLE
fix(scanning): avoid duplicate PDF fetch on opinion viewer load

### DIFF
--- a/scanning/templates/scanning/opinion_detail.html
+++ b/scanning/templates/scanning/opinion_detail.html
@@ -157,7 +157,11 @@ function loadPdf(url) {
 
 function switchTab(btn) {
     var url = btn.getAttribute('data-url');
-    loadPdf(url);
+    // Only (re)load when the variant actually changed. On initial load the
+    // DOMContentLoaded handler already loads _currentUrl, so the styling-only
+    // switchTab call for original-only opinions must not trigger a second
+    // fetch of the same PDF (the serve endpoint lazily pulls from S3).
+    if (url !== _currentUrl) loadPdf(url);
 
     document.querySelectorAll('.pdf-tab').forEach(function(t) {
         t.className = 'pdf-tab text-sm px-4 py-2 font-medium rounded-t border border-b-0 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700/50 -mb-px';


### PR DESCRIPTION
## Summary

On the opinion detail page, opinions that have **only an original PDF** (no redacted variant) fetch the `serve_opinionscan_pdf` endpoint twice on initial load. Since that endpoint lazily pulls the scan's entire processing directory from S3 on a cache miss, the duplicate request compounds the load latency the new spinner (#96) is meant to cover.

## Why it happens

In `scanning/templates/scanning/opinion_detail.html`, the `DOMContentLoaded` handler loads `_currentUrl`, then — for original-only opinions — calls `switchTab` solely to apply the active-tab highlight (the template hardcodes the `active` class on the Redacted tab only). But `switchTab` also called `loadPdf`, firing a second fetch of the same URL.

The load-token guard from #96 suppresses the duplicate *render*, but the second `getDocument()` request still goes out before any token check runs.

## Fix

Guard the reload inside `switchTab` so it only fetches when the variant actually changed:

```js
if (url !== _currentUrl) loadPdf(url);
```

The styling update still runs unconditionally, so the active-tab highlight is unaffected. As a side benefit, re-clicking the already-active tab no longer triggers a redundant reload.

Closes #98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)