### PR TITLE
fix(scanning): resolve viewer highlights/navigation by pdf_index and speed up step-2 jumps

### DIFF
--- a/scanning/static/scanning/shared.js
+++ b/scanning/static/scanning/shared.js
@@ -339,3 +339,20 @@ function drawExistingRedactions(overlay, pageRedactions, scale) {
         }
     });
 }
+
+// Jump to a lazy-rendered page element without a scroll animation. Pages start
+// at a placeholder height and grow to their true height once rasterized, which
+// shifts everything below them; so after jumping we re-align until the target
+// stops moving (capped) instead of animating through every page in between.
+window.scrollPageIntoView = function (el) {
+    if (!el) return;
+    var tries = 0;
+    (function settle() {
+        var before = el.getBoundingClientRect().top;
+        el.scrollIntoView({ block: 'start' });
+        var after = el.getBoundingClientRect().top;
+        if (++tries < 10 && Math.abs(after - before) > 2) {
+            setTimeout(settle, 90);
+        }
+    })();
+};

--- a/scanning/static/scanning/viewer_progress.js
+++ b/scanning/static/scanning/viewer_progress.js
@@ -80,9 +80,9 @@
             html +=
                 '<div class="rounded px-2 py-0.5 mb-0.5 cursor-pointer text-xs flex items-center justify-between ' +
                 bg +
-                "\" onclick=\"goToPage(" +
-                r.pdf_page +
-                ')\">';
+                "\" data-pdf-index=\"" +
+                (r.pdf_page - 1) +
+                "\" onclick=\"goToPage(this)\">";
             html +=
                 '<span><span class="font-medium text-gray-500">' +
                 r.pdf_page +

--- a/scanning/static/scanning/viewer_sidebar.js
+++ b/scanning/static/scanning/viewer_sidebar.js
@@ -267,7 +267,7 @@ function goToPage(elOrNum) {
             '.lazy-page[data-pdf-index="' + elOrNum.dataset.pdfIndex + '"]'
         );
         if (pel) {
-            pel.scrollIntoView({ behavior: "smooth", block: "start" });
+            window.scrollPageIntoView(pel);
             pel.style.outline = "3px solid #2563eb";
             setTimeout(function () {
                 pel.style.outline = "";
@@ -280,7 +280,7 @@ function goToPage(elOrNum) {
         document.getElementById("pv-page-" + pageNum) ||
         document.getElementById("page-" + pageNum);
     if (el) {
-        el.scrollIntoView({ behavior: "smooth", block: "start" });
+        window.scrollPageIntoView(el);
         el.style.outline = "3px solid #2563eb";
         setTimeout(function () {
             el.style.outline = "";
@@ -303,7 +303,7 @@ function highlightDetection(el) {
         '.lazy-page[data-pdf-index="' + d.pageIndex + '"]'
     );
     if (!container) return;
-    container.scrollIntoView({ behavior: "smooth", block: "start" });
+    window.scrollPageIntoView(container);
     container.style.outline = "3px solid #2563eb";
     setTimeout(function () {
         container.style.outline = "";

--- a/scanning/static/scanning/viewer_sidebar.js
+++ b/scanning/static/scanning/viewer_sidebar.js
@@ -259,6 +259,22 @@ var _opinions = [];
 // --- Global functions (called from template onclick handlers) ---
 
 function goToPage(elOrNum) {
+    // Opinion image/headnote badges carry data-pdf-index: resolve to that
+    // exact page. Logical page numbers can repeat (e.g. unnumbered front
+    // matter borrowing the real pages' numbers), so pdf_index is unambiguous.
+    if (typeof elOrNum === "object" && elOrNum.dataset.pdfIndex !== undefined) {
+        var pel = document.querySelector(
+            '.lazy-page[data-pdf-index="' + elOrNum.dataset.pdfIndex + '"]'
+        );
+        if (pel) {
+            pel.scrollIntoView({ behavior: "smooth", block: "start" });
+            pel.style.outline = "3px solid #2563eb";
+            setTimeout(function () {
+                pel.style.outline = "";
+            }, 2000);
+        }
+        return;
+    }
     var pageNum = (typeof elOrNum === "object") ? elOrNum.dataset.page : elOrNum;
     var el =
         document.getElementById("pv-page-" + pageNum) ||

--- a/scanning/static/scanning/viewer_step1.js
+++ b/scanning/static/scanning/viewer_step1.js
@@ -702,29 +702,6 @@ document.addEventListener('DOMContentLoaded', function () {
     };
 
     // --- Scroll to page ---
-    // Lazy-rendered pages start at a fixed placeholder height and resize to
-    // their true height once rasterized, which shifts everything below them.
-    // A single jump to a far page therefore lands off-target (and a smooth
-    // scroll makes it worse by rendering every page it passes). Jump
-    // instantly, then re-align over a few frames until the target stops
-    // moving (i.e. the pages above it have settled to their real heights).
-    function scrollToPdfPage(el) {
-        var tries = 0;
-        (function settle() {
-            // Measure where the target sits now (it may have drifted while the
-            // pages above it finished rasterizing), then realign it.
-            var before = el.getBoundingClientRect().top;
-            el.scrollIntoView({ block: 'start' });
-            var after = el.getBoundingClientRect().top;
-            tries++;
-            // If realigning barely moved it, layout has settled → stop.
-            // Otherwise wait for the next render pass and correct again.
-            if (tries < 10 && Math.abs(after - before) > 2) {
-                setTimeout(settle, 90);
-            }
-        })();
-    }
-
     window.goToPage = function (elOrNum) {
         // Accepts an element or a number.
         //  - OCR "Pages" list items carry data-pdf-index: jump to that exact
@@ -743,7 +720,7 @@ document.addEventListener('DOMContentLoaded', function () {
                  || document.getElementById('page-' + pageNumber);
         }
         if (el) {
-            scrollToPdfPage(el);
+            window.scrollPageIntoView(el);
             el.classList.add('highlight');
             setTimeout(function () { el.classList.remove('highlight'); }, 2000);
         }

--- a/scanning/static/scanning/viewer_step1.js
+++ b/scanning/static/scanning/viewer_step1.js
@@ -9,7 +9,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const pdfUrl = container.dataset.pdfUrl;
     const pageMap = JSON.parse(container.dataset.pageMap || '[]');
-    const flaggedPages = JSON.parse(container.dataset.flaggedPages || '[]');
+    const flaggedIndices = JSON.parse(container.dataset.flaggedIndices || '[]');
     const redactions = JSON.parse(container.dataset.redactions || '{}');
     const ocrByPage = JSON.parse(container.dataset.ocrByPage || '{}');
     const documentId = container.dataset.documentId;
@@ -58,7 +58,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     function createPdfPlaceholder(entry) {
         var pageDiv = createPageContainer(entry.logical_number, entry.pdf_index);
-        var isFlagged = flaggedPages.indexOf(entry.logical_number) !== -1;
+        var isFlagged = flaggedIndices.indexOf(entry.pdf_index) !== -1;
         if (isFlagged) {
             pageDiv.classList.add('flagged');
         }
@@ -702,15 +702,48 @@ document.addEventListener('DOMContentLoaded', function () {
     };
 
     // --- Scroll to page ---
+    // Lazy-rendered pages start at a fixed placeholder height and resize to
+    // their true height once rasterized, which shifts everything below them.
+    // A single jump to a far page therefore lands off-target (and a smooth
+    // scroll makes it worse by rendering every page it passes). Jump
+    // instantly, then re-align over a few frames until the target stops
+    // moving (i.e. the pages above it have settled to their real heights).
+    function scrollToPdfPage(el) {
+        var tries = 0;
+        (function settle() {
+            // Measure where the target sits now (it may have drifted while the
+            // pages above it finished rasterizing), then realign it.
+            var before = el.getBoundingClientRect().top;
+            el.scrollIntoView({ block: 'start' });
+            var after = el.getBoundingClientRect().top;
+            tries++;
+            // If realigning barely moved it, layout has settled → stop.
+            // Otherwise wait for the next render pass and correct again.
+            if (tries < 10 && Math.abs(after - before) > 2) {
+                setTimeout(settle, 90);
+            }
+        })();
+    }
+
     window.goToPage = function (elOrNum) {
-        // Accepts an element (with data-page) or a number.
-        // Issues pass logical page numbers; PDF containers store data-logical-number.
-        // OCR panel passes pdf_page (= pdf_index+1) so the ID fallback covers that case.
-        var pageNumber = (typeof elOrNum === 'object') ? elOrNum.dataset.page : elOrNum;
-        var el = container.querySelector('[data-logical-number="' + pageNumber + '"]')
+        // Accepts an element or a number.
+        //  - OCR "Pages" list items carry data-pdf-index: jump to that exact
+        //    PDF page. Unambiguous even when logical page numbers repeat (e.g.
+        //    unnumbered front matter borrowing the real pages' numbers, #90).
+        //  - Issue cards / image badges carry data-page (a logical page
+        //    number), resolved via data-logical-number with a page-<n> fallback.
+        var el;
+        if (typeof elOrNum === 'object' && elOrNum.dataset.pdfIndex !== undefined) {
+            el = container.querySelector(
+                '[data-pdf-index="' + elOrNum.dataset.pdfIndex + '"]'
+            );
+        } else {
+            var pageNumber = (typeof elOrNum === 'object') ? elOrNum.dataset.page : elOrNum;
+            el = container.querySelector('[data-logical-number="' + pageNumber + '"]')
                  || document.getElementById('page-' + pageNumber);
+        }
         if (el) {
-            el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            scrollToPdfPage(el);
             el.classList.add('highlight');
             setTimeout(function () { el.classList.remove('highlight'); }, 2000);
         }

--- a/scanning/static/scanning/viewer_step2.js
+++ b/scanning/static/scanning/viewer_step2.js
@@ -2222,7 +2222,7 @@ document.addEventListener('DOMContentLoaded', function () {
         if (redactionsVisible) drawRedactionOverlays();
         if (marginsVisible) drawMarginOverlays();
         var startEl = _pageDivForIndex(captionPage);
-        if (startEl) startEl.scrollIntoView({behavior: 'smooth', block: 'start'});
+        if (startEl) window.scrollPageIntoView(startEl);
     };
 
     // Click on viewer background to clear opinion highlight

--- a/scanning/static/scanning/viewer_step2.js
+++ b/scanning/static/scanning/viewer_step2.js
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', function () {
     var viewOnly = container.dataset.viewOnly === 'true';
     var opinionEditMode = container.dataset.opinionEdit === 'true';
     var pageMap = JSON.parse(container.dataset.pageMap || '[]');
-    var flaggedPages = JSON.parse(container.dataset.flaggedPages || '[]');
+    var flaggedIndices = JSON.parse(container.dataset.flaggedIndices || '[]');
     var ocrByPage = JSON.parse(container.dataset.ocrByPage || '{}');
 
     // Map page_index → logical_number from pageMap (display only)
@@ -205,8 +205,9 @@ document.addEventListener('DOMContentLoaded', function () {
         div.dataset.pdfIndex = entry.pdf_index;
         div.dataset.pageNum = pageNum;
 
-        // Flagged?
-        if (flaggedPages.indexOf(pageNum) !== -1) {
+        // Flagged? (match by pdf_index: logical numbers can repeat, e.g.
+        // unnumbered front matter borrowing the real pages' numbers)
+        if (flaggedIndices.indexOf(entry.pdf_index) !== -1) {
             div.classList.add('flagged');
         }
         // Duplicate?

--- a/scanning/static/scanning/viewer_step2.js
+++ b/scanning/static/scanning/viewer_step2.js
@@ -63,6 +63,23 @@ document.addEventListener('DOMContentLoaded', function () {
     // Detection overlay state
     var allDetections = null; // loaded once from API
     var detectionsVisible = {}; // { pdfIndex: true/false }
+
+    // Per-page detection index so each page render doesn't scan the whole
+    // detection list. Rebuilt when allDetections is reassigned or grows.
+    var _detIndex = null, _detIndexSrc = null, _detIndexLen = -1;
+    function _detectionsForPage(pageIdx) {
+        if (!allDetections) return [];
+        if (_detIndexSrc !== allDetections || _detIndexLen !== allDetections.length) {
+            _detIndex = {};
+            for (var i = 0; i < allDetections.length; i++) {
+                var d = allDetections[i];
+                (_detIndex[d.page_index] || (_detIndex[d.page_index] = [])).push(d);
+            }
+            _detIndexSrc = allDetections;
+            _detIndexLen = allDetections.length;
+        }
+        return _detIndex[pageIdx] || [];
+    }
     var cachedImgW = 0, cachedImgH = 0; // persist image dimensions across reloads
 
     // Draw detection mode state
@@ -508,7 +525,7 @@ document.addEventListener('DOMContentLoaded', function () {
                         drawRedactionOverlaysForPage(pdfIndex);
                     }
                     if (marginsVisible && marginRects) {
-                        drawMarginOverlays();
+                        drawMarginsForPage(pdfIndex);
                     }
                     if (overlayMode === 'bounds' && _boundsPageOwners) {
                         _drawBoundsForPage(pageDiv);
@@ -523,8 +540,8 @@ document.addEventListener('DOMContentLoaded', function () {
             // Overlay original PDF crops for IMAGE detections
             if (allDetections && !_viewingOpinion) {
                 var pageIdx = parseInt(pageDiv.dataset.pdfIndex);
-                var imgDets = allDetections.filter(function(d) {
-                    return d.page_index === pageIdx && d.label === 'IMAGE';
+                var imgDets = _detectionsForPage(pageIdx).filter(function(d) {
+                    return d.label === 'IMAGE';
                 });
                 if (imgDets.length > 0) {
                     var canvasW = viewport.width;
@@ -833,8 +850,8 @@ document.addEventListener('DOMContentLoaded', function () {
             CASE_SEQUENCE: true, HEADNOTE: true, CASE_METADATA: true,
             FOOTNOTES: true, IMAGE: true,
         };
-        var pageDets = allDetections.filter(function (d) {
-            return d.page_index === pdfIndex && (d.manual || USED_LABELS[d.label]);
+        var pageDets = _detectionsForPage(pdfIndex).filter(function (d) {
+            return d.manual || USED_LABELS[d.label];
         });
         if (!pageDets.length) return;
 
@@ -1413,25 +1430,40 @@ document.addEventListener('DOMContentLoaded', function () {
         }
     };
 
-    function drawMarginOverlays() {
-        clearOverlaysByClass('margin-overlay-box');
-        if (!marginRects || !marginsVisible) return;
+    // Per-page margin index so each render looks up its page in O(1) instead
+    // of scanning marginRects. Rebuilt when marginRects is reassigned or grows.
+    var _marginIndex = null, _marginIndexSrc = null, _marginIndexLen = -1;
+    function _marginsForPage(pageIndex) {
+        if (!marginRects) return null;
+        if (_marginIndexSrc !== marginRects || _marginIndexLen !== marginRects.length) {
+            _marginIndex = {};
+            for (var i = 0; i < marginRects.length; i++) {
+                _marginIndex[marginRects[i].page_index] = marginRects[i];
+            }
+            _marginIndexSrc = marginRects;
+            _marginIndexLen = marginRects.length;
+        }
+        return _marginIndex[pageIndex] || null;
+    }
 
-        marginRects.forEach(function(pageData) {
-            var pageEl = _pageDivForIndex(pageData.page_index);
-            if (!pageEl) return;
-            var wrapper = pageEl.querySelector('.canvas-wrapper');
-            var canvas = pageEl.querySelector('.pdf-canvas');
-            if (!wrapper || !canvas) return;
+    // Draw the margin boxes for a single page's data. Clears only that page's
+    // boxes so it can be called per-render without touching other pages.
+    function _drawMarginsForPageData(pageData) {
+        var pageEl = _pageDivForIndex(pageData.page_index);
+        if (!pageEl) return;
+        var wrapper = pageEl.querySelector('.canvas-wrapper');
+        var canvas = pageEl.querySelector('.pdf-canvas');
+        if (!wrapper || !canvas) return;
+        wrapper.querySelectorAll('.margin-overlay-box').forEach(function (el) { el.remove(); });
 
-            // Margin rects are in PDF points — scale via viewport
-            var pdfPage = pdfPages[pageData.page_index];
-            if (!pdfPage) return;
-            var vp = pdfPage.getViewport({scale: 1});
-            var msx = canvas.offsetWidth / vp.width;
-            var msy = canvas.offsetHeight / vp.height;
+        // Margin rects are in PDF points — scale via viewport
+        var pdfPage = pdfPages[pageData.page_index];
+        if (!pdfPage) return;
+        var vp = pdfPage.getViewport({scale: 1});
+        var msx = canvas.offsetWidth / vp.width;
+        var msy = canvas.offsetHeight / vp.height;
 
-            pageData.rects.forEach(function(r) {
+        pageData.rects.forEach(function(r) {
                 var div = document.createElement('div');
                 div.className = 'margin-overlay-box';
                 div.style.position = 'absolute';
@@ -1456,7 +1488,30 @@ document.addEventListener('DOMContentLoaded', function () {
 
                 wrapper.appendChild(div);
             });
-        });
+    }
+
+    // Redraw the whole document's margin overlays (used when toggling on).
+    function drawMarginOverlays() {
+        clearOverlaysByClass('margin-overlay-box');
+        if (!marginRects || !marginsVisible) return;
+        marginRects.forEach(_drawMarginsForPageData);
+    }
+
+    // Redraw margins for a single page (used on each lazy page render so we
+    // don't re-clear and re-draw the entire document's margins per page).
+    function drawMarginsForPage(pageIndex) {
+        if (!marginRects || !marginsVisible) return;
+        var pageData = _marginsForPage(pageIndex);
+        if (pageData) {
+            _drawMarginsForPageData(pageData);
+            return;
+        }
+        // No margins on this page: clear any stale boxes left on it.
+        var pageEl = _pageDivForIndex(pageIndex);
+        if (pageEl) {
+            var w = pageEl.querySelector('.canvas-wrapper');
+            if (w) w.querySelectorAll('.margin-overlay-box').forEach(function (el) { el.remove(); });
+        }
     }
 
     // ── Redaction overlay ──
@@ -2219,8 +2274,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
         _highlightedOpinion = {start: captionPage, end: keyPage};
         _currentViewPage = captionPage;
-        if (redactionsVisible) drawRedactionOverlays();
-        if (marginsVisible) drawMarginOverlays();
+        // Redaction/margin overlays are already drawn per page at render time
+        // and don't change when selecting an opinion. Redrawing the whole
+        // document here forced a ~1.4s reflow (layout thrash) on every click.
         var startEl = _pageDivForIndex(captionPage);
         if (startEl) window.scrollPageIntoView(startEl);
     };
@@ -2233,8 +2289,6 @@ document.addEventListener('DOMContentLoaded', function () {
             _highlightedOpinion = null;
             _currentOpIndex = -1;
             document.querySelectorAll('.opinion-card').forEach(function(c) { c.classList.remove('selected'); });
-            if (redactionsVisible) drawRedactionOverlays();
-            if (marginsVisible) drawMarginOverlays();
         }
     });
 

--- a/scanning/templates/scanning/scan_process.html
+++ b/scanning/templates/scanning/scan_process.html
@@ -83,9 +83,9 @@
            {% if issue.severity == 'error' %}border-red-300 bg-red-50 dark:border-red-700 dark:bg-red-900/20{% elif issue.severity == 'warning' %}border-yellow-300 bg-yellow-50 dark:border-yellow-700 dark:bg-yellow-900/20{% else %}border-blue-300 bg-blue-50 dark:border-blue-700 dark:bg-blue-900/20{% endif %}"
            data-message="{{ issue.message }}"
            data-check="{{ issue.check_name }}"
-           {% if issue.page_number %}data-page="{{ issue.page_number }}"{% endif %}
-           {% if issue.check_name == 'duplicate_page' and issue.page_number %}onclick="if(window.showDuplicates) showDuplicates(this.dataset.page); else goToPage(this)"
-           {% elif issue.page_number %}onclick="goToPage(this)"{% endif %}>
+           {% if issue.check_name == 'duplicate_page' and issue.page_number %}data-page="{{ issue.page_number }}" onclick="if(window.showDuplicates) showDuplicates(this.dataset.page); else goToPage(this)"
+           {% elif issue.nav_pdf_index is not None %}data-pdf-index="{{ issue.nav_pdf_index }}" onclick="goToPage(this)"
+           {% elif issue.page_number %}data-page="{{ issue.page_number }}" onclick="goToPage(this)"{% endif %}>
         <div class="flex items-center gap-1.5">
           <span class="font-bold uppercase text-[10px]">{{ issue.get_severity_display }}</span>
           {% if issue.page_number %}<span class="text-gray-500">Page {{ issue.page_number }}</span>{% endif %}
@@ -142,7 +142,7 @@
            {% elif r.seq_issue == 'duplicate' %}bg-orange-100 dark:bg-orange-900/30 border border-orange-300 dark:border-orange-700
            {% elif r.seq_issue == 'gap' %}bg-yellow-100 dark:bg-yellow-900/30 border border-yellow-300 dark:border-yellow-700
            {% else %}bg-green-50 dark:bg-green-900/20{% endif %}"
-           data-page="{{ r.pdf_page }}" onclick="goToPage(this)">
+           data-pdf-index="{{ r.pdf_page|add:'-1' }}" onclick="goToPage(this)">
         <span>
           <span class="font-medium text-gray-500">{{ r.pdf_page }}</span>
           {% if r.detected %}
@@ -241,8 +241,8 @@
       <div class="ml-4 mb-1 flex flex-wrap gap-0.5">
         {% for pg in op.image_pages %}
         <span class="text-[10px] px-1 py-0.5 rounded bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 border border-amber-200 dark:border-amber-800 cursor-pointer hover:bg-amber-200 dark:hover:bg-amber-900/50"
-              data-page="{{ pg }}" onclick="event.stopPropagation(); goToPage(this)"
-              title="Image on page {{ pg }}">🖼️ {{ pg }}</span>
+              data-pdf-index="{{ pg.idx }}" onclick="event.stopPropagation(); goToPage(this)"
+              title="Image on page {{ pg.num }}">🖼️ {{ pg.num }}</span>
         {% endfor %}
       </div>
       {% endif %}
@@ -250,8 +250,8 @@
       <div class="ml-4 mb-1 flex flex-wrap gap-0.5">
         {% for pg in op.uncovered_headnote_pages %}
         <span class="text-[10px]" style="border: 1px solid; padding: 3px; background-color: yellow"
-              data-page="{{ pg }}" onclick="event.stopPropagation(); goToPage(this)"
-              title="Uncovered headnote on page {{ pg }}">Page {{ pg }}</span>
+              data-pdf-index="{{ pg.idx }}" onclick="event.stopPropagation(); goToPage(this)"
+              title="Uncovered headnote on page {{ pg.num }}">Page {{ pg.num }}</span>
         {% endfor %}
       </div>
       {% endif %}
@@ -275,7 +275,7 @@
            data-pdf-url="{% if step == 3 %}{% else %}{% url 'serve_scan_pdf' scan.pk %}{% endif %}"
            data-document-id="{{ scan.pk }}"
            data-page-map='{{ page_map_json }}'
-           data-flagged-pages='{{ flagged_pages_json }}'
+           data-flagged-indices='{{ flagged_indices_json }}'
            data-redactions='{}'
            data-ocr-by-page='{{ ocr_by_page_json }}'
            {% if step == 3 %}data-opinion-edit="true"{% endif %}>

--- a/scanning/views_process.py
+++ b/scanning/views_process.py
@@ -140,7 +140,7 @@ def scan_process_view(request: HttpRequest, pk: int) -> HttpResponse:
         else:
             step = 1
 
-    issues = scan.issues.all()
+    issues = list(scan.issues.all())
     inserts = {ins.logical_page_number: ins for ins in scan.inserts.all()}
 
     page_map = scan.page_map
@@ -153,13 +153,43 @@ def scan_process_view(request: HttpRequest, pk: int) -> HttpResponse:
 
     # Map pdf_index → logical page number for navigation
     idx_to_logical = {}
+    logical_to_indices: dict[int, list[int]] = {}
     for entry in page_map:
         if entry.get("type") == "pdf_page":
             idx_to_logical[entry["pdf_index"]] = entry["logical_number"]
+            logical_to_indices.setdefault(entry["logical_number"], []).append(
+                entry["pdf_index"]
+            )
 
-    flagged_pages = sorted(
-        set(i.page_number for i in issues if i.page_number is not None)
-    )
+    # The viewer highlights flagged pages by pdf_index (a page's physical
+    # position), which is unique. An issue's ``page_number`` means a physical
+    # PDF page for some checks and a logical/printed page number for others;
+    # logical numbers can repeat when unnumbered front matter borrows numbers
+    # from the real pages (issue #90), so they must be resolved through the
+    # page_map rather than matched directly.
+    physical_page_checks = {
+        CheckName.NO_PAGE_NUMBER,
+        CheckName.SUSPICIOUS_READING,
+        CheckName.AUTO_CORRECTED,
+        CheckName.BLANK_PAGE,
+        CheckName.ORIENTATION,
+    }
+    flagged_indices: set[int] = set()
+    for i in issues:
+        # Resolve each issue to PDF page indices (unique physical positions),
+        # used both for the red-border highlight and for click-to-navigate.
+        # ``nav_pdf_index`` is the first resolved index, or None when the issue
+        # has no page (or points at a missing page absent from the page_map).
+        i.nav_pdf_index = None
+        if i.page_number is None:
+            continue
+        if i.check_name in physical_page_checks:
+            indices = [i.page_number - 1]
+        else:
+            indices = logical_to_indices.get(i.page_number, [])
+        flagged_indices.update(indices)
+        if indices:
+            i.nav_pdf_index = indices[0]
 
     ocr_results = scan.ocr_results
     ocr_by_page = {}
@@ -201,15 +231,17 @@ def scan_process_view(request: HttpRequest, pk: int) -> HttpResponse:
         ).values_list("page_index", flat=True)
     )
 
-    # Attach image_pages (logical page numbers) to each opinion
+    # Attach image_pages to each opinion. Each entry carries the logical
+    # number to display (``num``) and the pdf_index to navigate to (``idx``);
+    # logical numbers can repeat (#90), so navigation must use the index.
     for op in opinions:
         cp = op.get("caption_page", 0)
         ep = op.get("page_end", op.get("key_page", cp))
-        op["image_pages"] = sorted(
-            idx_to_logical.get(idx, idx + 1)
+        op["image_pages"] = [
+            {"num": idx_to_logical.get(idx, idx + 1), "idx": idx}
             for idx in range(cp, ep + 1)
             if idx in image_page_indices
-        )
+        ]
 
     has_redaction_rects = bool(scan.redaction_rects)
 
@@ -238,11 +270,11 @@ def scan_process_view(request: HttpRequest, pk: int) -> HttpResponse:
     for op in opinions:
         cp = op.get("caption_page", 0)
         ep = op.get("page_end", op.get("key_page", cp))
-        op["uncovered_headnote_pages"] = sorted(
-            idx_to_logical.get(idx, idx + 1)
+        op["uncovered_headnote_pages"] = [
+            {"num": idx_to_logical.get(idx, idx + 1), "idx": idx}
             for idx in range(cp, ep + 1)
             if idx in uncovered_hn_pages
-        )
+        ]
 
     opinion_scans = []
     if step == 3:
@@ -359,7 +391,7 @@ def scan_process_view(request: HttpRequest, pk: int) -> HttpResponse:
             "issues": issues,
             "page_map_json": json.dumps(page_map),
             "missing_pages": missing_pages,
-            "flagged_pages_json": json.dumps(flagged_pages),
+            "flagged_indices_json": json.dumps(sorted(flagged_indices)),
             "ocr_results": ocr_results,
             "ocr_by_page_json": json.dumps(ocr_by_page),
             "has_pending_changes": has_pending_changes,


### PR DESCRIPTION
## Summary

Fixes the step 1 and step 2 process viewers when a volume starts with unnumbered front matter (logical page numbers are not unique, so highlight/navigation keyed on them landed on the wrong page), and makes page jumps in step 2 fast. Related to #90.

## Changes

- Highlight flagged pages and navigate by `pdf_index` (not logical number) across both viewers: the sidebar "Pages" list, issue cards, and opinion image/headnote badges all resolve to the correct physical page (`data-flagged-pages` → `data-flagged-indices`).
- Jump without a scroll animation in both viewers: snap to the target, then re-align until it settles, instead of smooth-scrolling through every page in between.
- Fix the ~4s step-2 page jump: selecting/clearing an opinion no longer redraws every redaction/margin box across the whole document (that caused a ~1.4s forced reflow). Margins draw per page on render, and detection/margin lookups are O(1) per page.

## Notes

The false "DUPLICATE" badge from the same root cause is fixed in blackletter (freelawproject/blackletter#53); it takes effect once that is released and the dependency pin is bumped here.

Closes #100
