### PR TITLE
fix(scanning): mark page_map duplicates in step-1 sidebar

### DIFF
--- a/scanning/templates/scanning/scan_process.html
+++ b/scanning/templates/scanning/scan_process.html
@@ -129,27 +129,22 @@
           <span class="text-[9px] text-red-600 dark:text-red-400 font-bold whitespace-nowrap">ORDER</span>
           <div class="flex-1 border-t-2 border-dashed border-red-400"></div>
         </div>
-        {% elif r.seq_issue == 'duplicate' %}
-        <div class="flex items-center gap-1 my-1">
-          <div class="flex-1 border-t-2 border-dashed border-orange-400"></div>
-          <span class="text-[9px] text-orange-600 dark:text-orange-400 font-bold whitespace-nowrap">DUP</span>
-          <div class="flex-1 border-t-2 border-dashed border-orange-400"></div>
-        </div>
         {% endif %}
       <div class="rounded px-2 py-0.5 mb-0.5 cursor-pointer text-xs flex items-center justify-between
            {% if not r.detected %}bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800
            {% elif r.seq_issue == 'backward' %}bg-red-100 dark:bg-red-900/30 border border-red-300 dark:border-red-700
-           {% elif r.seq_issue == 'duplicate' %}bg-orange-100 dark:bg-orange-900/30 border border-orange-300 dark:border-orange-700
+           {% elif r.is_duplicate %}bg-orange-100 dark:bg-orange-900/30 border border-orange-300 dark:border-orange-700
            {% elif r.seq_issue == 'gap' %}bg-yellow-100 dark:bg-yellow-900/30 border border-yellow-300 dark:border-yellow-700
            {% else %}bg-green-50 dark:bg-green-900/20{% endif %}"
            data-pdf-index="{{ r.pdf_page|add:'-1' }}" onclick="goToPage(this)">
         <span>
           <span class="font-medium text-gray-500">{{ r.pdf_page }}</span>
           {% if r.detected %}
-          <span class="{% if r.seq_issue == 'backward' %}text-red-700 dark:text-red-300{% elif r.seq_issue == 'duplicate' %}text-orange-700 dark:text-orange-300{% elif r.seq_issue == 'gap' %}text-yellow-700 dark:text-yellow-300{% else %}text-green-700 dark:text-green-300{% endif %} font-semibold ml-1">#{{ r.detected }}</span>
+          <span class="{% if r.seq_issue == 'backward' %}text-red-700 dark:text-red-300{% elif r.is_duplicate %}text-orange-700 dark:text-orange-300{% elif r.seq_issue == 'gap' %}text-yellow-700 dark:text-yellow-300{% else %}text-green-700 dark:text-green-300{% endif %} font-semibold ml-1">#{{ r.detected }}</span>
           {% else %}
           <span class="text-red-600 dark:text-red-400 ml-1">—</span>
           {% endif %}
+          {% if r.is_duplicate %}<span class="text-[9px] font-bold text-orange-600 dark:text-orange-400 ml-1">DUP</span>{% endif %}
         </span>
         {% if r.type == 'range' %}<span class="text-[9px] text-blue-500">range</span>{% endif %}
         {% if r.zone == 'manual' %}<span class="text-[9px] text-purple-500">manual</span>{% endif %}

--- a/scanning/tests/test_views.py
+++ b/scanning/tests/test_views.py
@@ -1769,3 +1769,53 @@ class TestProcessActionsFragment(ScanningTestCase):
         self.assertIn(
             reverse("reprocess", kwargs={"pk": self.scan.pk}), body["html"]
         )
+
+
+@override_settings(MEDIA_ROOT=MEDIA_ROOT)
+class TestSidebarDuplicateMarkers(ScanningTestCase):
+    """The step-1 sidebar page list marks duplicates from the same
+    page_map data the PDF viewer uses, so the two views agree even when
+    the duplicate copies are not consecutive (the old consecutive-only
+    check missed those, leaving the viewer and sidebar inconsistent)."""
+
+    def setUp(self):
+        self.user = self.make_user()
+        self.client.force_login(self.user)
+        # Page 5's number repeats on pdf pages 1 and 3, separated by an
+        # undetected page so the sequence check resets and never sees the
+        # two "5"s as consecutive. Only the page_map carries the duplicate.
+        self.scan = ScanFactory(
+            uploaded_by=self.user,
+            status=Status.PENDING_REVIEW,
+            page_count=4,
+            ocr_results=[
+                {"pdf_page": 1, "detected": "5", "type": "single"},
+                {"pdf_page": 2, "detected": None, "type": None},
+                {"pdf_page": 3, "detected": "5", "type": "single"},
+                {"pdf_page": 4, "detected": "6", "type": "single"},
+            ],
+            page_map=[
+                {"type": "pdf_page", "pdf_index": 0, "logical_number": 5},
+                {"type": "pdf_page", "pdf_index": 1, "logical_number": 2},
+                {
+                    "type": "pdf_page",
+                    "pdf_index": 2,
+                    "logical_number": 5,
+                    "duplicate": True,
+                },
+                {"type": "pdf_page", "pdf_index": 3, "logical_number": 6},
+            ],
+        )
+
+    def test_page_map_duplicate_is_marked_in_sidebar(self):
+        """A page_map duplicate gets a DUP badge even when its copies are
+        not consecutive in the numbering sequence."""
+        response = self.client.get(
+            reverse("scan_process", kwargs={"pk": self.scan.pk}) + "?step=1"
+        )
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode()
+        # Exactly one duplicate (pdf page 3) is flagged, matching the single
+        # page_map duplicate, not zero (the old consecutive check) nor more.
+        self.assertEqual(html.count(">DUP<"), 1)
+        self.assertEqual(html.count("bg-orange-100"), 1)

--- a/scanning/tests/test_views.py
+++ b/scanning/tests/test_views.py
@@ -2,6 +2,7 @@ import io
 import json
 import os
 import pathlib
+import re
 import shutil
 import tempfile
 from datetime import timedelta
@@ -1815,7 +1816,27 @@ class TestSidebarDuplicateMarkers(ScanningTestCase):
         )
         self.assertEqual(response.status_code, 200)
         html = response.content.decode()
-        # Exactly one duplicate (pdf page 3) is flagged, matching the single
+        # Exactly one DUP badge is rendered (the consecutive-check divider was
+        # removed, so the badge is the only ">DUP<" left), matching the single
         # page_map duplicate, not zero (the old consecutive check) nor more.
         self.assertEqual(html.count(">DUP<"), 1)
-        self.assertEqual(html.count("bg-orange-100"), 1)
+        # The orange duplicate highlight must land on the right row. Each page
+        # row carries its classes next to a unique ``data-pdf-index``; scope
+        # the check to those rows so an unrelated bg-orange-100 elsewhere on
+        # the page can neither satisfy nor mask the assertion. pdf page 3 is
+        # pdf_index 2.
+        row_classes = {
+            int(idx): classes
+            for classes, idx in re.findall(
+                r'class="([^"]*)"\s+data-pdf-index="(\d+)"', html
+            )
+        }
+        self.assertIn("bg-orange-100", row_classes[2])
+        self.assertEqual(
+            [
+                idx
+                for idx, cls in row_classes.items()
+                if "bg-orange-100" in cls
+            ],
+            [2],
+        )

--- a/scanning/views_process.py
+++ b/scanning/views_process.py
@@ -161,6 +161,18 @@ def scan_process_view(request: HttpRequest, pk: int) -> HttpResponse:
                 entry["pdf_index"]
             )
 
+    # PDF page indices the page_map flags as duplicates (a detected page
+    # number that already appeared on an earlier page). The PDF viewer marks
+    # these with a DUPLICATE badge; the sidebar page list mirrors the same set
+    # so the two views stay consistent. Unlike a consecutive-only check this
+    # also catches duplicates whose copies are far apart (e.g. the same
+    # printed "page 1" appearing on several pages).
+    duplicate_indices = {
+        entry["pdf_index"]
+        for entry in page_map
+        if entry.get("type") == "pdf_page" and entry.get("duplicate")
+    }
+
     # The viewer highlights flagged pages by pdf_index (a page's physical
     # position), which is unique. An issue's ``page_number`` means a physical
     # PDF page for some checks and a logical/printed page number for others;
@@ -196,10 +208,13 @@ def scan_process_view(request: HttpRequest, pk: int) -> HttpResponse:
     for r in ocr_results:
         ocr_by_page[r["pdf_page"]] = r
 
-    # Annotate sequence issues for the sidebar page list
+    # Annotate sequence issues for the sidebar page list. Duplicates are taken
+    # from ``duplicate_indices`` (the same page_map data the viewer uses);
+    # ``seq_issue`` only covers ordering anomalies (backward / gap).
     prev_num = None
     for r in ocr_results:
         r["seq_issue"] = ""
+        r["is_duplicate"] = (r["pdf_page"] - 1) in duplicate_indices
         if not r.get("detected") or r.get("type") == "range":
             prev_num = None
             continue
@@ -210,9 +225,7 @@ def scan_process_view(request: HttpRequest, pk: int) -> HttpResponse:
             continue
         if prev_num is not None:
             diff = num - prev_num
-            if diff == 0:
-                r["seq_issue"] = "duplicate"
-            elif diff < 0:
+            if diff < 0:
                 r["seq_issue"] = "backward"
             elif diff > 2:
                 r["seq_issue"] = "gap"


### PR DESCRIPTION
The step-1 sidebar "Pages" list and the PDF viewer disagreed on which pages are duplicates. The viewer badges pages from `page_map.duplicate` (a detected page number that appeared earlier anywhere in the document), while the sidebar derived its marker from `seq_issue`, a consecutive-only check (`diff == 0` between adjacent detected numbers). When duplicate copies are not adjacent (the common case for repeated low numbers borrowed from unnumbered front matter, see #90), the sidebar showed nothing while the viewer showed a badge, so the only way to find those pages was to scroll the viewer.

This drives the sidebar duplicate marker from the same `page_map` data the viewer uses: the view computes a per-page `is_duplicate` flag from the page_map, and `seq_issue` is now limited to ordering anomalies (backward / gap). The misleading consecutive "DUP" divider is replaced with an inline `DUP` badge plus the existing orange row highlight, so the sidebar matches the viewer. Clicking a duplicate row still jumps to the page and highlights it.

The live-processing preview (`viewer_progress.js`) intentionally keeps the consecutive heuristic, since the `page_map` does not exist yet at poll time and a naive "seen-before" check there would reintroduce the front-matter false positives.

Verified on scan 1872: the sidebar now shows 7 `DUP` badges matching the viewer (previously 0). Added `TestSidebarDuplicateMarkers` covering a non-adjacent page_map duplicate; full view suite passes.

Closes #103
