### PR TITLE
fix(scanning): validate, clear, and refresh manual page-number edits

### DIFF
--- a/scanning/services.py
+++ b/scanning/services.py
@@ -1405,6 +1405,126 @@ def run_incremental_validation(scan_pk: int, pdf_path: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _split_detected(
+    ocr_results: list, exp_start: int | None, exp_end: int | None
+) -> tuple[list, dict]:
+    """Partition detected single page numbers into out-of-range and in-range.
+
+    A detected number is out of range when it is below 1 or, when an expected
+    range is known, falls more than 5 outside it. Range pages and pages
+    without a detected number are skipped.
+
+    :param ocr_results: Per-page OCR results.
+    :param exp_start: Expected first page number, or None.
+    :param exp_end: Expected last page number, or None.
+    :returns: ``(out_of_range, seen_nums)`` where ``seen_nums`` maps each
+        in-range number to the list of PDF pages it appears on.
+    :rtype: tuple[list, dict]
+    """
+    out_of_range: list = []
+    seen_nums: dict = {}
+    for r in ocr_results:
+        if not r["detected"] or r.get("type") == "range":
+            continue
+        try:
+            num = int(r["detected"])
+        except (ValueError, TypeError):
+            continue
+        if num < 1:
+            out_of_range.append(r)
+        elif exp_start is not None and (
+            num < exp_start - 5 or num > exp_end + 5
+        ):
+            out_of_range.append(r)
+        else:
+            seen_nums.setdefault(num, []).append(r["pdf_page"])
+    return out_of_range, seen_nums
+
+
+def _build_analysis(
+    ocr_results: list, exp_start: int | None, exp_end: int | None
+) -> dict:
+    """Analyze ocr_results into the structure ``_build_issues`` expects.
+
+    Computes out-of-range, duplicate, sequence, and missing-page data from
+    the current page numbers without re-running OCR or opening the PDF.
+
+    :param ocr_results: Per-page OCR results (already finalized).
+    :param exp_start: Expected first page number, or None.
+    :param exp_end: Expected last page number, or None.
+    :returns: The analysis dict consumed by ``_build_issues``.
+    :rtype: dict
+    """
+    out_of_range, seen_nums = _split_detected(ocr_results, exp_start, exp_end)
+    out_of_range_pages = {r["pdf_page"] for r in out_of_range}
+    all_nums = sorted(seen_nums.keys())
+    duplicates = {k: v for k, v in seen_nums.items() if len(v) > 1}
+    seq_issues = _detect_sequence_issues(ocr_results, out_of_range_pages)
+
+    range_re = re.compile(r"^(\d{1,4})\s*[–\-]\s*(\d{1,4})$")
+    range_pages = set()
+    ranges_found = [r for r in ocr_results if r.get("type") == "range"]
+    for r in ranges_found:
+        m = range_re.match(r["detected"].replace("–", "-"))
+        if m:
+            for pg in range(int(m.group(1)), int(m.group(2)) + 1):
+                range_pages.add(pg)
+
+    if exp_start is not None and all_nums:
+        missing_pages = sorted(
+            (set(range(exp_start, exp_end + 1)) - set(all_nums))
+            - range_pages
+            - {0}
+        )
+    elif all_nums:
+        missing_pages = sorted(
+            (set(range(all_nums[0], all_nums[-1] + 1)) - set(all_nums))
+            - range_pages
+            - {0}
+        )
+    else:
+        missing_pages = []
+
+    return {
+        "results": ocr_results,
+        "seq_issues": seq_issues,
+        "duplicates": duplicates,
+        "seen_nums": seen_nums,
+        "all_nums": all_nums,
+        "missing_pages": missing_pages,
+        "ranges_found": ranges_found,
+        "not_detected": [r for r in ocr_results if not r["detected"]],
+        "out_of_range": out_of_range,
+    }
+
+
+def rebuild_page_map(scan: "Scan") -> None:
+    """Rebuild ``page_map`` and ``missing_pages`` from current ocr_results.
+
+    Recomputes the page-sequence projection (duplicate flags and
+    missing-page placeholders) without re-running OCR, opening the PDF, or
+    touching Issue records, so dismissed issues are preserved. Used after a
+    manual page-number edit so the viewer reflects the change immediately;
+    Issue cards are refreshed separately by a full Recheck.
+
+    :param scan: The Scan whose page_map to rebuild.
+    """
+    ocr_results = scan.ocr_results
+    if not ocr_results:
+        return
+    try:
+        exp_start, exp_end = _parse_expected_range(scan.pdf_path)
+    except FileNotFoundError:
+        exp_start, exp_end = _parse_expected_range(scan.original_pdf.name)
+    analysis = _build_analysis(ocr_results, exp_start, exp_end)
+    result = _build_issues(
+        analysis, scan.page_count, exp_start=exp_start, exp_end=exp_end
+    )
+    scan.page_map = result["page_map"]
+    scan.missing_pages = result["missing_pages"]
+    scan.save()
+
+
 def recalculate_issues(scan: "Scan") -> None:
     """Rebuild issues from scan.ocr_results without re-running OCR.
 
@@ -1417,26 +1537,7 @@ def recalculate_issues(scan: "Scan") -> None:
 
     exp_start, exp_end = _parse_expected_range(scan.pdf_path)
 
-    def _split(results):
-        oor, s = [], {}
-        for r in results:
-            if not r["detected"] or r.get("type") == "range":
-                continue
-            try:
-                num = int(r["detected"])
-            except ValueError:
-                continue
-            if num < 1:
-                oor.append(r)
-            elif exp_start is not None and (
-                num < exp_start - 5 or num > exp_end + 5
-            ):
-                oor.append(r)
-            else:
-                s.setdefault(num, []).append(r["pdf_page"])
-        return oor, s
-
-    out_of_range, seen_nums = _split(ocr_results)
+    out_of_range, seen_nums = _split_detected(ocr_results, exp_start, exp_end)
 
     auto_corrected = []
     if out_of_range and seen_nums:
@@ -1484,49 +1585,8 @@ def recalculate_issues(scan: "Scan") -> None:
                     new_results.append(r)
                 ocr_results = new_results
                 scan.ocr_results = ocr_results
-                out_of_range, seen_nums = _split(ocr_results)
 
-    out_of_range_pages = {r["pdf_page"] for r in out_of_range}
-    all_nums = sorted(seen_nums.keys())
-    duplicates = {k: v for k, v in seen_nums.items() if len(v) > 1}
-
-    seq_issues = _detect_sequence_issues(ocr_results, out_of_range_pages)
-
-    range_re = re.compile(r"^(\d{1,4})\s*[–\-]\s*(\d{1,4})$")
-    range_pages = set()
-    ranges_found = [r for r in ocr_results if r.get("type") == "range"]
-    for r in ranges_found:
-        m = range_re.match(r["detected"].replace("\u2013", "-"))
-        if m:
-            for pg in range(int(m.group(1)), int(m.group(2)) + 1):
-                range_pages.add(pg)
-
-    if exp_start is not None and all_nums:
-        missing_pages = sorted(
-            (set(range(exp_start, exp_end + 1)) - set(all_nums))
-            - range_pages
-            - {0}
-        )
-    elif all_nums:
-        missing_pages = sorted(
-            (set(range(all_nums[0], all_nums[-1] + 1)) - set(all_nums))
-            - range_pages
-            - {0}
-        )
-    else:
-        missing_pages = []
-
-    analysis = {
-        "results": ocr_results,
-        "seq_issues": seq_issues,
-        "duplicates": duplicates,
-        "seen_nums": seen_nums,
-        "all_nums": all_nums,
-        "missing_pages": missing_pages,
-        "ranges_found": ranges_found,
-        "not_detected": [r for r in ocr_results if not r["detected"]],
-        "out_of_range": out_of_range,
-    }
+    analysis = _build_analysis(ocr_results, exp_start, exp_end)
 
     result = _build_issues(
         analysis, scan.page_count, exp_start=exp_start, exp_end=exp_end

--- a/scanning/static/scanning/viewer_step1.js
+++ b/scanning/static/scanning/viewer_step1.js
@@ -335,24 +335,45 @@ document.addEventListener('DOMContentLoaded', function () {
         if (editBtn) {
             editBtn.addEventListener('click', function () {
                 var current = ocr && ocr.detected ? ocr.detected : '';
-                var num = prompt('Enter the correct page number for PDF page ' + pdfPage + ':', current);
-                if (num !== null && num.trim()) {
-                    fetch('/scans/' + documentId + '/assign-page/', {
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json',
-                            'X-CSRFToken': csrfToken,
-                        },
-                        body: JSON.stringify({ pdf_page: pdfPage, page_number: num.trim() }),
-                    })
-                    .then(function (r) { return r.json(); })
-                    .then(function (data) {
-                        if (data.status === 'ok') {
-                            editBtn.className = 'ocr-tag editable-page';
-                            editBtn.innerHTML = '#' + num.trim() + ' <small>(manual)</small>';
-                        }
-                    });
+                var num = prompt(
+                    'Page number for PDF page ' + pdfPage +
+                    ' (leave blank if this page has no number):',
+                    current
+                );
+                if (num === null) return; // cancelled
+                var trimmed = num.trim();
+                if (trimmed && (!/^\d+$/.test(trimmed) || parseInt(trimmed, 10) < 1)) {
+                    alert('Page number must be a positive whole number, or blank for none.');
+                    return;
                 }
+                fetch('/scans/' + documentId + '/assign-page/', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': csrfToken,
+                    },
+                    body: JSON.stringify({
+                        pdf_page: pdfPage,
+                        page_number: trimmed === '' ? null : trimmed,
+                    }),
+                })
+                .then(function (r) {
+                    return r.json().then(function (d) { return { ok: r.ok, data: d }; });
+                })
+                .then(function (res) {
+                    if (!res.ok || res.data.status !== 'ok') {
+                        alert((res.data && res.data.error) || 'Could not update the page number.');
+                        return;
+                    }
+                    ocr.detected = res.data.detected;
+                    if (res.data.detected) {
+                        editBtn.className = 'ocr-tag editable-page';
+                        editBtn.innerHTML = '#' + res.data.detected + ' <small>(manual)</small>';
+                    } else {
+                        editBtn.className = 'ocr-tag miss editable-page';
+                        editBtn.innerHTML = '[no page # found — click to assign]';
+                    }
+                });
             });
         }
 

--- a/scanning/static/scanning/viewer_step1.js
+++ b/scanning/static/scanning/viewer_step1.js
@@ -377,8 +377,12 @@ document.addEventListener('DOMContentLoaded', function () {
                     // duplicate/missing badges and the issue cards are now stale.
                     // Surface the pending banner so the user can click Recheck to
                     // refresh them (a cheap recalculate, no RunPod rebuild needed).
+                    // Only set the edit-specific wording when nothing was pending
+                    // yet (banner hidden). If a page insert/deletion is already
+                    // pending, leave its "rebuild to apply" text: Recheck is hidden
+                    // in that state and Rebuild & Validate handles both.
                     var banner = document.getElementById('pending-banner');
-                    if (banner) {
+                    if (banner && banner.hidden) {
                         banner.textContent =
                             'Page numbers changed. Click Recheck to refresh ' +
                             'duplicate flags and issues.';

--- a/scanning/static/scanning/viewer_step1.js
+++ b/scanning/static/scanning/viewer_step1.js
@@ -373,6 +373,19 @@ document.addEventListener('DOMContentLoaded', function () {
                         editBtn.className = 'ocr-tag miss editable-page';
                         editBtn.innerHTML = '[no page # found — click to assign]';
                     }
+                    // The server already rebuilt page_map, but the rendered
+                    // duplicate/missing badges and the issue cards are now stale.
+                    // Surface the pending banner so the user can click Recheck to
+                    // refresh them (a cheap recalculate, no RunPod rebuild needed).
+                    var banner = document.getElementById('pending-banner');
+                    if (banner) {
+                        banner.textContent =
+                            'Page numbers changed. Click Recheck to refresh ' +
+                            'duplicate flags and issues.';
+                        banner.hidden = false;
+                    }
+                    var badge = document.getElementById('pending-badge');
+                    if (badge) badge.hidden = false;
                 });
             });
         }

--- a/scanning/static/scanning/viewer_step2.js
+++ b/scanning/static/scanning/viewer_step2.js
@@ -273,21 +273,42 @@ document.addEventListener('DOMContentLoaded', function () {
                 (function (btn, pp) {
                     btn.addEventListener('click', function () {
                         var current = ocr && ocr.detected ? ocr.detected : '';
-                        var num = prompt('Enter the correct page number for PDF page ' + pp + ':', current);
-                        if (num !== null && num.trim()) {
-                            fetch('/scans/' + documentId + '/assign-page/', {
-                                method: 'POST',
-                                headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
-                                body: JSON.stringify({ pdf_page: pp, page_number: num.trim() }),
-                            })
-                            .then(function (r) { return r.json(); })
-                            .then(function (data) {
-                                if (data.status === 'ok') {
-                                    btn.className = 'ocr-tag editable-page';
-                                    btn.innerHTML = '#' + num.trim() + ' <small>(manual)</small>';
-                                }
-                            });
+                        var num = prompt(
+                            'Page number for PDF page ' + pp +
+                            ' (leave blank if this page has no number):',
+                            current
+                        );
+                        if (num === null) return; // cancelled
+                        var trimmed = num.trim();
+                        if (trimmed && (!/^\d+$/.test(trimmed) || parseInt(trimmed, 10) < 1)) {
+                            alert('Page number must be a positive whole number, or blank for none.');
+                            return;
                         }
+                        fetch('/scans/' + documentId + '/assign-page/', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
+                            body: JSON.stringify({
+                                pdf_page: pp,
+                                page_number: trimmed === '' ? null : trimmed,
+                            }),
+                        })
+                        .then(function (r) {
+                            return r.json().then(function (d) { return { ok: r.ok, data: d }; });
+                        })
+                        .then(function (res) {
+                            if (!res.ok || res.data.status !== 'ok') {
+                                alert((res.data && res.data.error) || 'Could not update the page number.');
+                                return;
+                            }
+                            ocr.detected = res.data.detected;
+                            if (res.data.detected) {
+                                btn.className = 'ocr-tag editable-page';
+                                btn.innerHTML = '#' + res.data.detected + ' <small>(manual)</small>';
+                            } else {
+                                btn.className = 'ocr-tag miss editable-page';
+                                btn.innerHTML = '[no page # found]';
+                            }
+                        });
                     });
                 })(editBtn, pdfPage);
             }

--- a/scanning/templates/scanning/scan_process.html
+++ b/scanning/templates/scanning/scan_process.html
@@ -43,7 +43,7 @@
       <span class="text-base font-bold">{% if scan.reporter %}{{ scan.reporter.short_name|upper }} vol. {{ scan.volume }}{% else %}Scan #{{ scan.pk }}{% endif %}</span>
       <span class="text-xs text-gray-500 dark:text-gray-400">{{ scan.page_count }} pages</span>
       {% if missing_pages %}<span class="badge-error text-xs">{{ missing_pages|length }} missing</span>{% endif %}
-      <span id="pending-badge" class="badge-warning text-xs"{% if not has_pending_changes %} hidden{% endif %}>Pending Changes</span>
+      <span id="pending-badge" class="text-xs font-medium rounded px-2 py-0.5 bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200"{% if not has_pending_changes %} hidden{% endif %}>Pending Changes</span>
       {% if scan.s3_uploaded %}<span class="badge-s3 text-xs" title="Files uploaded to S3">S3</span>{% endif %}
     </div>
   </div>
@@ -58,7 +58,7 @@
 <div class="w-full px-4 pb-6">
   <div class="flex gap-4" style="height:calc(100vh - 200px);min-height:500px;">
     {# Sidebar #}
-    <aside class="w-72 flex-shrink-0 overflow-y-auto border border-gray-200 dark:border-gray-700 rounded bg-white dark:bg-gray-900 p-3" style="max-height:calc(100vh - 200px);">
+    <aside class="w-72 flex-shrink-0 overflow-y-auto border border-gray-200 dark:border-gray-700 rounded bg-white dark:bg-gray-900 px-3 pb-3{% if step != 1 or is_processing %} pt-3{% endif %}" style="max-height:calc(100vh - 200px);">
       {% if is_processing %}
       <h2 class="text-sm font-bold mb-2">Processing</h2>
       <div class="rounded bg-gray-100 dark:bg-gray-800 p-3 mb-2">
@@ -72,12 +72,12 @@
       {% elif step == 1 %}
       {# Step 1: Build - issues first, then collapsible pages #}
 
-      <div id="pending-banner" class="bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-200 text-xs rounded px-2 py-1 mb-2"{% if not has_pending_changes %} hidden{% endif %}>
+      <div id="pending-banner" class="sticky top-0 z-10 -mx-3 px-3 py-2 rounded-t shadow-sm bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-200 text-xs"{% if not has_pending_changes %} hidden{% endif %}>
         Pending changes &mdash; rebuild to apply
       </div>
 
       {% if issues %}
-      <h2 class="text-sm font-bold mb-2">Issues ({{ issues|length }})</h2>
+      <h2 class="text-sm font-bold mb-2 pt-3">Issues ({{ issues|length }})</h2>
       {% for issue in issues %}
       <div class="issue-card rounded border px-2 py-1.5 mb-1 cursor-pointer text-xs
            {% if issue.severity == 'error' %}border-red-300 bg-red-50 dark:border-red-700 dark:bg-red-900/20{% elif issue.severity == 'warning' %}border-yellow-300 bg-yellow-50 dark:border-yellow-700 dark:bg-yellow-900/20{% else %}border-blue-300 bg-blue-50 dark:border-blue-700 dark:bg-blue-900/20{% endif %}"
@@ -103,11 +103,11 @@
       {% endfor %}
       {% else %}
       {% if ocr_results %}
-      <div class="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded px-2 py-2 text-xs text-green-700 dark:text-green-300 font-medium mb-2">
+      <div class="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded px-2 py-2 text-xs text-green-700 dark:text-green-300 font-medium mb-2 mt-3">
         All clear — no issues
       </div>
       {% else %}
-      <div class="bg-gray-50 dark:bg-gray-900/20 border border-gray-200 dark:border-gray-700 rounded px-2 py-2 text-xs text-gray-500 dark:text-gray-400 font-medium mb-2">
+      <div class="bg-gray-50 dark:bg-gray-900/20 border border-gray-200 dark:border-gray-700 rounded px-2 py-2 text-xs text-gray-500 dark:text-gray-400 font-medium mb-2 mt-3">
         Not yet processed
       </div>
       {% endif %}

--- a/scanning/tests/test_views.py
+++ b/scanning/tests/test_views.py
@@ -1769,3 +1769,135 @@ class TestProcessActionsFragment(ScanningTestCase):
         self.assertIn(
             reverse("reprocess", kwargs={"pk": self.scan.pk}), body["html"]
         )
+
+
+@override_settings(MEDIA_ROOT=MEDIA_ROOT)
+class TestAssignPage(ScanningTestCase):
+    """Manual page-number edits validate input, support clearing, and
+    rebuild the page_map so duplicate flags stay in sync with the edit."""
+
+    def setUp(self):
+        self.user = self.make_user()
+        self.client.force_login(self.user)
+        self.scan = ScanFactory(
+            uploaded_by=self.user,
+            status=Status.PENDING_REVIEW,
+            page_count=3,
+            ocr_results=[
+                {
+                    "pdf_page": 1,
+                    "detected": "5",
+                    "type": "single",
+                    "zone": "yolo-pn",
+                },
+                {"pdf_page": 2, "detected": None, "type": None, "zone": None},
+                {
+                    "pdf_page": 3,
+                    "detected": "9",
+                    "type": "single",
+                    "zone": "yolo-pn",
+                },
+            ],
+        )
+
+    def _post(self, pdf_page, page_number):
+        return self.client.post(
+            reverse("assign_page", kwargs={"pk": self.scan.pk}),
+            data=json.dumps(
+                {"pdf_page": pdf_page, "page_number": page_number}
+            ),
+            content_type="application/json",
+        )
+
+    def test_rejects_zero(self):
+        """0 is not a valid page number and leaves the value unchanged."""
+        response = self._post(1, "0")
+        self.assertEqual(response.status_code, 400)
+        self.scan.refresh_from_db()
+        self.assertEqual(self.scan.ocr_results[0]["detected"], "5")
+
+    def test_rejects_negative(self):
+        """Negative numbers are rejected."""
+        self.assertEqual(self._post(1, "-3").status_code, 400)
+
+    def test_rejects_non_numeric(self):
+        """Non-numeric input is rejected."""
+        self.assertEqual(self._post(1, "abc").status_code, 400)
+
+    def test_unknown_page_returns_404(self):
+        """Assigning to a PDF page not in ocr_results is a 404."""
+        self.assertEqual(self._post(99, "5").status_code, 404)
+
+    def test_missing_page_number_key_rejected(self):
+        """Omitting page_number is a 400, not a silent clear (clearing is
+        explicit via null/empty)."""
+        response = self.client.post(
+            reverse("assign_page", kwargs={"pk": self.scan.pk}),
+            data=json.dumps({"pdf_page": 1}),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.scan.refresh_from_db()
+        self.assertEqual(self.scan.ocr_results[0]["detected"], "5")
+
+    def test_missing_pdf_page_rejected(self):
+        """Omitting pdf_page is a 400 rather than a server error."""
+        response = self.client.post(
+            reverse("assign_page", kwargs={"pk": self.scan.pk}),
+            data=json.dumps({"page_number": "5"}),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_sets_valid_number(self):
+        """A positive number is stored and marked manual."""
+        response = self._post(3, "7")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content)["detected"], "7")
+        self.scan.refresh_from_db()
+        r = self.scan.ocr_results[2]
+        self.assertEqual(r["detected"], "7")
+        self.assertEqual(r["type"], "single")
+        self.assertEqual(r["zone"], "manual")
+
+    def test_blank_clears_number(self):
+        """A blank value clears the page number (marks it unnumbered)."""
+        response = self._post(1, "")
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(json.loads(response.content)["detected"])
+        self.scan.refresh_from_db()
+        r = self.scan.ocr_results[0]
+        self.assertIsNone(r["detected"])
+        self.assertEqual(r["zone"], "manual")
+
+    def test_null_clears_number(self):
+        """A null value also clears the page number."""
+        response = self._post(1, None)
+        self.assertEqual(response.status_code, 200)
+        self.scan.refresh_from_db()
+        self.assertIsNone(self.scan.ocr_results[0]["detected"])
+
+    def test_edit_creating_duplicate_flags_page_map(self):
+        """Assigning a number that already exists flags the page (and only
+        the later copy) as a duplicate in the rebuilt page_map."""
+        response = self._post(3, "5")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(json.loads(response.content)["duplicate"])
+        self.scan.refresh_from_db()
+        flagged = {
+            e["pdf_index"] for e in self.scan.page_map if e.get("duplicate")
+        }
+        self.assertIn(2, flagged)  # pdf_page 3 -> index 2 (second "5")
+        self.assertNotIn(0, flagged)  # the first "5" stays canonical
+
+    def test_clearing_duplicate_unflags_page_map(self):
+        """Clearing a duplicated number removes the duplicate flag."""
+        self._post(3, "5")
+        self.scan.refresh_from_db()
+        self.assertTrue(any(e.get("duplicate") for e in self.scan.page_map))
+        self._post(3, "")
+        self.scan.refresh_from_db()
+        flagged = {
+            e["pdf_index"] for e in self.scan.page_map if e.get("duplicate")
+        }
+        self.assertNotIn(2, flagged)

--- a/scanning/views_process.py
+++ b/scanning/views_process.py
@@ -746,35 +746,89 @@ def reprocess(request: HttpRequest, pk: int) -> HttpResponse:
 @login_required
 @require_POST
 def assign_page(request: HttpRequest, pk: int) -> JsonResponse:
-    """Manually assign a page number to a PDF page.
+    """Manually set or clear a PDF page's detected page number.
 
-    :param request: The HTTP request (JSON body with pdf_page and
-        page_number).
+    A blank/empty ``page_number`` clears the number, marking the page as
+    having none (e.g. front matter the model mis-tagged). Any other value
+    must be a positive integer. After updating, the page_map is rebuilt so
+    duplicate flags stay in sync with the change.
+
+    :param request: The HTTP request (JSON body with ``pdf_page`` and
+        ``page_number``; ``page_number`` may be null/empty to clear).
     :param pk: Scan primary key.
-    :return: JSON response confirming the assignment.
+    :return: JSON response with the stored value and duplicate flag.
     """
     scan = get_object_or_404(Scan, pk=pk)
     try:
         data = json.loads(request.body)
     except json.JSONDecodeError:
         return JsonResponse({"error": "Invalid JSON"}, status=400)
-    pdf_page = data["pdf_page"]
-    page_number = data["page_number"]
+    pdf_page = data.get("pdf_page")
+    if pdf_page is None:
+        return JsonResponse({"error": "pdf_page is required."}, status=400)
+    if "page_number" not in data:
+        return JsonResponse(
+            {"error": 'page_number is required (send null or "" to clear).'},
+            status=400,
+        )
+    raw = data["page_number"]
+
+    clear = raw is None or (isinstance(raw, str) and not raw.strip())
+    page_value = None
+    if not clear:
+        try:
+            number = int(str(raw).strip())
+        except (TypeError, ValueError):
+            return JsonResponse(
+                {"error": "Page number must be a positive whole number."},
+                status=400,
+            )
+        if number < 1:
+            return JsonResponse(
+                {"error": "Page number must be a positive whole number."},
+                status=400,
+            )
+        page_value = str(number)
+
     ocr_results = scan.ocr_results
+    if not any(r["pdf_page"] == pdf_page for r in ocr_results):
+        return JsonResponse({"error": "Unknown PDF page."}, status=404)
     for r in ocr_results:
         if r["pdf_page"] == pdf_page:
-            r["detected"] = page_number
-            r["type"] = "single"
+            if clear:
+                r["detected"] = None
+                r["type"] = None
+                r["score"] = None
+            else:
+                r["detected"] = page_value
+                r["type"] = "single"
+                r["score"] = 1.0
             r["zone"] = "manual"
-            r["score"] = 1.0
             r["ocr"] = "manual"
             break
     scan.ocr_results = ocr_results
+
+    # Clear the page's no-page-number flag; the rebuild does not touch Issue
+    # rows, so a full Recheck re-derives the issue list (and any new flag).
     scan.issues.filter(
         check_name=CheckName.NO_PAGE_NUMBER, page_number=pdf_page
     ).delete()
-    scan.save()
-    return JsonResponse({"status": "ok"})
+
+    # Rebuild page_map so the viewer/sidebar duplicate flags reflect the edit
+    # immediately (saves the scan, including the updated ocr_results).
+    from scanning import services
+
+    services.rebuild_page_map(scan)
+
+    duplicate = any(
+        e.get("type") == "pdf_page"
+        and e.get("pdf_index") == pdf_page - 1
+        and e.get("duplicate")
+        for e in scan.page_map
+    )
+    return JsonResponse(
+        {"status": "ok", "detected": page_value, "duplicate": duplicate}
+    )
 
 
 @login_required


### PR DESCRIPTION
The step-1 manual page-number correction (`assign_page`) had three gaps (#105): it could only *set* a number (never clear one), accepted invalid values like `0`, and didn't refresh the page_map, so duplicate flags went stale after an edit.

**Clear a number.** The edit prompt now accepts a blank value to mark a page as having no number (e.g. front matter the model mis-tagged): the page reverts to the "no page #" state and is recorded as `manual`. Clearing is explicit, sent as `null`/`""`.

**Validation.** `assign_page` now rejects non-positive and non-numeric values with `400`, unknown PDF pages with `404`, and missing `pdf_page`/`page_number` keys with `400` (so a malformed request can't silently clear a page). The prompt handler pre-validates and surfaces server errors.

**Refresh duplicate flags.** Each set/clear now rebuilds `page_map` and `missing_pages` from the current `ocr_results` via the new `services.rebuild_page_map`, so the viewer's DUPLICATE badge reflects the edit immediately instead of staying stale until a full Recheck. The rebuild is PDF-free (uses the same expected-range derivation as Recheck) and deliberately does not touch Issue rows, so dismissed issues are preserved; issue cards still refresh on a full Recheck. Extracted `_split_detected` and `_build_analysis` as shared helpers with `recalculate_issues` (no behavior change to the Recheck path).

Verified against the running app: validation returns the right 400/404s, a blank clears the number, and creating/removing a duplicate flips the rendered page_map's `duplicate` flag for the affected page.

Deferred to a separate blackletter issue: only the 2nd+ copies of a repeated number are flagged in the page_map while the `duplicate_page` issue lists all copies (the first-occurrence inconsistency, gap 4 in #105).

Closes #105
