### PR TITLE
fix(scanning): remove dismissed issue card and update issue count

### DIFF
--- a/scanning/static/scanning/viewer_sidebar.js
+++ b/scanning/static/scanning/viewer_sidebar.js
@@ -436,29 +436,6 @@ function deleteDuplicates(btn) {
     });
 }
 
-function dismissIssue(btn, issueId) {
-    var cfg = window.SCAN_CONFIG;
-    fetch("/scans/" + cfg.docId + "/dismiss-issue/", {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-            "X-CSRFToken": cfg.csrfToken,
-        },
-        body: JSON.stringify({ issue_id: issueId }),
-    })
-        .then(function (r) {
-            return r.json();
-        })
-        .then(function (data) {
-            if (data.status === "ok") {
-                btn.closest(".issue-card").style.opacity = "0.3";
-                btn.closest(".issue-card").style.pointerEvents = "none";
-            } else {
-                alert(data.message || "Cannot dismiss");
-            }
-        });
-}
-
 function pairOpinions() {
     var cfg = window.SCAN_CONFIG;
     if (cfg.step < 2) return;

--- a/scanning/static/scanning/viewer_step1.js
+++ b/scanning/static/scanning/viewer_step1.js
@@ -738,25 +738,33 @@ document.addEventListener('DOMContentLoaded', function () {
         })
         .then(function (r) { return r.json(); })
         .then(function (data) {
-            if (data.status === 'ok') {
-                var card = btn.closest('.issue-card');
-                card.style.opacity = '0.3';
-                card.style.pointerEvents = 'none';
-                // Check if all issues are dismissed
-                var remaining = document.querySelectorAll('.issue-card:not([style*="opacity"])');
-                if (remaining.length === 0) {
-                    var issuesPanel = document.querySelector('.issues-panel');
-                    var allClear = document.querySelector('.all-clear');
-                    if (!allClear) {
-                        var div = document.createElement('div');
-                        div.className = 'all-clear';
-                        div.textContent = 'All Clear — no issues found';
-                        issuesPanel.appendChild(div);
-                    }
-                }
+            if (data.status !== 'ok') {
+                alert(data.message || data.error || 'Could not dismiss issue.');
+                return;
             }
+            var card = btn.closest('.issue-card');
+            if (card) card.remove();
+            refreshIssuesCount();
+        })
+        .catch(function () {
+            alert('Could not dismiss issue. Please try again.');
         });
     };
+
+    // Update the "Issues (N)" heading after a dismissal and swap in the
+    // "all clear" state once the last issue is gone.
+    function refreshIssuesCount() {
+        var section = document.getElementById('issues-section');
+        if (!section) return;
+        var remaining = section.querySelectorAll('.issue-card').length;
+        var countEl = document.getElementById('issues-count');
+        if (countEl) countEl.textContent = remaining;
+        if (remaining === 0) {
+            section.hidden = true;
+            var allClear = document.getElementById('issues-all-clear');
+            if (allClear) allClear.hidden = false;
+        }
+    }
 
     // --- Delete duplicate pages ---
     window.deleteDuplicates = function (btn) {

--- a/scanning/static/scanning/viewer_step1.js
+++ b/scanning/static/scanning/viewer_step1.js
@@ -745,6 +745,9 @@ document.addEventListener('DOMContentLoaded', function () {
             var card = btn.closest('.issue-card');
             if (card) card.remove();
             refreshIssuesCount();
+            if (typeof window.refreshProcessActionBar === 'function') {
+                window.refreshProcessActionBar();
+            }
         })
         .catch(function () {
             alert('Could not dismiss issue. Please try again.');

--- a/scanning/templates/scanning/scan_process.html
+++ b/scanning/templates/scanning/scan_process.html
@@ -76,8 +76,9 @@
         Pending changes &mdash; rebuild to apply
       </div>
 
-      {% if issues %}
-      <h2 class="text-sm font-bold mb-2">Issues ({{ issues|length }})</h2>
+      {% if ocr_results %}
+      <div id="issues-section"{% if not issues %} hidden{% endif %}>
+      <h2 class="text-sm font-bold mb-2">Issues (<span id="issues-count">{{ issues|length }}</span>)</h2>
       {% for issue in issues %}
       <div class="issue-card rounded border px-2 py-1.5 mb-1 cursor-pointer text-xs
            {% if issue.severity == 'error' %}border-red-300 bg-red-50 dark:border-red-700 dark:bg-red-900/20{% elif issue.severity == 'warning' %}border-yellow-300 bg-yellow-50 dark:border-yellow-700 dark:bg-yellow-900/20{% else %}border-blue-300 bg-blue-50 dark:border-blue-700 dark:bg-blue-900/20{% endif %}"
@@ -101,16 +102,14 @@
         </div>
       </div>
       {% endfor %}
-      {% else %}
-      {% if ocr_results %}
-      <div class="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded px-2 py-2 text-xs text-green-700 dark:text-green-300 font-medium mb-2">
+      </div>
+      <div id="issues-all-clear" class="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded px-2 py-2 text-xs text-green-700 dark:text-green-300 font-medium mb-2"{% if issues %} hidden{% endif %}>
         All clear — no issues
       </div>
       {% else %}
       <div class="bg-gray-50 dark:bg-gray-900/20 border border-gray-200 dark:border-gray-700 rounded px-2 py-2 text-xs text-gray-500 dark:text-gray-400 font-medium mb-2">
         Not yet processed
       </div>
-      {% endif %}
       {% endif %}
 
       {% if ocr_results %}


### PR DESCRIPTION
Closes #107

Dismissing a step-1 sidebar issue only dimmed the card to 30% opacity. It stayed in the list and the "Issues (N)" heading never changed until a full reload. The dismissal did persist server-side, so this was a client-side UI bug.

## Changes
- Remove the card from the DOM on a successful dismiss and update the "Issues (N)" heading immediately.
- Swap in the existing "All clear, no issues" block once the last issue is dismissed.
- Surface server errors: the dismiss endpoint returns `{status: "error"}` when there are pending changes, which the old handler ignored silently. It now alerts the user and keeps the card.
- Consolidate the two duplicate `dismissIssue` handlers (`viewer_step1.js` and `viewer_sidebar.js`) into the single step-1 copy, and drop the dead `.issues-panel` / `.all-clear` lookups that referenced elements not present in the template.

## Template hooks
Added `id="issues-section"`, an `id="issues-count"` span in the heading, and an always-present (hidden) `id="issues-all-clear"` block so the JS can toggle state without a reload.
