### PR TITLE
perf(scanning): stream upload to S3 in one pass, drop local disk write

### DIFF
--- a/scanning/models.py
+++ b/scanning/models.py
@@ -650,8 +650,8 @@ class Scan(AbstractDateTimeModel):
 
         Resolution order:
 
-        1. ``output_dir/<name>.original.pdf`` (present after upload or
-           after pulling from S3).
+        1. ``output_dir/<name>.original.pdf`` (present in DEV after
+           upload, or in prod after pulling from S3).
         2. Django ``FileField.path`` if the file actually exists on disk
            (covers DEV and tests where the FileField was written to
            MEDIA_ROOT).

--- a/scanning/s3_sync.py
+++ b/scanning/s3_sync.py
@@ -17,6 +17,7 @@ behavior as prod.
 from __future__ import annotations
 
 import logging
+import time
 from pathlib import Path
 
 import boto3
@@ -253,6 +254,53 @@ def upload_file_to_s3(scan: Scan, relative_path: str) -> bool:
         scan.pk,
         bucket,
         key,
+    )
+    return True
+
+
+def upload_fileobj_to_s3(scan: Scan, upload, relative_path: str) -> bool:
+    """Stream an uploaded file straight to S3 without a local copy.
+
+    Used by the upload view in prod so the bytes Django already spooled
+    go to S3 in a single pass, with no wasted local disk write. Prefers
+    the temp-file path boto3 can read directly (Django spools large
+    uploads to a ``TemporaryUploadedFile``) and falls back to the file
+    object for small in-memory uploads.
+
+    :param scan: The scan the file belongs to.
+    :type scan: Scan
+    :param upload: The uploaded file (a Django ``UploadedFile``).
+    :param relative_path: Path relative to the scan's output dir, used
+        as the S3 key suffix.
+    :type relative_path: str
+    :returns: True if uploaded, False if S3 is disabled.
+    :rtype: bool
+    """
+    if not _s3_enabled():
+        return False
+
+    bucket = settings.AWS_PRIVATE_STORAGE_BUCKET_NAME
+    key = f"{s3_processing_prefix(scan)}{relative_path}"
+    extra_args = {"ContentType": "application/pdf"}
+    s3 = boto3.client("s3")
+
+    start = time.monotonic()
+    temp_path = getattr(upload, "temporary_file_path", None)
+    if callable(temp_path):
+        s3.upload_file(temp_path(), bucket, key, ExtraArgs=extra_args)
+    else:
+        upload.seek(0)
+        s3.upload_fileobj(upload, bucket, key, ExtraArgs=extra_args)
+    elapsed = time.monotonic() - start
+
+    size_mb = (getattr(upload, "size", 0) or 0) / (1024 * 1024)
+    logger.info(
+        "Streamed %.1f MB to s3://%s/%s for scan %s in %.1fs",
+        size_mb,
+        bucket,
+        key,
+        scan.pk,
+        elapsed,
     )
     return True
 

--- a/scanning/tests/test_s3_sync.py
+++ b/scanning/tests/test_s3_sync.py
@@ -5,6 +5,7 @@ import pathlib
 import tempfile
 from unittest.mock import MagicMock, patch
 
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import SimpleTestCase, TestCase, override_settings
 
 from scanning import s3_sync
@@ -246,6 +247,61 @@ class TestSyncHelpersWithCredentials(TestCase):
         _, bucket, key = mock_s3.upload_file.call_args.args
         self.assertEqual(bucket, "test-bucket")
         self.assertEqual(key, f"processing/{scan.pk}/tc/164/1/detections.json")
+
+    def test_upload_fileobj_to_s3_streams_small_file(self):
+        scan = _reporter_scan()
+        scan.status = Status.PENDING_REVIEW
+        scan.save(update_fields=["status"])
+        upload = SimpleUploadedFile(
+            "x.original.pdf",
+            b"%PDF-1.4 body",
+            content_type="application/pdf",
+        )
+
+        mock_s3 = MagicMock()
+        with patch("scanning.s3_sync.boto3") as mock_boto3:
+            mock_boto3.client.return_value = mock_s3
+            ok = s3_sync.upload_fileobj_to_s3(scan, upload, "x.original.pdf")
+
+        self.assertTrue(ok)
+        # Small in-memory upload has no temp path, so it streams the
+        # file object directly. No local file is touched.
+        mock_s3.upload_fileobj.assert_called_once()
+        mock_s3.upload_file.assert_not_called()
+        _, bucket, key = mock_s3.upload_fileobj.call_args.args
+        self.assertEqual(bucket, "test-bucket")
+        self.assertEqual(key, f"processing/{scan.pk}/tc/164/1/x.original.pdf")
+        self.assertEqual(
+            mock_s3.upload_fileobj.call_args.kwargs["ExtraArgs"],
+            {"ContentType": "application/pdf"},
+        )
+
+    def test_upload_fileobj_to_s3_uses_temporary_file_path(self):
+        scan = _reporter_scan()
+        scan.status = Status.PENDING_REVIEW
+        scan.save(update_fields=["status"])
+        # Large uploads spool to a TemporaryUploadedFile exposing
+        # temporary_file_path(); boto3 reads that path directly.
+        upload = MagicMock()
+        upload.temporary_file_path.return_value = "/tmp/spool.pdf"
+        upload.size = 2048
+
+        mock_s3 = MagicMock()
+        with patch("scanning.s3_sync.boto3") as mock_boto3:
+            mock_boto3.client.return_value = mock_s3
+            ok = s3_sync.upload_fileobj_to_s3(scan, upload, "x.original.pdf")
+
+        self.assertTrue(ok)
+        mock_s3.upload_file.assert_called_once()
+        mock_s3.upload_fileobj.assert_not_called()
+        path_arg, bucket, key = mock_s3.upload_file.call_args.args
+        self.assertEqual(path_arg, "/tmp/spool.pdf")
+        self.assertEqual(bucket, "test-bucket")
+        self.assertEqual(key, f"processing/{scan.pk}/tc/164/1/x.original.pdf")
+        self.assertEqual(
+            mock_s3.upload_file.call_args.kwargs["ExtraArgs"],
+            {"ContentType": "application/pdf"},
+        )
 
 
 class TestS3EnabledBranches(SimpleTestCase):

--- a/scanning/tests/test_views.py
+++ b/scanning/tests/test_views.py
@@ -1091,7 +1091,7 @@ class TestQueueUploadS3(ScanningTestCase):
     def test_dev_writes_filefield_and_skips_s3(self):
         from unittest.mock import patch
 
-        with patch("scanning.s3_sync.upload_file_to_s3") as mock_s3:
+        with patch("scanning.s3_sync.upload_fileobj_to_s3") as mock_s3:
             response, _ = self._post_upload()
 
         self.assertEqual(response.status_code, 302)
@@ -1111,7 +1111,7 @@ class TestQueueUploadS3(ScanningTestCase):
         with (
             patch("scanning.views.has_s3_credentials", return_value=True),
             patch(
-                "scanning.s3_sync.upload_file_to_s3", return_value=True
+                "scanning.s3_sync.upload_fileobj_to_s3", return_value=True
             ) as mock_s3,
         ):
             response, _ = self._post_upload()
@@ -1132,7 +1132,7 @@ class TestQueueUploadS3(ScanningTestCase):
         with (
             patch("scanning.views.has_s3_credentials", return_value=True),
             patch(
-                "scanning.s3_sync.upload_file_to_s3",
+                "scanning.s3_sync.upload_fileobj_to_s3",
                 side_effect=RuntimeError("boom"),
             ),
             self.assertLogs("scanning.views", level="ERROR") as cm,
@@ -1151,7 +1151,7 @@ class TestQueueUploadS3(ScanningTestCase):
 
         with (
             patch("scanning.views.has_s3_credentials", return_value=False),
-            patch("scanning.s3_sync.upload_file_to_s3") as mock_s3,
+            patch("scanning.s3_sync.upload_fileobj_to_s3") as mock_s3,
             self.assertLogs("scanning.views", level="ERROR") as cm,
         ):
             response, _ = self._post_upload()
@@ -1165,11 +1165,11 @@ class TestQueueUploadS3(ScanningTestCase):
     def test_prod_upload_returning_false_deletes_scan(self):
         from unittest.mock import patch
 
-        # upload_file_to_s3 returning False (e.g. the helper's own
+        # upload_fileobj_to_s3 returning False (e.g. the helper's own
         # short-circuit) should be treated as a failure by the view.
         with (
             patch("scanning.views.has_s3_credentials", return_value=True),
-            patch("scanning.s3_sync.upload_file_to_s3", return_value=False),
+            patch("scanning.s3_sync.upload_fileobj_to_s3", return_value=False),
         ):
             response, _ = self._post_upload()
 

--- a/scanning/tests/test_views.py
+++ b/scanning/tests/test_views.py
@@ -402,7 +402,7 @@ class TestQueueUploadXhr(ScanningTestCase):
         with (
             patch("scanning.views.has_s3_credentials", return_value=True),
             patch(
-                "scanning.s3_sync.upload_file_to_s3", return_value=True
+                "scanning.s3_sync.upload_fileobj_to_s3", return_value=True
             ) as mock_upload,
         ):
             response = self.client.post(
@@ -415,6 +415,13 @@ class TestQueueUploadXhr(ScanningTestCase):
         mock_upload.assert_called_once()
         scan = Scan.objects.get(volume_obj=self.volume)
         self.assertTrue(scan.original_pdf.name)
+        # The prod path streams straight to S3; it must not write a
+        # local copy of the original PDF (issue #94).
+        out_dir = pathlib.Path(scan.output_dir)
+        self.assertFalse(
+            out_dir.exists() and list(out_dir.glob("*.original.pdf")),
+            "prod upload must not write a local original PDF",
+        )
 
     @override_settings(DEVELOPMENT=False)
     def test_xhr_prod_upload_without_credentials_returns_json_redirect(self):

--- a/scanning/views.py
+++ b/scanning/views.py
@@ -511,9 +511,7 @@ def queue_upload(request, reporter_slug, vol):
     scan.status = Status.UPLOADED
     scan.save()  # Save first to get a PK
 
-    # Create processing directory and save original PDF there
     output_dir = Path(scan.output_dir)
-    output_dir.mkdir(parents=True, exist_ok=True)
 
     original_name = (
         f"{volume.reporter.short_name}.{volume.volume_number}"
@@ -521,23 +519,22 @@ def queue_upload(request, reporter_slug, vol):
         f".original.pdf"
     )
 
-    # Keep a local copy in output_dir for the processing pipeline. In
-    # prod this is /tmp/scanning/{pk}/...; in DEV it is under MEDIA_ROOT.
-    local_path = output_dir / original_name
-    with open(local_path, "wb") as f:
-        for chunk in pdf.chunks():
-            f.write(chunk)
-
     if settings.DEVELOPMENT:
-        # DEV: store via Django FileField (MEDIA_ROOT/original_scans/...)
-        # so the shared mount makes the file available to the daemon.
+        # DEV: keep a local copy in output_dir (under MEDIA_ROOT, shared
+        # with the daemon) and store it via the Django FileField.
+        output_dir.mkdir(parents=True, exist_ok=True)
+        local_path = output_dir / original_name
+        with open(local_path, "wb") as f:
+            for chunk in pdf.chunks():
+                f.write(chunk)
         pdf.seek(0)
         scan.original_pdf.save(original_name, pdf, save=False)
         scan.save(update_fields=["original_pdf"])
     else:
-        # PROD: push to S3 under processing/{pk}/... so the daemon can
-        # pull it (containers don't share /tmp/). Skip the FileField
-        # write so MEDIA_ROOT stays empty.
+        # PROD: stream the uploaded file straight to S3 under
+        # processing/{pk}/... in a single pass so the daemon can pull it
+        # (containers don't share /tmp/). No local copy is written here;
+        # the daemon recreates one when it downloads from S3.
         from scanning import s3_sync
 
         if not has_s3_credentials():
@@ -553,7 +550,7 @@ def queue_upload(request, reporter_slug, vol):
             return _upload_redirect(request, queue_url)
 
         try:
-            uploaded = s3_sync.upload_file_to_s3(scan, original_name)
+            uploaded = s3_sync.upload_fileobj_to_s3(scan, pdf, original_name)
         except Exception:
             logger.exception(
                 "Failed to upload original PDF to S3 for scan %s", scan.pk


### PR DESCRIPTION
Closes #94

`queue_upload` did two full passes over the uploaded PDF in prod after the browser finished sending: a local disk write, then a read-back to upload to S3. The web and daemon containers don't share disk, so the local copy is never read in prod (the daemon pulls the original from S3), making that pass pure waste.

This streams the file Django already spooled straight to S3 in a single pass and drops the local write in prod. The dev path (local FileField storage, shared with the daemon) is unchanged.

## Changes
- New `s3_sync.upload_fileobj_to_s3`: uploads the spooled `TemporaryUploadedFile` by path (or the file object for small in-memory uploads), tags it `application/pdf`, and logs the transferred size and duration.
- `queue_upload`: in prod, stream to S3 via the new helper; the local disk write now happens only on the dev path.
- Fixed stale comments and the `pdf_path` docstring that described the prod local copy as present after upload.

## Scope and follow-up
This removes the wasted disk pass and the 1-2 GB temp files the web container was writing, but the S3 upload itself still happens inside the request, so a large file still occupies the gunicorn worker (and the `--timeout 180` ceiling) during transfer. The size/duration log added here will surface the real prod cost.
