### PR TITLE
fix(scanning): correct over-counted opinion coverage span

### DIFF
--- a/scanning/tests/test_utils.py
+++ b/scanning/tests/test_utils.py
@@ -1,0 +1,73 @@
+"""Tests for scanning.utils helpers."""
+
+from django.test import TestCase
+
+from scanning.utils import compute_coverage_gaps
+
+
+def _op(caption_page, key_page, **extra):
+    """Build a minimal opinion dict for coverage-gap tests.
+
+    :param caption_page: 0-based pdf index where the opinion starts.
+    :type caption_page: int
+    :param key_page: 0-based pdf index of the opinion's key icon (end).
+    :type key_page: int
+    :param extra: Additional opinion keys (e.g. page_end, page_count).
+    :returns: An opinion dict.
+    :rtype: dict
+    """
+    return {"caption_page": caption_page, "key_page": key_page, **extra}
+
+
+class TestComputeCoverageGaps(TestCase):
+    def test_no_gaps_when_fully_covered(self):
+        opinions = [_op(0, 3)]
+        self.assertEqual(compute_coverage_gaps(opinions, 1, 4), [])
+
+    def test_orphan_page_between_opinions_is_a_gap(self):
+        # Regression for #111: an opinion's covered span must end at its
+        # key_page, not key_page + page_count. A large page_count must not
+        # inflate coverage and swallow the orphaned page between opinions.
+        opinions = [
+            _op(0, 10, page_count=11),  # covers pages 1-11
+            _op(12, 22, page_count=11),  # covers pages 13-23
+        ]
+        # pdf index 11 (page 12) is covered by neither opinion.
+        self.assertEqual(compute_coverage_gaps(opinions, 1, 23), [(12, 12, 1)])
+
+    def test_page_count_does_not_extend_coverage(self):
+        # A single opinion with an inflated page_count covers only
+        # caption_page..key_page; trailing pages remain uncovered.
+        opinions = [_op(0, 5, page_count=6)]
+        self.assertEqual(compute_coverage_gaps(opinions, 1, 9), [(7, 9, 3)])
+
+    def test_page_end_extends_coverage_beyond_key_page(self):
+        # When page_end is present it defines the opinion's last page.
+        opinions = [_op(0, 5, page_end=8)]
+        self.assertEqual(compute_coverage_gaps(opinions, 1, 9), [])
+
+    def test_gap_before_first_opinion(self):
+        opinions = [_op(2, 9)]
+        self.assertEqual(compute_coverage_gaps(opinions, 1, 10), [(1, 2, 2)])
+
+    def test_gap_after_last_opinion(self):
+        opinions = [_op(0, 9)]
+        self.assertEqual(compute_coverage_gaps(opinions, 1, 12), [(11, 12, 2)])
+
+    def test_multiple_gaps(self):
+        opinions = [_op(2, 4), _op(8, 9)]
+        self.assertEqual(
+            compute_coverage_gaps(opinions, 1, 12),
+            [(1, 2, 2), (6, 8, 3), (11, 12, 2)],
+        )
+
+    def test_start_page_offset_is_applied(self):
+        opinions = [_op(0, 10)]
+        self.assertEqual(
+            compute_coverage_gaps(opinions, 100, 112), [(111, 112, 2)]
+        )
+
+    def test_returns_empty_for_missing_inputs(self):
+        self.assertEqual(compute_coverage_gaps([], 1, 10), [])
+        self.assertEqual(compute_coverage_gaps([_op(0, 3)], None, 10), [])
+        self.assertEqual(compute_coverage_gaps([_op(0, 3)], 1, None), [])

--- a/scanning/utils.py
+++ b/scanning/utils.py
@@ -97,11 +97,11 @@ def compute_coverage_gaps(
     """Compute contiguous page runs not covered by any paired opinion.
 
     A page in ``[start_page, end_page]`` is covered if it falls within
-    an opinion's ``caption_page`` through ``key_page + page_count - 1``
-    span (opinion page indices are offset by ``start_page``).
+    an opinion's ``caption_page`` through ``page_end`` (or ``key_page``)
+    span, inclusive (opinion page indices are offset by ``start_page``).
 
-    :param opinions: List of opinion dicts with caption_page, key_page,
-        and page_count.
+    :param opinions: List of opinion dicts with caption_page and
+        page_end or key_page.
     :param start_page: First page in the scan's expected range.
     :param end_page: Last page in the scan's expected range.
     :returns: List of ``(start, end, count)`` tuples, one per gap run.
@@ -112,14 +112,9 @@ def compute_coverage_gaps(
 
     covered: set[int] = set()
     for op in opinions:
-        cp = op.get("caption_page", 0) + (start_page or 1)
-        kp = (
-            op.get("key_page", 0)
-            + (start_page or 1)
-            + op.get("page_count", 1)
-            - 1
-        )
-        for p in range(cp, kp + 1):
+        cp = op.get("caption_page", 0)
+        ep = op.get("page_end", op.get("key_page", cp))
+        for p in range(cp + start_page, ep + start_page + 1):
             covered.add(p)
     expected = set(range(start_page, end_page + 1))
     missing = sorted(expected - covered)


### PR DESCRIPTION
## Summary
`compute_coverage_gaps` inflated each opinion's covered span by adding both `key_page` and `page_count`. Since `page_count == key_page - caption_page + 1`, the span end was pushed roughly `page_count - 1` pages past the opinion's real end, bleeding into the following opinions and masking genuinely uncovered pages, so no gap warning was emitted.

## Fix
Use the opinion's actual last page as the covered-span end: `page_end` when present, otherwise `key_page` (consistent with how `views_process.py` derives the opinion end via `ep = op.get("page_end", op.get("key_page", cp))`). The `page_count` term is dropped entirely.

## Tests
Added `scanning/tests/test_utils.py` for `compute_coverage_gaps`:
- regression for #111: an orphaned page between two opinions is reported as a gap, and an inflated `page_count` no longer swallows it
- `page_count` does not extend coverage; `page_end` does
- gaps before the first opinion, after the last, and multiple disjoint gaps
- `start_page` offset handling and empty/missing inputs

## Verification
When an opinion ends before the next one begins, the orphaned page now surfaces in the step-2 sidebar as a `Pages X-Y (N pages) not covered by any opinion` warning, which was previously masked:

<img width="559" height="143" alt="sidebar" src="https://github.com/user-attachments/assets/9cd63e69-66cf-4367-8d3e-b7b925409b67" />


Closes #111
