### PR TITLE
feat(scanning): report worker-timeout stack traces to Sentry

### DIFF
--- a/scanning/workers.py
+++ b/scanning/workers.py
@@ -37,13 +37,17 @@ class UvicornWorker(BaseUvicornWorker):
         every signal to ``SIG_DFL`` here and only re-installs SIGUSR1, so under
         this worker class SIGABRT would otherwise kill the process with no
         Python running and nothing sent to Sentry. Restore a handler that
-        captures the current stacks first. Best-effort: it runs on the main
-        thread and needs the GIL, so a worker fully wedged in GIL-holding C
-        code may die before it runs — but in practice fitz/MuPDF releases the
-        GIL during heavy work, so the handler usually gets a slice to report.
+        captures the current stacks first. The Python handler is best-effort:
+        it runs on the main thread and needs the GIL, so a worker fully wedged
+        in GIL-holding C code may die before it runs. To cover that case we
+        also re-arm faulthandler for SIGABRT with ``chain=True``: its C-level
+        handler dumps all thread stacks to stderr (pod logs) *without* the GIL,
+        then chains to the Python ``handle_abort`` for the Sentry report once
+        the GIL is available.
         """
         super().init_signals()
         signal.signal(signal.SIGABRT, self.handle_abort)
+        faulthandler.register(signal.SIGABRT, chain=True)
 
     def handle_abort(self, sig: int, frame: Any) -> None:
         self._report_timeout_to_sentry()
@@ -67,7 +71,11 @@ class UvicornWorker(BaseUvicornWorker):
                     "gunicorn WORKER TIMEOUT: worker aborted after --timeout",
                     level="fatal",
                 )
-            sentry_sdk.flush(timeout=2.0)
+            # gunicorn's arbiter escalates SIGABRT to SIGKILL on its next
+            # murder-loop cycle (~1s later). Keep the flush sub-second so the
+            # event has a chance to ship before SIGKILL and so it doesn't stall
+            # the graceful exit (worker_abort + sys.exit(1)) in handle_abort.
+            sentry_sdk.flush(timeout=0.7)
         except Exception:
             # Never let reporting crash the abort/exit path, but don't swallow
             # silently: print to stderr (pod logs), which is signal-safe unlike

--- a/scanning/workers.py
+++ b/scanning/workers.py
@@ -1,3 +1,7 @@
+import faulthandler
+import signal
+import sys
+import traceback
 from typing import Any
 
 from uvicorn.workers import UvicornWorker as BaseUvicornWorker
@@ -9,3 +13,67 @@ class UvicornWorker(BaseUvicornWorker):
         "http": "auto",
         "lifespan": "off",
     }
+
+    def init_process(self) -> None:
+        """Enable faulthandler so a native crash dumps a stack.
+
+        Runs in the forked child (gunicorn calls this post-fork). faulthandler
+        installs C-level handlers for the fatal signals (SIGSEGV, SIGFPE,
+        SIGBUS, SIGILL); if a C extension such as fitz/MuPDF faults on a bad
+        PDF, every thread's stack is dumped to stderr (pod logs) before the
+        process dies, instead of a silent exit. It costs nothing until an
+        actual crash. The 180s WORKER TIMEOUT is captured separately by the
+        SIGABRT handler wired up in init_signals().
+        """
+        faulthandler.enable()
+        super().init_process()
+
+    def init_signals(self) -> None:
+        """Re-wire SIGABRT so a worker timeout is reported to Sentry.
+
+        gunicorn's arbiter sends SIGABRT to a worker that misses its
+        ``--timeout`` heartbeat, and gunicorn's base worker would route that to
+        ``handle_abort``/the ``worker_abort`` hook. But uvicorn's worker resets
+        every signal to ``SIG_DFL`` here and only re-installs SIGUSR1, so under
+        this worker class SIGABRT would otherwise kill the process with no
+        Python running and nothing sent to Sentry. Restore a handler that
+        captures the current stacks first. Best-effort: it runs on the main
+        thread and needs the GIL, so a worker fully wedged in GIL-holding C
+        code may die before it runs — but in practice fitz/MuPDF releases the
+        GIL during heavy work, so the handler usually gets a slice to report.
+        """
+        super().init_signals()
+        signal.signal(signal.SIGABRT, self.handle_abort)
+
+    def handle_abort(self, sig: int, frame: Any) -> None:
+        self._report_timeout_to_sentry()
+        super().handle_abort(sig, frame)
+
+    @staticmethod
+    def _report_timeout_to_sentry() -> None:
+        """Capture every thread's stack and send it to Sentry as a fatal event."""
+        try:
+            import sentry_sdk
+
+            dump = []
+            for thread_id, thread_frame in sys._current_frames().items():
+                dump.append(f"Thread {thread_id}:")
+                dump.append("".join(traceback.format_stack(thread_frame)))
+            stacks = "\n".join(dump)
+
+            with sentry_sdk.new_scope() as scope:
+                scope.set_extra("all_thread_stacks", stacks)
+                sentry_sdk.capture_message(
+                    "gunicorn WORKER TIMEOUT: worker aborted after --timeout",
+                    level="fatal",
+                )
+            sentry_sdk.flush(timeout=2.0)
+        except Exception:
+            # Never let reporting crash the abort/exit path, but don't swallow
+            # silently: print to stderr (pod logs), which is signal-safe unlike
+            # the logging module (its lock could be held by the interrupted frame).
+            print(
+                "workers: failed to report WORKER TIMEOUT to Sentry",
+                file=sys.stderr,
+            )
+            traceback.print_exc(file=sys.stderr)

--- a/scanning/workers.py
+++ b/scanning/workers.py
@@ -37,17 +37,20 @@ class UvicornWorker(BaseUvicornWorker):
         every signal to ``SIG_DFL`` here and only re-installs SIGUSR1, so under
         this worker class SIGABRT would otherwise kill the process with no
         Python running and nothing sent to Sentry. Restore a handler that
-        captures the current stacks first. The Python handler is best-effort:
-        it runs on the main thread and needs the GIL, so a worker fully wedged
-        in GIL-holding C code may die before it runs. To cover that case we
-        also re-arm faulthandler for SIGABRT with ``chain=True``: its C-level
-        handler dumps all thread stacks to stderr (pod logs) *without* the GIL,
-        then chains to the Python ``handle_abort`` for the Sentry report once
-        the GIL is available.
+        captures the current stacks first. Best-effort: it runs on the main
+        thread and needs the GIL, so a worker fully wedged in GIL-holding C
+        code may die before it runs — but in practice fitz/MuPDF releases the
+        GIL during heavy work, so the handler usually gets a slice to report.
+
+        We can't hand SIGABRT to faulthandler for a GIL-free fallback:
+        ``faulthandler.register`` rejects the fatal signals (SIGABRT included)
+        with a RuntimeError, and ``faulthandler.enable`` (see init_process)
+        only dumps and re-raises to SIG_DFL with no chained Python callback.
+        A fully GIL-wedged worker therefore loses the Sentry event, matching
+        the existing SIGSEGV/SIGBUS story where only the stderr dump survives.
         """
         super().init_signals()
         signal.signal(signal.SIGABRT, self.handle_abort)
-        faulthandler.register(signal.SIGABRT, chain=True)
 
     def handle_abort(self, sig: int, frame: Any) -> None:
         self._report_timeout_to_sentry()


### PR DESCRIPTION
## What & why

`scanning-web` workers time out (SCANNING-1V `WORKER TIMEOUT`, 57×) with **no attribution**: the timeout is logged by the gunicorn master and carries no Python stack, so the blocking code path is unknown. This PR makes a timed-out worker report *what it was doing* to Sentry, per the investigation plan in #113.

Since all views are sync `def` running in the asgiref threadpool, a CPU-bound call there can hold the GIL and starve the event-loop callback that pings gunicorn — which is what trips the 180s `WORKER TIMEOUT`.

## Change (`scanning/workers.py`)

**Re-wire SIGABRT → Sentry.** gunicorn's arbiter sends SIGABRT to a worker that misses its `--timeout` heartbeat. gunicorn's base worker would route that to the `worker_abort` hook, but uvicorn's worker resets all signals to `SIG_DFL` and only re-installs SIGUSR1 — so under this worker class `worker_abort` never fires and the process dies with no Python running. We restore a SIGABRT handler that captures **all thread stacks** into a `level="fatal"` Sentry event (`all_thread_stacks` extra), then chains to gunicorn's default abort. Best-effort (runs on the main thread, needs the GIL); a reporting failure is printed to stderr rather than swallowed.

**Enable faulthandler** for native-crash coverage: if a C extension such as fitz/MuPDF faults on a bad PDF (SIGSEGV/SIGBUS/etc.), all thread stacks are dumped to stderr/pod logs before the process dies, instead of a silent exit. Zero cost until an actual crash.

## Changed from the first revision (addressing review)
- **Dropped** the `faulthandler.dump_traceback_later(..., repeat=True)` watchdog — it's an unconditional periodic timer, not a wedge detector, so it would have flooded healthy pods with all-thread dumps every 120s. Kept only `faulthandler.enable()` for crash dumps.
- **Dropped** the gunicorn `--access-logformat`/`%(D)s` change — uvicorn's worker ignores gunicorn's access-log format (it emits a hardcoded format via its own protocol layer), so the duration atom would never have appeared. Per-request duration is better done in middleware and is deferred to #115.

## Notes / limitations
- The SIGABRT→Sentry report needs the GIL, so a worker fully wedged in GIL-holding C code may die before it runs; in practice fitz/MuPDF releases the GIL during heavy work, so it usually gets a slice to report.
- Native crashes reach pod logs only, not Sentry (Python can't run after a fault).
- **Not** included: Sentry performance tracing, and observability (memory/OOM watchdog, in-flight-request logging, concurrency counters) — tracked in #115.

Refs #113