### PR TITLE
fix(scanning): retry transient daemon DB connection failures (SCANNING-20)

### DIFF
--- a/scanning/management/commands/process_next_scan.py
+++ b/scanning/management/commands/process_next_scan.py
@@ -16,10 +16,18 @@ Examples:
 """
 
 import logging
+import time
 
 from django.core.management.base import BaseCommand
 
 logger = logging.getLogger(__name__)
+
+# Every tick opens a fresh TCP+TLS connection (CONN_MAX_AGE=0 +
+# connections.close_all()), so an occasional transient connect failure
+# (SSL close_notify loss on a Postgres/pgbouncer blip) is expected. Retry
+# a couple of times before giving up on the tick. See issue #116.
+MAX_DB_RETRIES = 3
+RETRY_BACKOFF_SECONDS = 0.5
 
 
 class Command(BaseCommand):
@@ -35,8 +43,45 @@ class Command(BaseCommand):
         :param options: Parsed command-line options.
         :return: None.
         """
-        self._recover_stale()
-        self._process_next()
+        claimed = self._claim_next_scan_with_retry()
+        if claimed is None:
+            return
+        scan, action = claimed
+        self._dispatch(scan, action)
+
+    def _claim_next_scan_with_retry(self):
+        """Recover stale rows and claim the next queued scan, retrying
+        transient DB connection failures.
+
+        A fresh TCP+TLS connection is opened each attempt; a lost handshake
+        (``OperationalError``) is retried with a short backoff. Both
+        ``_recover_stale`` and ``_claim_next`` are idempotent under re-run,
+        so retrying the pair is safe. A blip that survives every attempt is
+        logged at WARNING (not ERROR) so a recovered, self-healing tick
+        doesn't create a Sentry error event.
+
+        :return: ``(scan, action)`` for the claimed scan, or ``None`` if
+            nothing was queued or the connection never recovered.
+        :rtype: tuple | None
+        """
+        from django.db import OperationalError, connections
+
+        for attempt in range(MAX_DB_RETRIES):
+            connections.close_all()
+            try:
+                self._recover_stale()
+                return self._claim_next()
+            except OperationalError as exc:
+                if attempt == MAX_DB_RETRIES - 1:
+                    logger.warning(
+                        "DB connection failed during daemon tick after "
+                        "%d attempts: %s",
+                        attempt + 1,
+                        exc,
+                    )
+                    return None
+                time.sleep(RETRY_BACKOFF_SECONDS * (attempt + 1))
+        return None
 
     def _recover_stale(self):
         """Reset scans stuck in PROCESSING past the timeout back to QUEUED.
@@ -67,18 +112,17 @@ class Command(BaseCommand):
                 progress_message="Re-queued (previous attempt timed out)",
             )
 
-    def _process_next(self):
-        """Fetch the next queued scan and dispatch its action.
+    def _claim_next(self):
+        """Atomically claim the next queued scan and mark it PROCESSING.
 
-        :return: None.
+        :return: ``(scan, action)`` for the claimed scan, or ``None`` if no
+            scan is queued.
+        :rtype: tuple | None
         """
-        from django.db import connections, transaction
+        from django.db import transaction
         from django.utils import timezone
 
-        from scanning import services
         from scanning.models import QueuedAction, Scan, Status
-
-        connections.close_all()
 
         with transaction.atomic():
             scan = (
@@ -88,7 +132,7 @@ class Command(BaseCommand):
                 .first()
             )
             if scan is None:
-                return
+                return None
 
             action = scan.queued_action or QueuedAction.FULL_PIPELINE
             Scan.objects.filter(pk=scan.pk).update(
@@ -98,6 +142,18 @@ class Command(BaseCommand):
                 progress_current=0,
                 progress_total=0,
             )
+
+        return scan, action
+
+    def _dispatch(self, scan, action):
+        """Run the queued action for an already-claimed scan.
+
+        :param scan: The claimed Scan instance (status PROCESSING).
+        :param action: The QueuedAction to run.
+        :return: None.
+        """
+        from scanning import services
+        from scanning.models import QueuedAction, Scan, Status
 
         self.stdout.write(f"Processing scan {scan.pk} ({action})")
 

--- a/scanning/management/commands/run_daemon.py
+++ b/scanning/management/commands/run_daemon.py
@@ -29,6 +29,7 @@ from dataclasses import dataclass, field
 from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
+from django.db import OperationalError
 
 logger = logging.getLogger(__name__)
 
@@ -117,6 +118,16 @@ class Command(BaseCommand):
                     continue
                 try:
                     call_command(task.name)
+                except OperationalError as exc:
+                    # Transient DB blip (e.g. a lost TLS handshake on a
+                    # fresh connection). Self-recovering; log at WARNING so
+                    # it stays a breadcrumb and doesn't create a Sentry
+                    # error event. See issue #116.
+                    logger.warning(
+                        "Scheduled task %s hit a transient DB error: %s",
+                        task.name,
+                        exc,
+                    )
                 except Exception:
                     logger.exception("Scheduled task %s failed", task.name)
                 task.mark_ran(time.monotonic())

--- a/scanning/tests/test_process_next_scan.py
+++ b/scanning/tests/test_process_next_scan.py
@@ -33,7 +33,10 @@ class TestProcessNextScanRetry(TestCase):
             patch.object(
                 Command,
                 "_recover_stale",
-                side_effect=[OperationalError("SSL error: unexpected eof"), None],
+                side_effect=[
+                    OperationalError("SSL error: unexpected eof"),
+                    None,
+                ],
             ),
             patch(
                 "scanning.management.commands.process_next_scan.time.sleep"

--- a/scanning/tests/test_process_next_scan.py
+++ b/scanning/tests/test_process_next_scan.py
@@ -1,0 +1,95 @@
+"""Tests for the process_next_scan daemon tick, focused on the transient
+DB-connection retry behavior added for issue #116 (SCANNING-20)."""
+
+from unittest.mock import patch
+
+from django.db import OperationalError
+from django.test import TestCase
+
+from scanning.factories import ScanFactory
+from scanning.management.commands.process_next_scan import (
+    MAX_DB_RETRIES,
+    Command,
+)
+from scanning.models import Status
+
+
+class TestProcessNextScanRetry(TestCase):
+    """A transient OperationalError while claiming should be retried.
+
+    The tick calls ``connections.close_all()`` every attempt; that would tear
+    down the connection this TestCase's wrapping transaction rides on, so it's
+    patched to a no-op. We're exercising the retry control flow, not the real
+    connection teardown/reconnect.
+    """
+
+    def test_retry_recovers_and_claims_scan(self):
+        """A blip on the first attempt is retried; the scan is then claimed."""
+        scan = ScanFactory(status=Status.QUEUED)
+        cmd = Command()
+
+        with (
+            patch("django.db.connections.close_all"),
+            patch.object(
+                Command,
+                "_recover_stale",
+                side_effect=[OperationalError("SSL error: unexpected eof"), None],
+            ),
+            patch(
+                "scanning.management.commands.process_next_scan.time.sleep"
+            ) as mock_sleep,
+            patch("scanning.services.run_full_pipeline") as mock_pipeline,
+        ):
+            cmd.handle()
+
+        scan.refresh_from_db()
+        self.assertEqual(scan.status, Status.PROCESSING)
+        mock_pipeline.assert_called_once_with(scan.pk)
+        # One failed attempt -> exactly one backoff sleep.
+        self.assertEqual(mock_sleep.call_count, 1)
+
+    def test_exhausted_retries_logs_warning_and_leaves_scan_queued(self):
+        """When every attempt fails, warn (no Sentry error) and give up cleanly."""
+        scan = ScanFactory(status=Status.QUEUED)
+        cmd = Command()
+
+        with (
+            patch("django.db.connections.close_all"),
+            patch.object(
+                Command,
+                "_recover_stale",
+                side_effect=OperationalError("SSL error: unexpected eof"),
+            ),
+            patch(
+                "scanning.management.commands.process_next_scan.time.sleep"
+            ) as mock_sleep,
+            patch("scanning.services.run_full_pipeline") as mock_pipeline,
+            self.assertLogs(
+                "scanning.management.commands.process_next_scan",
+                level="WARNING",
+            ) as logs,
+        ):
+            # Must not raise: the daemon tick swallows the transient error.
+            cmd.handle()
+
+        scan.refresh_from_db()
+        self.assertEqual(scan.status, Status.QUEUED)
+        mock_pipeline.assert_not_called()
+        # Backoff sleeps between attempts, none after the final failure.
+        self.assertEqual(mock_sleep.call_count, MAX_DB_RETRIES - 1)
+        self.assertEqual(len(logs.records), 1)
+        self.assertEqual(logs.records[0].levelname, "WARNING")
+        self.assertIn("DB connection failed", logs.records[0].getMessage())
+
+    def test_no_queued_scan_is_a_noop(self):
+        """With nothing queued, the tick claims nothing and dispatches nothing."""
+        ScanFactory(status=Status.UPLOADED)
+        cmd = Command()
+
+        with (
+            patch("django.db.connections.close_all"),
+            patch("scanning.services.run_full_pipeline") as mock_pipeline,
+        ):
+            cmd.handle()
+
+        mock_pipeline.assert_not_called()

--- a/scanning/tests/test_run_daemon.py
+++ b/scanning/tests/test_run_daemon.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch
 
+from django.db import OperationalError
 from django.test import TestCase, override_settings
 
 from scanning.factories import ScanFactory
@@ -64,6 +65,44 @@ class TestRunDaemonSchedule(TestCase):
         self.assertGreaterEqual(len(calls), 1)
         self.assertIn(
             calls[0], {"process_next_scan", "cleanup_processing_tmp"}
+        )
+
+    def test_transient_db_error_logged_as_warning_not_exception(self):
+        """A transient OperationalError from a task is a WARNING, not an error.
+
+        Downgrading it keeps a self-recovering DB blip out of Sentry's error
+        stream while the loop continues ticking (issue #116).
+        """
+        cmd = Command()
+        cmd.shutdown = False
+
+        def failing_call_command(name, *a, **kw):
+            cmd.shutdown = True
+            raise OperationalError("SSL error: unexpected eof while reading")
+
+        with (
+            patch(
+                "scanning.management.commands.run_daemon.call_command",
+                side_effect=failing_call_command,
+            ),
+            patch("scanning.management.commands.run_daemon.signal.signal"),
+            patch("scanning.management.commands.run_daemon.time.sleep"),
+            self.assertLogs(
+                "scanning.management.commands.run_daemon", level="WARNING"
+            ) as logs,
+        ):
+            cmd.handle()
+
+        # Both scheduled tasks are due on the first tick, so one warning per
+        # task; the point is every record is a WARNING (logger.exception would
+        # have logged at ERROR) mentioning the transient DB error.
+        self.assertTrue(cmd.shutdown)
+        self.assertGreaterEqual(len(logs.records), 1)
+        self.assertTrue(
+            all(r.levelname == "WARNING" for r in logs.records)
+        )
+        self.assertTrue(
+            all("transient DB error" in r.getMessage() for r in logs.records)
         )
 
 

--- a/scanning/tests/test_run_daemon.py
+++ b/scanning/tests/test_run_daemon.py
@@ -98,9 +98,7 @@ class TestRunDaemonSchedule(TestCase):
         # have logged at ERROR) mentioning the transient DB error.
         self.assertTrue(cmd.shutdown)
         self.assertGreaterEqual(len(logs.records), 1)
-        self.assertTrue(
-            all(r.levelname == "WARNING" for r in logs.records)
-        )
+        self.assertTrue(all(r.levelname == "WARNING" for r in logs.records))
         self.assertTrue(
             all("transient DB error" in r.getMessage() for r in logs.records)
         )


### PR DESCRIPTION
## Summary

Sentry [SCANNING-20](https://freelawproject.sentry.io/issues/7515179433/) fires transient DB connection errors from the daemon:

    OperationalError: connection failed: connection to server at "172.30.1.92", port 5432 failed: SSL error: unexpected eof while reading

17 occurrences in ~5 weeks, 0 users impacted, already handled and self-recovering — but each one lands as a Sentry *error*.

## Root cause

`CONN_MAX_AGE: 0` plus `connections.close_all()` on every ~5s daemon tick means the daemon opens a brand-new TCP+TLS connection every tick (~17k/day) and never reuses one. Occasionally that fresh handshake loses `close_notify` (a Postgres/pgbouncer restart or failover, a connection-limit rejection, or a middlebox reset), raising `OperationalError`. It's environmental, self-recovering noise — the next tick reconnects fine.

It surfaces as a Sentry *error* only because the daemon loop logs it via `logger.exception`, and Sentry's `DjangoIntegration` promotes ERROR-level logs to events (default `event_level=ERROR`).

## Changes

- **Retry the DB-claim portion of a tick.** `process_next_scan._process_next()` was split into `_claim_next()` (the atomic claim) and `_dispatch()` (the pipeline run). The claim — `_recover_stale()` + `_claim_next()`, both idempotent under re-run — is now wrapped in `_claim_next_scan_with_retry()`, which opens a fresh connection and retries up to 3 times with a short backoff (0.5·attempt s). The long-running pipeline dispatch stays **outside** the retry so it runs exactly once with its existing error handling.
- **Downgrade recovered blips to WARNING.** A transient failure that survives all retries is logged at WARNING (a Sentry breadcrumb, not an error event), and the tick gives up cleanly until the next one.
- **Defense-in-depth in the daemon loop.** `run_daemon` now catches `OperationalError` from any scheduled task and logs it at WARNING before the generic `except Exception: logger.exception`, so a transient DB blip from `cleanup_processing_tmp` (or any path outside the retry) also stays out of Sentry's error stream.

## Tests

- New `scanning/tests/test_process_next_scan.py` (the command previously had no dedicated tests): retry-then-succeed, exhausted-retries (warns, scan stays QUEUED, no exception propagates), and empty-queue no-op.
- `scanning/tests/test_run_daemon.py`: added a case asserting a transient `OperationalError` is logged at WARNING, never ERROR.

All 261 tests pass (1 skipped).

Fixes: #116
