### PR TITLE
feat(scanning): log in-flight requests and concurrency to attribute worker saturation

### DIFF
--- a/scanning/middleware.py
+++ b/scanning/middleware.py
@@ -1,0 +1,62 @@
+"""Request-path middleware for web-worker observability (issue #115)."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+
+from django.http import HttpRequest, HttpResponse
+
+from . import observability
+
+
+class InFlightRequestMiddleware:
+    """Track each in-flight request in a shared registry for the monitor thread.
+
+    gunicorn's access log only writes a line on response *completion*, so a
+    request that hangs until the worker is SIGKILL'd never logs. This records the
+    request on entry (keyed by the serving thread id) and clears it on
+    completion; :class:`scanning.observability.WebMonitor` logs any entry that
+    stays in flight too long, naming the frozen endpoint with its params before
+    the worker dies.
+    """
+
+    def __init__(
+        self, get_response: Callable[[HttpRequest], HttpResponse]
+    ) -> None:
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        ident = threading.get_ident()
+        observability.register_request(ident, request.path, request.method)
+        try:
+            return self.get_response(request)
+        finally:
+            observability.unregister_request(ident)
+
+    def process_view(
+        self,
+        request: HttpRequest,
+        view_func: Callable[..., HttpResponse],
+        view_args: tuple,
+        view_kwargs: dict,
+    ) -> None:
+        """Enrich the entry with resolved view context (scan_pk, user).
+
+        Runs after URL resolution and after auth middleware, so ``request.user``
+        is available; the username is captured as a plain string here rather than
+        being read from the request by the monitor thread.
+        """
+        scan_pk = view_kwargs.get("pk") or view_kwargs.get("scan_pk")
+        user = getattr(request, "user", None)
+        username = (
+            getattr(user, "username", None) or "anonymous"
+            if user is not None
+            else None
+        )
+        observability.annotate_request(
+            threading.get_ident(),
+            str(scan_pk) if scan_pk is not None else None,
+            username,
+        )
+        return None

--- a/scanning/observability.py
+++ b/scanning/observability.py
@@ -1,0 +1,178 @@
+"""Web-worker observability: in-flight-request and concurrency logging.
+
+Closes the attribution gaps left by the worker-timeout instrumentation in
+:mod:`scanning.workers` (see issue #115). All web views are sync ``def`` running
+in the asgiref threadpool, so a handful of heavy requests (PDF render, S3 pull,
+blackletter generation) can occupy every worker and starve the event loop — the
+worker then misses its gunicorn heartbeat (WORKER TIMEOUT / SCANNING-1V) and the
+kubelet's liveness probe times out and kills the pod. Neither the gunicorn access
+log (which writes only on response *completion*, so a request that hangs until
+the worker dies never logs) nor faulthandler (which names the view function but
+not the request context) tells you *which* request saturated the workers.
+
+This closes that:
+
+- A middleware records each in-flight request in a shared registry, keyed by the
+  serving thread id, with its URL, ``scan_pk`` and user (see
+  :mod:`scanning.middleware`).
+- A background thread periodically logs any request that has been in flight
+  longer than a threshold — with its endpoint and params, *while it is still
+  hung* — plus the in-flight count and ``threading.active_count()`` to surface
+  threadpool/concurrency saturation.
+
+Memory/RSS is intentionally not tracked here: ``container_memory_working_set_bytes``
+from cAdvisor is already in Prometheus/Grafana.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import NamedTuple
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# In-flight request registry (populated by InFlightRequestMiddleware)
+# ---------------------------------------------------------------------------
+
+
+class InFlightRequest(NamedTuple):
+    """A snapshot of a request currently being served, keyed by thread id.
+
+    Only plain primitives are stored — never the request object — so the monitor
+    thread can read them without touching request/DB state from another thread.
+    """
+
+    path: str
+    method: str
+    start: float  # time.monotonic() at request entry
+    scan_pk: str | None
+    user: str | None
+
+
+_registry: dict[int, InFlightRequest] = {}
+_registry_lock = threading.Lock()
+
+
+def register_request(ident: int, path: str, method: str) -> None:
+    """Record a request as in-flight on entry. ``ident`` is the worker thread id."""
+    with _registry_lock:
+        _registry[ident] = InFlightRequest(
+            path=path,
+            method=method,
+            start=time.monotonic(),
+            scan_pk=None,
+            user=None,
+        )
+
+
+def annotate_request(
+    ident: int, scan_pk: str | None, user: str | None
+) -> None:
+    """Enrich an in-flight entry with view context resolved after dispatch."""
+    with _registry_lock:
+        entry = _registry.get(ident)
+        if entry is not None:
+            _registry[ident] = entry._replace(scan_pk=scan_pk, user=user)
+
+
+def unregister_request(ident: int) -> None:
+    """Clear a request from the registry on completion (called in a ``finally``)."""
+    with _registry_lock:
+        _registry.pop(ident, None)
+
+
+def _snapshot_registry() -> list[tuple[int, InFlightRequest]]:
+    with _registry_lock:
+        return list(_registry.items())
+
+
+# ---------------------------------------------------------------------------
+# The monitor
+# ---------------------------------------------------------------------------
+
+
+class WebMonitor:
+    """One tick of concurrency/in-flight checks, plus the loop to run them.
+
+    Split from thread management so ``run_checks`` can be exercised directly in
+    tests with an injected ``now`` and a seeded registry, without real threads.
+    """
+
+    def __init__(self, *, interval: float, inflight_warn: float) -> None:
+        self.interval = interval
+        self.inflight_warn = inflight_warn
+
+    def run_checks(self, now: float) -> None:
+        """Perform one observability tick. ``now`` is a ``time.monotonic()`` value."""
+        inflight = _snapshot_registry()
+
+        # Concurrency/threadpool saturation signal.
+        logger.info(
+            "web-monitor inflight=%d threads=%d",
+            len(inflight),
+            threading.active_count(),
+        )
+
+        # Name each hung request, with params, while it is still in flight.
+        for ident, entry in inflight:
+            elapsed = now - entry.start
+            if elapsed >= self.inflight_warn:
+                logger.warning(
+                    "web-monitor hung request thread=%d elapsed=%.1fs "
+                    "%s %s scan_pk=%s user=%s",
+                    ident,
+                    elapsed,
+                    entry.method,
+                    entry.path,
+                    entry.scan_pk,
+                    entry.user,
+                )
+
+    def _loop(self) -> None:
+        while True:
+            time.sleep(self.interval)
+            try:
+                self.run_checks(time.monotonic())
+            except Exception:
+                # A transient failure in one tick must never kill the monitor.
+                logger.exception("web-monitor tick failed")
+
+
+_monitor_lock = threading.Lock()
+_monitor_started = False
+
+
+def start_monitor() -> None:
+    """Launch the background monitor thread once per worker process.
+
+    Called post-fork from :meth:`scanning.workers.UvicornWorker.init_process`
+    (the app is preloaded, so a thread started pre-fork would not survive). Reads
+    its knobs from Django settings and is idempotent.
+    """
+    global _monitor_started
+    with _monitor_lock:
+        if _monitor_started:
+            return
+        _monitor_started = True
+
+    from django.conf import settings
+
+    monitor = WebMonitor(
+        interval=settings.WEB_MONITOR_INTERVAL_SECONDS,
+        inflight_warn=settings.WEB_INFLIGHT_WARN_SECONDS,
+    )
+    thread = threading.Thread(
+        target=monitor._loop,
+        name="web-monitor",
+        daemon=True,
+    )
+    thread.start()
+    logger.info(
+        "web-monitor started (interval=%ss inflight_warn=%ss)",
+        monitor.interval,
+        monitor.inflight_warn,
+    )

--- a/scanning/settings/__init__.py
+++ b/scanning/settings/__init__.py
@@ -1,6 +1,7 @@
 from .django import *
 from .project.daemon import *
 from .project.logging import *
+from .project.observability import *
 from .project.processing_storage import *
 from .project.runpod import *
 from .project.security import *

--- a/scanning/settings/django.py
+++ b/scanning/settings/django.py
@@ -101,6 +101,8 @@ TEMPLATES = [
 ]
 
 MIDDLEWARE = [
+    # Outermost, so the in-flight start time covers the whole request lifetime.
+    "scanning.middleware.InFlightRequestMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",

--- a/scanning/settings/project/observability.py
+++ b/scanning/settings/project/observability.py
@@ -1,0 +1,17 @@
+import environ
+
+env = environ.FileAwareEnv()
+
+# How often (in seconds) the web-worker monitor thread wakes up to log the
+# in-flight request count + active thread count and check for hung requests.
+WEB_MONITOR_INTERVAL_SECONDS = env.float(
+    "WEB_MONITOR_INTERVAL_SECONDS", default=10.0
+)
+
+# A request still in flight for longer than this (seconds) is logged as hung by
+# the monitor thread, together with its endpoint, scan_pk and user, *while it is
+# still running* — gunicorn's access log only writes on completion, so a request
+# that hangs until the worker is killed never logs there.
+WEB_INFLIGHT_WARN_SECONDS = env.float(
+    "WEB_INFLIGHT_WARN_SECONDS", default=30.0
+)

--- a/scanning/tests/test_observability.py
+++ b/scanning/tests/test_observability.py
@@ -1,0 +1,121 @@
+"""Tests for web-worker observability (issue #115).
+
+These exercise the pure tick logic and the middleware registry directly, without
+starting real background threads.
+"""
+
+from unittest import mock
+
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory, SimpleTestCase
+
+from scanning import observability
+from scanning.middleware import InFlightRequestMiddleware
+from scanning.observability import InFlightRequest, WebMonitor
+
+
+class RegistryTestMixin:
+    """Reset the shared in-flight registry around each test."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        observability._registry.clear()
+        self.addCleanup(observability._registry.clear)
+
+
+class InFlightMiddlewareTest(RegistryTestMixin, SimpleTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.factory = RequestFactory()
+
+    def test_entry_present_during_request_and_cleared_after(self) -> None:
+        seen: dict[int, InFlightRequest] = {}
+
+        def get_response(request):
+            # The registry is populated while the view runs.
+            seen.update(observability._registry)
+            from django.http import HttpResponse
+
+            return HttpResponse("ok")
+
+        middleware = InFlightRequestMiddleware(get_response)
+        request = self.factory.get("/scan/42/")
+        middleware(request)
+
+        self.assertEqual(len(seen), 1)
+        (entry,) = seen.values()
+        self.assertEqual(entry.path, "/scan/42/")
+        self.assertEqual(entry.method, "GET")
+        # Cleared on completion.
+        self.assertEqual(observability._registry, {})
+
+    def test_entry_cleared_even_when_view_raises(self) -> None:
+        def get_response(request):
+            raise ValueError("boom")
+
+        middleware = InFlightRequestMiddleware(get_response)
+        with self.assertRaises(ValueError):
+            middleware(self.factory.get("/scan/42/"))
+        # The finally in __call__ must still clear the entry.
+        self.assertEqual(observability._registry, {})
+
+    def test_process_view_records_scan_pk_and_user(self) -> None:
+        middleware = InFlightRequestMiddleware(lambda r: None)
+        request = self.factory.get("/scan/42/")
+        request.user = AnonymousUser()
+
+        observability.register_request(1234, "/scan/42/", "GET")
+        with mock.patch("threading.get_ident", return_value=1234):
+            middleware.process_view(request, lambda r: None, (), {"pk": 42})
+
+        entry = observability._registry[1234]
+        self.assertEqual(entry.scan_pk, "42")
+        self.assertEqual(entry.user, "anonymous")
+
+
+class WebMonitorTest(RegistryTestMixin, SimpleTestCase):
+    def _monitor(self, **kwargs) -> WebMonitor:
+        defaults = dict(interval=10.0, inflight_warn=30.0)
+        defaults.update(kwargs)
+        return WebMonitor(**defaults)
+
+    def test_concurrency_line_logged(self) -> None:
+        observability._registry[1] = InFlightRequest(
+            path="/scan/7/", method="GET", start=99.0, scan_pk="7", user="a"
+        )
+        monitor = self._monitor()
+        with self.assertLogs("scanning.observability", level="INFO") as logs:
+            monitor.run_checks(now=100.0)
+        self.assertIn("web-monitor inflight=1", "\n".join(logs.output))
+
+    def test_hung_request_is_logged(self) -> None:
+        observability._registry[1] = InFlightRequest(
+            path="/scan/7/process/",
+            method="POST",
+            start=0.0,
+            scan_pk="7",
+            user="alice",
+        )
+        monitor = self._monitor(inflight_warn=30.0)
+        with self.assertLogs(
+            "scanning.observability", level="WARNING"
+        ) as logs:
+            monitor.run_checks(now=100.0)  # elapsed 100s >= 30s
+
+        joined = "\n".join(logs.output)
+        self.assertIn("hung request", joined)
+        self.assertIn("scan_pk=7", joined)
+        self.assertIn("/scan/7/process/", joined)
+
+    def test_fresh_request_not_flagged(self) -> None:
+        observability._registry[1] = InFlightRequest(
+            path="/scan/7/",
+            method="GET",
+            start=95.0,
+            scan_pk="7",
+            user="alice",
+        )
+        monitor = self._monitor(inflight_warn=30.0)
+        with self.assertLogs("scanning.observability", level="INFO") as logs:
+            monitor.run_checks(now=100.0)  # elapsed 5s < 30s
+        self.assertNotIn("hung request", "\n".join(logs.output))

--- a/scanning/views_process.py
+++ b/scanning/views_process.py
@@ -104,6 +104,12 @@ def scan_process_view(request: HttpRequest, pk: int) -> HttpResponse:
     """
     scan = get_object_or_404(Scan.objects.select_related("reporter"), pk=pk)
     is_processing = scan.status in (Status.PROCESSING, Status.QUEUED)
+    # Breadcrumb for the web-pod observability trail (issue #115): this view
+    # does an S3 pull plus a render over potentially large detection sets, so a
+    # hang/OOM here should leave a marker in the pod logs and Sentry.
+    logger.info(
+        "scan_process_view: rendering scan=%s status=%s", scan.pk, scan.status
+    )
 
     # Always attempt the S3 pull. The helper is size-based idempotent
     # and no-ops in DEV/TESTING, so calling it during QUEUED/PROCESSING
@@ -475,6 +481,9 @@ def serve_scan_pdf(request: HttpRequest, pk: int) -> FileResponse:
     :raises Http404: When no PDF exists locally and S3 has nothing to pull.
     """
     scan = get_object_or_404(Scan, pk=pk)
+    # Breadcrumb (issue #115): serving may pull from S3 and stream a multi-GB
+    # original; mark the start so a stall here is attributable in the trail.
+    logger.info("serve_scan_pdf: resolving pdf for scan=%s", scan.pk)
 
     def _processed_local() -> FileResponse | None:
         """Return the OCR pdf, else ``bitonal.pdf``, from ``output_dir``."""
@@ -547,6 +556,15 @@ def serve_original_crop(request: HttpRequest, pk: int) -> HttpResponse:
     except ValueError:
         return HttpResponse(status=400)
 
+    # Breadcrumb (issue #115): the pixmap render below is the clearest
+    # per-request memory spike in the web pod (5-20 MB at dpi=300), so log it
+    # with its scale before allocating.
+    logger.info(
+        "serve_original_crop: rendering scan=%s page=%s dpi=%s",
+        scan.pk,
+        page,
+        dpi,
+    )
     with fitz.open(scan.pdf_path) as doc:
         if page < 0 or page >= doc.page_count:
             return HttpResponse(status=404)
@@ -734,6 +752,9 @@ def recalculate(request: HttpRequest, pk: int) -> HttpResponse:
         return redirect("scan_process", pk=pk)
     from scanning import services
 
+    # Breadcrumb (issue #115): recalculation runs synchronously on the request
+    # thread over the scan's OCR results.
+    logger.info("recalculate: recomputing issues for scan=%s", scan.pk)
     services.recalculate_issues(scan)
     return redirect("scan_process", pk=pk)
 

--- a/scanning/workers.py
+++ b/scanning/workers.py
@@ -26,6 +26,11 @@ class UvicornWorker(BaseUvicornWorker):
         SIGABRT handler wired up in init_signals().
         """
         faulthandler.enable()
+        # Launch the in-flight-request and concurrency monitor thread (issue
+        # #115). Post-fork so it lives in the worker, not the preloaded master.
+        from scanning.observability import start_monitor
+
+        start_monitor()
         super().init_process()
 
     def init_signals(self) -> None:


### PR DESCRIPTION
## What & why

Closes the "which request saturated the workers" attribution gap left by #114.

All web views are sync `def` running in the asgiref threadpool, so a handful of heavy requests (PDF render via fitz, S3 pull, blackletter generation) can occupy every worker and starve the event loop. The worker then misses its gunicorn heartbeat (**WORKER TIMEOUT / SCANNING-1V**) and the kubelet's **liveness probe** times out and kills the pod (#120). But:

- the gunicorn **access log** only writes on response *completion*, so a request that hangs until the worker dies **never logs**, and
- **faulthandler** (#114) names the view *function* but not the request context (`scan_pk`, user, URL).

So today there's no way to see *which* request wedged the workers. This adds it.

## Changes

- **`InFlightRequestMiddleware`** — records each request (path, method, `scan_pk`, user) in a shared registry keyed by the serving thread id; cleared in a `finally` so it can't leak (verified even when the view raises).
- **`scanning/observability.py`** — a per-worker background monitor thread that each tick logs `web-monitor inflight=N threads=M` (threadpool/concurrency saturation) and warns on any request in flight past `WEB_INFLIGHT_WARN_SECONDS`, **with its endpoint + params, while it's still hung**.
- Monitor is started post-fork in `UvicornWorker.init_process` (preload-safe: one monitor per worker). The only other change to `workers.py` is that `start_monitor()` call — the #114 SIGABRT/timeout handler is untouched.
- **INFO breadcrumbs** on the heavy web request paths (`scan_process_view`, `serve_scan_pdf`, `serve_original_crop`, `recalculate`). These double as **Sentry breadcrumbs** on the timeout events, showing the last steps a wedged worker ran.
- Settings knobs: `WEB_MONITOR_INTERVAL_SECONDS` (10s), `WEB_INFLIGHT_WARN_SECONDS` (30s).

## Deliberately out of scope

Memory/RSS is **not** tracked here — `container_memory_working_set_bytes` from cAdvisor is already in Prometheus/Grafana. Investigation showed the pod churn is infrastructure (spot reclamation, HPA flapping, preemption, 1.5 GB image), not app OOM, so the memory/OOM watchdog originally scoped for #115 was dropped.

## Testing

`python manage.py test scanning.tests.test_observability` — 6 tests: middleware lifecycle (incl. exception path and `scan_pk`/user capture) and the monitor tick (concurrency line, hung vs fresh request). ruff clean.

## Related

- Refs #115
- Relates to #120 (liveness-probe kills from the same worker saturation), #119 (image size aggravating churn), #113/#114 (investigation + timeout stack capture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
