### PR TITLE
feat(scanning): attach in-flight requests to WORKER TIMEOUT Sentry event

### DIFF
--- a/scanning/middleware.py
+++ b/scanning/middleware.py
@@ -28,7 +28,12 @@ class InFlightRequestMiddleware:
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
         ident = threading.get_ident()
-        observability.register_request(ident, request.path, request.method)
+        # get_full_path() (not request.path) so the query string is captured —
+        # the params (e.g. ?page=15&dpi=300 on a crop render, ?step=) are exactly
+        # what attributes a heavy request when it wedges a worker.
+        observability.register_request(
+            ident, request.get_full_path(), request.method
+        )
         try:
             return self.get_response(request)
         finally:

--- a/scanning/observability.py
+++ b/scanning/observability.py
@@ -104,7 +104,7 @@ def snapshot_for_report(now: float | None = None) -> list[dict]:
     Only reads the lock-guarded registry — never request/DB state — so it is
     safe to call from any thread. The main thread never holds ``_registry_lock``
     (only request/monitor threads do, briefly), so this cannot self-deadlock in
-    the signal handler. ``now`` defaults to ``time.monotonic()``; the newest
+    the signal handler. ``now`` defaults to ``time.monotonic()``; the oldest
     (longest-running) request is listed first.
     """
     if now is None:

--- a/scanning/observability.py
+++ b/scanning/observability.py
@@ -90,6 +90,40 @@ def _snapshot_registry() -> list[tuple[int, InFlightRequest]]:
         return list(_registry.items())
 
 
+def snapshot_for_report(now: float | None = None) -> list[dict]:
+    """Return a JSON-serializable snapshot of in-flight requests for Sentry.
+
+    Called from :meth:`scanning.workers.UvicornWorker._report_timeout_to_sentry`
+    (which runs in the SIGABRT handler on the *main* thread) to attach the
+    wedging request's endpoint, ``scan_pk`` and user to the WORKER TIMEOUT
+    event. Sentry breadcrumbs are per-thread, so the monitor thread's warnings
+    never reach that event; the registry is a lock-guarded module global, so
+    reading it directly from the main thread is the one way this attribution
+    lands in Sentry rather than only in the pod logs.
+
+    Only reads the lock-guarded registry — never request/DB state — so it is
+    safe to call from any thread. The main thread never holds ``_registry_lock``
+    (only request/monitor threads do, briefly), so this cannot self-deadlock in
+    the signal handler. ``now`` defaults to ``time.monotonic()``; the newest
+    (longest-running) request is listed first.
+    """
+    if now is None:
+        now = time.monotonic()
+    snapshot = [
+        {
+            "thread": ident,
+            "method": entry.method,
+            "path": entry.path,
+            "scan_pk": entry.scan_pk,
+            "user": entry.user,
+            "elapsed_s": round(now - entry.start, 1),
+        }
+        for ident, entry in _snapshot_registry()
+    ]
+    snapshot.sort(key=lambda item: item["elapsed_s"], reverse=True)
+    return snapshot
+
+
 # ---------------------------------------------------------------------------
 # The monitor
 # ---------------------------------------------------------------------------

--- a/scanning/tests/test_observability.py
+++ b/scanning/tests/test_observability.py
@@ -39,12 +39,13 @@ class InFlightMiddlewareTest(RegistryTestMixin, SimpleTestCase):
             return HttpResponse("ok")
 
         middleware = InFlightRequestMiddleware(get_response)
-        request = self.factory.get("/scan/42/")
+        # Query string included: register_request uses get_full_path().
+        request = self.factory.get("/scan/42/?page=3&dpi=300")
         middleware(request)
 
         self.assertEqual(len(seen), 1)
         (entry,) = seen.values()
-        self.assertEqual(entry.path, "/scan/42/")
+        self.assertEqual(entry.path, "/scan/42/?page=3&dpi=300")
         self.assertEqual(entry.method, "GET")
         # Cleared on completion.
         self.assertEqual(observability._registry, {})

--- a/scanning/tests/test_observability.py
+++ b/scanning/tests/test_observability.py
@@ -119,3 +119,38 @@ class WebMonitorTest(RegistryTestMixin, SimpleTestCase):
         with self.assertLogs("scanning.observability", level="INFO") as logs:
             monitor.run_checks(now=100.0)  # elapsed 5s < 30s
         self.assertNotIn("hung request", "\n".join(logs.output))
+
+
+class SnapshotForReportTest(RegistryTestMixin, SimpleTestCase):
+    """The snapshot attached to the WORKER TIMEOUT Sentry event (issue #115)."""
+
+    def test_empty_registry_returns_empty_list(self) -> None:
+        self.assertEqual(observability.snapshot_for_report(now=100.0), [])
+
+    def test_computes_elapsed_and_orders_longest_first(self) -> None:
+        observability._registry[1] = InFlightRequest(
+            path="/scans/7/original-crop/?page=15&dpi=300",
+            method="GET",
+            start=40.0,  # elapsed 60s
+            scan_pk="7",
+            user="alice",
+        )
+        observability._registry[2] = InFlightRequest(
+            path="/scans/9/process/",
+            method="POST",
+            start=95.0,  # elapsed 5s
+            scan_pk="9",
+            user="bob",
+        )
+
+        snapshot = observability.snapshot_for_report(now=100.0)
+
+        # Longest-running request first, with a JSON-serializable payload.
+        self.assertEqual([item["scan_pk"] for item in snapshot], ["7", "9"])
+        self.assertEqual(snapshot[0]["elapsed_s"], 60.0)
+        self.assertEqual(snapshot[0]["method"], "GET")
+        self.assertEqual(
+            snapshot[0]["path"], "/scans/7/original-crop/?page=15&dpi=300"
+        )
+        self.assertEqual(snapshot[0]["user"], "alice")
+        self.assertEqual(snapshot[1]["elapsed_s"], 5.0)

--- a/scanning/workers.py
+++ b/scanning/workers.py
@@ -67,14 +67,25 @@ class UvicornWorker(BaseUvicornWorker):
         try:
             import sentry_sdk
 
+            from scanning import observability
+
             dump = []
             for thread_id, thread_frame in sys._current_frames().items():
                 dump.append(f"Thread {thread_id}:")
                 dump.append("".join(traceback.format_stack(thread_frame)))
             stacks = "\n".join(dump)
 
+            # Attribution for *which* request wedged the worker. The monitor
+            # thread's hung-request warnings can't reach this event — Sentry
+            # breadcrumbs are per-thread and this runs on the main thread — but
+            # the in-flight registry is a lock-guarded module global we can read
+            # directly here. Without this the endpoint/scan_pk/user only ever
+            # appear in the pod logs (issue #115).
+            in_flight = observability.snapshot_for_report()
+
             with sentry_sdk.new_scope() as scope:
                 scope.set_extra("all_thread_stacks", stacks)
+                scope.set_extra("in_flight_requests", in_flight)
                 sentry_sdk.capture_message(
                     "gunicorn WORKER TIMEOUT: worker aborted after --timeout",
                     level="fatal",


### PR DESCRIPTION
## What & why

Follow-up to #121. That PR added an in-flight-request registry + monitor thread so we could attribute *which* request wedged a web worker. But the attribution only ever reaches the **pod logs** — it never makes it into the Sentry WORKER TIMEOUT event, which is where triage actually starts.

The reason is thread scoping. The monitor thread's `web-monitor hung request …` warnings and the per-view INFO breadcrumbs are emitted from **background / request-serving threads**, and Sentry breadcrumbs are **per-thread** (contextvar-scoped isolation scope; `threading.Thread` children don't inherit the parent context). The fatal event is captured on the **main thread** inside the SIGABRT handler (`_report_timeout_to_sentry`), so none of those breadcrumbs are visible at capture time.

## Evidence

Verified against the first post-#121 deploy event — **SCANNING-2C**, `gunicorn WORKER TIMEOUT: worker aborted after --timeout`, release `18b2a12`:

- The worker booted at 20:00:00 and timed out at 20:14:46 (~14 min later).
- Over that window the monitor should have logged `web-monitor inflight=…` ~80+ times.
- The event's breadcrumb trail is **6 lines total**: gunicorn boot, the one-time `web-monitor started`, and uvicorn start. The `web-monitor started` line survives *only* because it's logged on the main thread in `init_process`. Zero periodic monitor lines, zero `hung request`, zero view breadcrumbs.

So #121's Sentry payload is effectively empty; the useful data lives only in stdout.

## Change

The registry (`observability._registry`) is a **lock-guarded module global**, not thread-scoped, so the main thread can read it directly. This adds:

- `observability.snapshot_for_report(now=None)` — returns a JSON-serializable list of in-flight requests (`thread`, `method`, `path`, `scan_pk`, `user`, `elapsed_s`), longest-running first. Reads only the lock-guarded registry, so it's safe to call from the SIGABRT handler; the main thread never holds `_registry_lock`, so it can't self-deadlock.
- `_report_timeout_to_sentry()` snapshots it and attaches it as an `in_flight_requests` scope extra alongside `all_thread_stacks`.

Net effect: the wedging endpoint + `scan_pk` + user now land on the fatal event itself.

## Testing

`python manage.py test scanning.tests.test_observability` — 8 tests (adds `SnapshotForReportTest`: empty-registry and elapsed/ordering). ruff clean.

## Notes / scope

- Purely additive; no change to the existing stack-dump path, monitor, middleware, or flush budget.
- In the specific SCANNING-2C event the captured stacks showed no request thread wedged (only idle sentry threads + the sleeping monitor + the main thread in the abort handler), i.e. the registry can legitimately be empty at capture — `snapshot_for_report` returns `[]` then, which is fine. This wires up attribution for the common case where a heavy request *is* in flight.

## Related

- Refs #115, follows #121 (in-flight registry + monitor), builds on #114 (SIGABRT stack capture).