### PR TITLE
Slim the container image with a multi-stage build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,8 +26,9 @@ jobs:
           push: false
           tags: scanning:latest
           outputs: type=docker,dest=/tmp/scanning.tar
-          build-args: |
-            BUILD_ENV=dev
+          # Test the dev stage: the suite runs with DEVELOPMENT=True, which
+          # pulls in dev-only apps (django_extensions, ...) absent from prod.
+          target: dev
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -136,11 +136,14 @@ WORKDIR /opt/scanning
 COPY --from=deps-prod /opt/venv /opt/venv
 
 # App source (build context excludes node_modules and built static via
-# .dockerignore) plus the compiled Tailwind CSS from the static stage.
+# .dockerignore) plus the full compiled static-global tree from the static
+# stage. That tree (Tailwind CSS + FontAwesome CSS + webfonts) is gitignored,
+# so it is absent from a fresh checkout's build context and must come from the
+# builder, or collectstatic silently ships an image missing those assets.
 COPY . .
 COPY --from=static-builder \
-     /opt/scanning/scanning/assets/static-global/css/tailwind_styles.css \
-     /opt/scanning/scanning/assets/static-global/css/tailwind_styles.css
+     /opt/scanning/scanning/assets/static-global/ \
+     /opt/scanning/scanning/assets/static-global/
 
 # Create directories for collectstatic output and uploaded/processed files
 RUN mkdir -p /opt/scanning/scanning/assets/static/ \

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -1,3 +1,10 @@
+# syntax=docker/dockerfile:1
+
+##############################################################################
+# build-base: full image with compilers and build tooling.                   #
+# Shared parent for the dependency- and static-build stages. Nothing from     #
+# here ships to prod unless it is explicitly COPYed into the runtime stage.   #
+##############################################################################
 FROM python:3.12 AS build-base
 
 # Install apt dependencies
@@ -20,42 +27,125 @@ COPY --from=ghcr.io/astral-sh/uv:0.9.22 /uv /uvx /bin/
 
 ENV PYTHONUNBUFFERED=1
 ENV YOLO_CONFIG_DIR=/tmp/Ultralytics
-ENV PADDLEX_HOME=/tmp/paddlex
+# paddlex reads PADDLE_PDX_CACHE_HOME (not PADDLEX_HOME); point it at /tmp.
+ENV PADDLE_PDX_CACHE_HOME=/tmp/paddlex
 
-ARG BUILD_ENV=prod
-ARG GIT_SHA=""
-ENV GIT_SHA=${GIT_SHA}
-
-FROM build-base AS python-base
-
-WORKDIR /opt/scanning
-
-# uv install dependencies
-COPY pyproject.toml .
-COPY uv.lock .
 ENV \
     UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
     UV_PROJECT_ENVIRONMENT=/opt/venv \
     PATH="/opt/venv/bin:$PATH"
+
+WORKDIR /opt/scanning
+
+##############################################################################
+# deps-prod / deps-dev: build the virtualenv at /opt/venv.                    #
+# Split so each build only resolves the deps it needs and layer caching keys  #
+# on pyproject.toml + uv.lock alone (source changes don't bust the venv).     #
+##############################################################################
+FROM build-base AS deps-prod
+
+COPY pyproject.toml uv.lock ./
+# No --all-extras: the only extra is `dev` (mypy, pytest, debug-toolbar, ...),
+# which must not ship to prod. Extras are opt-in, so plain sync excludes it.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync
+
+FROM build-base AS deps-dev
+
+COPY pyproject.toml uv.lock ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --all-extras
 
-# npm install dependencies
+##############################################################################
+# static-builder: install npm packages and compile Tailwind CSS.             #
+# node/npm/node_modules live here only and never reach the runtime image.    #
+##############################################################################
+FROM build-base AS static-builder
+
 COPY package.json ./
 COPY package-lock.jso[n] ./
 RUN npm install
 
 COPY . .
-
-# Build Tailwind CSS
 RUN npm run build
+
+##############################################################################
+# dev: full image used for local development (docker-compose `target: dev`).  #
+# Source is bind-mounted over /opt/scanning at run time; keeps uv + dev deps  #
+# for the entrypoint's editable blackletter install and runserver.            #
+##############################################################################
+FROM build-base AS dev
+
+ARG GIT_SHA=""
+ENV GIT_SHA=${GIT_SHA}
+
+COPY --from=deps-dev /opt/venv /opt/venv
+COPY . .
+
+RUN mkdir -p /opt/scanning/scanning/assets/static/ \
+             /opt/scanning/scanning/assets/media/
+RUN chmod +x /opt/scanning/docker/django/docker-entrypoint.sh
+RUN chown www-data:www-data /opt/scanning/docker/django/docker-entrypoint.sh \
+                            /opt/scanning/scanning/assets/media/
+
+ENTRYPOINT ["/bin/sh", "/opt/scanning/docker/django/docker-entrypoint.sh"]
+
+##############################################################################
+# prod: slim runtime image (default build target).                           #
+# Carries only the prebuilt venv, the app source, and the compiled CSS.       #
+# Build-only tooling (nodejs, npm, node_modules, git, curl, uv, compilers)    #
+# is left behind. The daemon runs the full ML stack from this same image, so  #
+# the runtime apt libs below must cover torch/paddle/opencv/tesseract.        #
+##############################################################################
+FROM python:3.12-slim AS prod
+
+# Runtime-only apt libs (no -dev packages, no build tooling):
+#   libpq5           - PostgreSQL client library
+#   tesseract-ocr*   - OCR engine + English data (pytesseract / ocrmypdf)
+#   libgl1, libglib2 - OpenCV / PaddleOCR shared libs
+#   libgomp1         - OpenMP runtime for torch / paddle CPU kernels
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update --quiet=2 && \
+    apt-get install \
+    --no-install-recommends \
+    --assume-yes \
+    --quiet=2 \
+    libpq5 \
+    tesseract-ocr tesseract-ocr-eng \
+    libgl1 libglib2.0-0 \
+    libgomp1
+
+ENV PYTHONUNBUFFERED=1
+ENV YOLO_CONFIG_DIR=/tmp/Ultralytics
+ENV PADDLE_PDX_CACHE_HOME=/tmp/paddlex
+# gunicorn/daemon run as www-data, whose home (/var/www) isn't writable. Point
+# HOME at /tmp so ML libs that cache under ~ (paddle's ~/.cache/paddle, which
+# has no env override; torch hub; etc.) can write instead of crashing on
+# import/first use.
+ENV HOME=/tmp
+ENV PATH="/opt/venv/bin:$PATH"
+
+ARG GIT_SHA=""
+ENV GIT_SHA=${GIT_SHA}
+
+WORKDIR /opt/scanning
+
+# Prebuilt virtualenv (CPU-only torch/paddle per pyproject [tool.uv.sources]).
+COPY --from=deps-prod /opt/venv /opt/venv
+
+# App source (build context excludes node_modules and built static via
+# .dockerignore) plus the compiled Tailwind CSS from the static stage.
+COPY . .
+COPY --from=static-builder \
+     /opt/scanning/scanning/assets/static-global/css/tailwind_styles.css \
+     /opt/scanning/scanning/assets/static-global/css/tailwind_styles.css
 
 # Create directories for collectstatic output and uploaded/processed files
 RUN mkdir -p /opt/scanning/scanning/assets/static/ \
              /opt/scanning/scanning/assets/media/
 
-USER root
 RUN chmod +x /opt/scanning/docker/django/docker-entrypoint.sh
 # media/ must be writable by www-data (gunicorn runs as www-data in prod)
 RUN chown www-data:www-data /opt/scanning/docker/django/docker-entrypoint.sh \

--- a/docker/scanning/docker-compose.yml
+++ b/docker/scanning/docker-compose.yml
@@ -42,8 +42,7 @@ services:
     build:
       context: "${SCANNING_BASE_DIR:-../../}"
       dockerfile: "./docker/django/Dockerfile"
-      args:
-        BUILD_ENV: dev
+      target: dev
     command: run_daemon
     depends_on:
       scanning-postgres:
@@ -69,8 +68,7 @@ services:
     build:
       context: "${SCANNING_BASE_DIR:-../../}"
       dockerfile: "./docker/django/Dockerfile"
-      args:
-        BUILD_ENV: dev
+      target: dev
     command: web-dev
     depends_on:
       scanning-postgres:


### PR DESCRIPTION
Closes #119

## What

Rework `docker/django/Dockerfile` into a multi-stage build with a slim runtime, so the prod image stops shipping build-only tooling and dev dependencies. This cuts pull time on cold nodes and reduces the churn amplification described in the issue.

## Changes

- **Multi-stage build.** `build-base` (full `python:3.12` + compilers/node/uv) feeds three stages: `deps-prod`/`deps-dev` build the venv at `/opt/venv`, `static-builder` runs `npm run build` for Tailwind. The default `prod` target is `python:3.12-slim` and copies in only the venv, app source, and compiled CSS. `nodejs`, `npm`, `node_modules`, `git`, `curl`, `uv`, and compilers are left behind.
- **Drop the dev extra from prod.** Prod now runs plain `uv sync` (no `--all-extras`), so `mypy`, `pytest`, `pre-commit`, `django-debug-toolbar`, and `django-extensions` no longer ship to prod.
- **Trim runtime apt.** `libpq5` (not `libpq-dev`), `tesseract-ocr(-eng)`, `libgl1`, `libglib2.0-0`, `libgomp1`. Dropped `postgresql-client` (unused in the prod entrypoint).
- **Fix a cache-permission crash.** `gunicorn`/the daemon run as `www-data`, whose home `/var/www` isn't writable. Several ML libs cache under `~` — notably paddle's `~/.cache/paddle`, which has no env override — so this crashed on import/first use. Set `HOME=/tmp` (matching the existing `/tmp` cache convention) and fix the no-op `PADDLEX_HOME` -> `PADDLE_PDX_CACHE_HOME`.
- **dev stage for local dev + CI.** `docker-compose.yml` and the CI test build now target the `dev` stage, which keeps `uv` and the dev deps needed when the suite runs with `DEVELOPMENT=True` (`django_extensions` is added to `INSTALLED_APPS` whenever `DEVELOPMENT` is true, independent of `TESTING`).

## Results (measured on a local build)

- Image size: **~1.57 GB -> ~1.07 GB** (~32% smaller).
- Full ML stack imports cleanly under the slim runtime as `www-data`: torch 2.11.0+cpu, paddle 3.3.1, cv2 4.10.0, ultralytics, paddleocr, ocrmypdf, pymupdf, blackletter, django. Confirms `libgomp1` + the trimmed apt set are sufficient and the daemon is unaffected.
- `manage.py check` as `www-data` with prod settings: `0 issues`.
- paddlex/paddle cache dirs resolve to writable `/tmp/paddlex` and `/tmp/.cache/paddle` — the previous `PermissionError: /var/www` is gone.

## Acceptance criteria status

- [x] Runtime image measurably smaller — **~1.07 GB** (documented number; see below re: the <700 MB target).
- [ ] **< ~700 MB not reached by this PR.** torch (742 MB) + paddle (717 MB) dominate the venv and the web tier still carries them. Hitting <700 MB needs proposal #3 — moving the `analyze`/ML deps into a daemon-only image. They're currently hard `dependencies` (not an extra), so it's a real refactor; suggest a follow-up issue.
- [x] Web and daemon behavior unchanged (daemon still has the full ML stack).
- [ ] Cold-node pull time / startupProbe items live in the infra repo's k8s manifests, out of scope here.

## Notes

- CPU-only torch/paddle wheels (proposal #3, first half) were already pinned in `pyproject.toml` — no change needed.
- Suggest opening an independent issue to split the image into separate web and daemon builds (proposal #3), so the web tier drops the ML stack (torch/paddle/etc.) and lands under the ~700 MB target. It's a self-contained follow-up: carve the ML deps into an optional group, keep them daemon-only, and guard in CI that the web image boots without them.
