### PR TITLE
Split into lean web and heavy daemon images

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,12 +87,12 @@ jobs:
 
       - name: Launch Temporary Pod
         run: |
-          kubectl run temp-pod-${{ steps.vars.outputs.sha_short }} -n ${{ env.EKS_NAMESPACE }} --image=freelawproject/scanning:${{ steps.vars.outputs.sha_short }}-prod --restart Never --pod-running-timeout=120s --overrides='
+          kubectl run temp-pod-${{ steps.vars.outputs.sha_short }} -n ${{ env.EKS_NAMESPACE }} --image=freelawproject/scanning:${{ steps.vars.outputs.sha_short }}-web --restart Never --pod-running-timeout=120s --overrides='
           {
               "spec": {
               "containers": [{
                   "name": "temp-pod",
-                  "image": "freelawproject/scanning:${{ steps.vars.outputs.sha_short }}-prod",
+                  "image": "freelawproject/scanning:${{ steps.vars.outputs.sha_short }}-web",
                   "command": ["/bin/sh", "-c", "trap : TERM INT; sleep 259200 & wait"],
                   "envFrom": [{
                   "secretRef": {
@@ -140,7 +140,7 @@ jobs:
         run: aws eks update-kubeconfig --region ${{ env.AWS_REGION }} --name ${{ env.EKS_CLUSTER_NAME }}
 
       - name: Rollout scanning-web
-        run: kubectl set image -n ${{ env.EKS_NAMESPACE }} deployment/scanning-web web=freelawproject/scanning:${{ needs.setup-deploy.outputs.sha_short }}-prod
+        run: kubectl set image -n ${{ env.EKS_NAMESPACE }} deployment/scanning-web web=freelawproject/scanning:${{ needs.setup-deploy.outputs.sha_short }}-web
       - name: Watch scanning-web rollout status
         run: kubectl rollout status -n ${{ env.EKS_NAMESPACE }} deployment/scanning-web
 
@@ -159,7 +159,7 @@ jobs:
         run: aws eks update-kubeconfig --region ${{ env.AWS_REGION }} --name ${{ env.EKS_CLUSTER_NAME }}
 
       - name: Rollout scanning-daemon
-        run: kubectl set image -n ${{ env.EKS_NAMESPACE }} deployment/scanning-daemon scanning-daemon=freelawproject/scanning:${{ needs.setup-deploy.outputs.sha_short }}-prod
+        run: kubectl set image -n ${{ env.EKS_NAMESPACE }} deployment/scanning-daemon scanning-daemon=freelawproject/scanning:${{ needs.setup-deploy.outputs.sha_short }}-daemon
       - name: Watch scanning-daemon rollout status
         run: kubectl rollout status -n ${{ env.EKS_NAMESPACE }} deployment/scanning-daemon
 

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -3,7 +3,7 @@
 ##############################################################################
 # build-base: full image with compilers and build tooling.                   #
 # Shared parent for the dependency- and static-build stages. Nothing from     #
-# here ships to prod unless it is explicitly COPYed into the runtime stage.   #
+# here ships to prod unless it is explicitly COPYed into a runtime stage.      #
 ##############################################################################
 FROM python:3.12 AS build-base
 
@@ -39,17 +39,38 @@ ENV \
 WORKDIR /opt/scanning
 
 ##############################################################################
-# deps-prod / deps-dev: build the virtualenv at /opt/venv.                    #
-# Split so each build only resolves the deps it needs and layer caching keys  #
+# deps-web / deps-ml / deps-dev: build the virtualenv at /opt/venv.           #
+# Split so each image resolves only the deps it needs and layer caching keys  #
 # on pyproject.toml + uv.lock alone (source changes don't bust the venv).     #
+#   deps-web  lean base only         -> web image (detection offloaded)        #
+#   deps-ml   base + local-ml extra  -> daemon image + offline/local detection #
+#   deps-dev  everything incl. dev   -> local dev (docker-compose)             #
+#                                                                             #
+# blackletter currently resolves from a git branch (see pyproject             #
+# [tool.uv.sources]) until 0.0.14 is published; git is available in           #
+# build-base, so uv sync can clone it during the build.                        #
 ##############################################################################
-FROM build-base AS deps-prod
+FROM build-base AS deps-web
 
 COPY pyproject.toml uv.lock ./
-# No --all-extras: the only extra is `dev` (mypy, pytest, debug-toolbar, ...),
-# which must not ship to prod. Extras are opt-in, so plain sync excludes it.
+# Base deps only. The only opt-in extras are `dev` and `local-ml`; plain sync
+# excludes both, so no torch/paddle/ultralytics lands here. Detection is
+# offloaded to RunPod, so the web tier never runs a model in-process.
+#
+# blackletter bundles the small/medium YOLO weights (~72 MB) as package data.
+# The web tier never runs detection, so drop them here — they stay in the
+# daemon image (deps-ml keeps them for local/offline detection).
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync
+    uv sync && \
+    rm -f /opt/venv/lib/python*/site-packages/blackletter/weights/*.pt
+
+FROM build-base AS deps-ml
+
+COPY pyproject.toml uv.lock ./
+# local-ml pulls the CPU torch/paddle/ultralytics stack for in-process
+# detection (offline daemon, or RUNPOD_ENABLED=False). No dev tooling.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --extra local-ml
 
 FROM build-base AS deps-dev
 
@@ -59,7 +80,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 ##############################################################################
 # static-builder: install npm packages and compile Tailwind CSS.             #
-# node/npm/node_modules live here only and never reach the runtime image.    #
+# node/npm/node_modules live here only and never reach a runtime image.       #
 ##############################################################################
 FROM build-base AS static-builder
 
@@ -73,7 +94,8 @@ RUN npm run build
 ##############################################################################
 # dev: full image used for local development (docker-compose `target: dev`).  #
 # Source is bind-mounted over /opt/scanning at run time; keeps uv + dev deps  #
-# for the entrypoint's editable blackletter install and runserver.            #
+# and the full ML stack so RUNPOD_ENABLED can be toggled off and everything   #
+# runs locally.                                                                #
 ##############################################################################
 FROM build-base AS dev
 
@@ -92,19 +114,17 @@ RUN chown www-data:www-data /opt/scanning/docker/django/docker-entrypoint.sh \
 ENTRYPOINT ["/bin/sh", "/opt/scanning/docker/django/docker-entrypoint.sh"]
 
 ##############################################################################
-# prod: slim runtime image (default build target).                           #
-# Carries only the prebuilt venv, the app source, and the compiled CSS.       #
-# Build-only tooling (nodejs, npm, node_modules, git, curl, uv, compilers)    #
-# is left behind. The daemon runs the full ML stack from this same image, so  #
-# the runtime apt libs below must cover torch/paddle/opencv/tesseract.        #
+# prod-web: slim runtime for the web tier (the deployment that scales and     #
+# churns). Carries only the LEAN venv, app source, and compiled CSS. No       #
+# torch/paddle/ultralytics and — because blackletter uses opencv headless      #
+# here — no libgl1. Requires detection offloaded (RUNPOD_ENABLED=True).        #
 ##############################################################################
-FROM python:3.12-slim AS prod
+FROM python:3.12-slim AS prod-web
 
-# Runtime-only apt libs (no -dev packages, no build tooling):
+# Runtime-only apt libs for the lean tier:
 #   libpq5           - PostgreSQL client library
 #   tesseract-ocr*   - OCR engine + English data (pytesseract / ocrmypdf)
-#   libgl1, libglib2 - OpenCV / PaddleOCR shared libs
-#   libgomp1         - OpenMP runtime for torch / paddle CPU kernels
+#   libglib2.0-0     - required by opencv-python-headless (cv2)
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update --quiet=2 && \
@@ -114,16 +134,13 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --quiet=2 \
     libpq5 \
     tesseract-ocr tesseract-ocr-eng \
-    libgl1 libglib2.0-0 \
-    libgomp1
+    libglib2.0-0
 
 ENV PYTHONUNBUFFERED=1
 ENV YOLO_CONFIG_DIR=/tmp/Ultralytics
 ENV PADDLE_PDX_CACHE_HOME=/tmp/paddlex
 # gunicorn/daemon run as www-data, whose home (/var/www) isn't writable. Point
-# HOME at /tmp so ML libs that cache under ~ (paddle's ~/.cache/paddle, which
-# has no env override; torch hub; etc.) can write instead of crashing on
-# import/first use.
+# HOME at /tmp so any lib that caches under ~ can write instead of crashing.
 ENV HOME=/tmp
 ENV PATH="/opt/venv/bin:$PATH"
 
@@ -132,8 +149,8 @@ ENV GIT_SHA=${GIT_SHA}
 
 WORKDIR /opt/scanning
 
-# Prebuilt virtualenv (CPU-only torch/paddle per pyproject [tool.uv.sources]).
-COPY --from=deps-prod /opt/venv /opt/venv
+# Prebuilt lean virtualenv.
+COPY --from=deps-web /opt/venv /opt/venv
 
 # App source (build context excludes node_modules and built static via
 # .dockerignore) plus the full compiled static-global tree from the static
@@ -151,6 +168,61 @@ RUN mkdir -p /opt/scanning/scanning/assets/static/ \
 
 RUN chmod +x /opt/scanning/docker/django/docker-entrypoint.sh
 # media/ must be writable by www-data (gunicorn runs as www-data in prod)
+RUN chown www-data:www-data /opt/scanning/docker/django/docker-entrypoint.sh \
+                            /opt/scanning/scanning/assets/media/
+
+USER www-data
+ENTRYPOINT ["/bin/sh", "/opt/scanning/docker/django/docker-entrypoint.sh"]
+
+##############################################################################
+# prod-ml: slim runtime for the daemon (also the offline/local-detection      #
+# image). Same layout as prod-web but carries the heavy CPU ML stack so        #
+# detection/OCR can run in-process, plus the full OpenCV/torch/paddle libs.    #
+##############################################################################
+FROM python:3.12-slim AS prod-ml
+
+# Runtime-only apt libs for the heavy tier:
+#   libpq5           - PostgreSQL client library
+#   tesseract-ocr*   - OCR engine + English data (pytesseract / ocrmypdf)
+#   libgl1, libglib2 - OpenCV (full) / PaddleOCR shared libs
+#   libgomp1         - OpenMP runtime for torch / paddle CPU kernels
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update --quiet=2 && \
+    apt-get install \
+    --no-install-recommends \
+    --assume-yes \
+    --quiet=2 \
+    libpq5 \
+    tesseract-ocr tesseract-ocr-eng \
+    libgl1 libglib2.0-0 \
+    libgomp1
+
+ENV PYTHONUNBUFFERED=1
+ENV YOLO_CONFIG_DIR=/tmp/Ultralytics
+ENV PADDLE_PDX_CACHE_HOME=/tmp/paddlex
+# See prod-web: point HOME at /tmp so ML libs that cache under ~ (paddle's
+# ~/.cache/paddle, torch hub, etc.) can write instead of crashing on import.
+ENV HOME=/tmp
+ENV PATH="/opt/venv/bin:$PATH"
+
+ARG GIT_SHA=""
+ENV GIT_SHA=${GIT_SHA}
+
+WORKDIR /opt/scanning
+
+# Prebuilt heavy virtualenv (CPU-only torch/paddle per pyproject [tool.uv.sources]).
+COPY --from=deps-ml /opt/venv /opt/venv
+
+COPY . .
+COPY --from=static-builder \
+     /opt/scanning/scanning/assets/static-global/ \
+     /opt/scanning/scanning/assets/static-global/
+
+RUN mkdir -p /opt/scanning/scanning/assets/static/ \
+             /opt/scanning/scanning/assets/media/
+
+RUN chmod +x /opt/scanning/docker/django/docker-entrypoint.sh
 RUN chown www-data:www-data /opt/scanning/docker/django/docker-entrypoint.sh \
                             /opt/scanning/scanning/assets/media/
 

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -45,10 +45,6 @@ WORKDIR /opt/scanning
 #   deps-web  lean base only         -> web image (detection offloaded)        #
 #   deps-ml   base + local-ml extra  -> daemon image + offline/local detection #
 #   deps-dev  everything incl. dev   -> local dev (docker-compose)             #
-#                                                                             #
-# blackletter currently resolves from a git branch (see pyproject             #
-# [tool.uv.sources]) until 0.0.14 is published; git is available in           #
-# build-base, so uv sync can clone it during the build.                        #
 ##############################################################################
 FROM build-base AS deps-web
 
@@ -116,15 +112,16 @@ ENTRYPOINT ["/bin/sh", "/opt/scanning/docker/django/docker-entrypoint.sh"]
 ##############################################################################
 # prod-web: slim runtime for the web tier (the deployment that scales and     #
 # churns). Carries only the LEAN venv, app source, and compiled CSS. No       #
-# torch/paddle/ultralytics and — because blackletter uses opencv headless      #
-# here — no libgl1. Requires detection offloaded (RUNPOD_ENABLED=True).        #
+# torch/paddle/ultralytics. Base blackletter uses non-headless opencv-python   #
+# (>=0.1.0), so libgl1 is required here. Requires detection offloaded          #
+# (RUNPOD_ENABLED=True).                                                       #
 ##############################################################################
 FROM python:3.12-slim AS prod-web
 
 # Runtime-only apt libs for the lean tier:
-#   libpq5           - PostgreSQL client library
-#   tesseract-ocr*   - OCR engine + English data (pytesseract / ocrmypdf)
-#   libglib2.0-0     - required by opencv-python-headless (cv2)
+#   libpq5              - PostgreSQL client library
+#   tesseract-ocr*      - OCR engine + English data (pytesseract / ocrmypdf)
+#   libgl1, libglib2.0-0 - required by opencv-python (cv2) in base blackletter
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update --quiet=2 && \
@@ -134,7 +131,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --quiet=2 \
     libpq5 \
     tesseract-ocr tesseract-ocr-eng \
-    libglib2.0-0
+    libgl1 libglib2.0-0
 
 ENV PYTHONUNBUFFERED=1
 ENV YOLO_CONFIG_DIR=/tmp/Ultralytics

--- a/docker/django/Makefile
+++ b/docker/django/Makefile
@@ -27,6 +27,6 @@ protects against arm64 builds being accidentally deployed to the server (which u
 		exit 1; \
 	fi
 
-	    echo "Architecture is OK. Pushing."; \
-	    docker push $(REPO):$(DOCKER_TAG_WEB); \
+	    echo "Architecture is OK. Pushing." && \
+	    docker push $(REPO):$(DOCKER_TAG_WEB) && \
 	    docker push $(REPO):$(DOCKER_TAG_DAEMON);

--- a/docker/django/Makefile
+++ b/docker/django/Makefile
@@ -9,11 +9,15 @@ endif
 .PHONY: build-image push-image
 
 REPO ?= freelawproject/scanning
-DOCKER_TAG_PROD = $(VERSION)-prod
+# One repo, two variant tags: a lean web image (prod-web target) and the heavy
+# daemon image (prod-ml target, also used offline / as the RunPod-adjacent base).
+DOCKER_TAG_WEB = $(VERSION)-web
+DOCKER_TAG_DAEMON = $(VERSION)-daemon
 UNAME := $(shell uname -m)
 
 build-image:
-	docker build -t $(REPO):$(DOCKER_TAG_PROD) --build-arg GIT_SHA=$(VERSION) --file docker/django/Dockerfile .
+	docker build --target prod-web -t $(REPO):$(DOCKER_TAG_WEB) --build-arg GIT_SHA=$(VERSION) --file docker/django/Dockerfile .
+	docker build --target prod-ml -t $(REPO):$(DOCKER_TAG_DAEMON) --build-arg GIT_SHA=$(VERSION) --file docker/django/Dockerfile .
 
 push-image: build-image
 	$(info Checking if valid architecture)
@@ -24,4 +28,5 @@ protects against arm64 builds being accidentally deployed to the server (which u
 	fi
 
 	    echo "Architecture is OK. Pushing."; \
-	    docker push $(REPO):$(DOCKER_TAG_PROD);
+	    docker push $(REPO):$(DOCKER_TAG_WEB); \
+	    docker push $(REPO):$(DOCKER_TAG_DAEMON);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   # validation and OCR — no torch/paddle. The heavy in-process inference stack
   # lives in the `local-ml` extra so the web/daemon images stay lean whenever
   # detection is offloaded to RunPod (RUNPOD_ENABLED=True).
-  "blackletter>=0.0.10",
+  "blackletter>=0.1.0",
   "ocrmypdf>=17",
   "pdfplumber>=0.11",
   "pymupdf>=1.25",
@@ -58,7 +58,7 @@ dev = [
 # wherever detection runs locally instead of on RunPod: local dev, CI, the
 # offline daemon, and the RunPod worker image. Excluded from the lean web image.
 local-ml = [
-  "blackletter[detect,analyze]>=0.0.10",
+  "blackletter[detect,analyze]>=0.1.0",
   "torch",
   "torchvision",
   "ultralytics>=8.3",
@@ -111,7 +111,7 @@ python_files = ["tests.py", "test_*.py"]
 # same OpenCV release means the same cv2 ABI, so whichever wheel writes
 # `site-packages/cv2/` last, `import cv2` stays consistent. `opencv-python-headless`
 # is listed defensively in case a transitive dep reintroduces it. Base blackletter
-# no longer pulls headless as of blackletter #61 / 0.0.14.
+# no longer pulls headless as of blackletter #61 / 0.1.0.
 override-dependencies = [
   "opencv-python==4.10.0.84",
   "opencv-contrib-python==4.10.0.84",
@@ -122,10 +122,6 @@ override-dependencies = [
 torch = { index = "pytorch-cpu" }
 torchvision = { index = "pytorch-cpu" }
 paddlepaddle = { index = "paddle-cpu" }
-# TEMPORARY: track the blackletter extras-split branch until it is released.
-# Once blackletter 0.0.14 is on PyPI, drop this source line and bump the
-# blackletter specifiers below to >=0.0.14 so the build resolves from PyPI.
-blackletter = { git = "https://github.com/freelawproject/blackletter.git", branch = "split-heavy-deps-into-extras" }
 
 [[tool.uv.index]]
 name = "pytorch-cpu"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,20 +29,18 @@ dependencies = [
   "gunicorn",
   "pillow",
   "psycopg[binary,pool]",
-  "blackletter[analyze]>=0.0.10",
+  # Base blackletter only: pairing, redaction (skip_doctr=True), margins,
+  # validation and OCR — no torch/paddle. The heavy in-process inference stack
+  # lives in the `local-ml` extra so the web/daemon images stay lean whenever
+  # detection is offloaded to RunPod (RUNPOD_ENABLED=True).
+  "blackletter>=0.0.10",
   "ocrmypdf>=17",
   "pdfplumber>=0.11",
   "pymupdf>=1.25",
-  "torch",
-  "torchvision",
-  "ultralytics>=8.3",
   "sentry-sdk[django]",
   "time-machine",
   "uvicorn[standard]",
   "pytesseract>=0.3.13",
-  "opencv-python==4.10.0.84",
-  "paddlepaddle",
-  "paddleocr>=3.4.0",
 ]
 
 [project.optional-dependencies]
@@ -55,6 +53,18 @@ dev = [
   "pre-commit",
   "pytest",
   "pytest-django",
+]
+# Heavy in-process inference stack (YOLO + PaddleOCR + doctr, all CPU). Install
+# wherever detection runs locally instead of on RunPod: local dev, CI, the
+# offline daemon, and the RunPod worker image. Excluded from the lean web image.
+local-ml = [
+  "blackletter[detect,analyze]>=0.0.10",
+  "torch",
+  "torchvision",
+  "ultralytics>=8.3",
+  "opencv-python==4.10.0.84",
+  "paddlepaddle",
+  "paddleocr>=3.4.0",
 ]
 
 [tool.setuptools.packages.find]
@@ -94,6 +104,10 @@ python_files = ["tests.py", "test_*.py"]
 torch = { index = "pytorch-cpu" }
 torchvision = { index = "pytorch-cpu" }
 paddlepaddle = { index = "paddle-cpu" }
+# TEMPORARY: track the blackletter extras-split branch until it is released.
+# Once blackletter 0.0.14 is on PyPI, drop this source line and bump the
+# blackletter specifiers below to >=0.0.14 so the build resolves from PyPI.
+blackletter = { git = "https://github.com/freelawproject/blackletter.git", branch = "split-heavy-deps-into-extras" }
 
 [[tool.uv.index]]
 name = "pytorch-cpu"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,9 @@ local-ml = [
   "torch",
   "torchvision",
   "ultralytics>=8.3",
-  "opencv-python==4.10.0.84",
+  # cv2 comes in transitively (ultralytics, python-doctr, paddlex); its version
+  # is pinned once in [tool.uv] override-dependencies to keep every cv2 variant
+  # on one OpenCV ABI.
   "paddlepaddle",
   "paddleocr>=3.4.0",
 ]
@@ -99,6 +101,22 @@ lint.ignore = [
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "scanning.settings"
 python_files = ["tests.py", "test_*.py"]
+
+[tool.uv]
+# Keep every cv2-providing distribution on one OpenCV version. The daemon
+# (local-ml) tree pulls two variants that both own the top-level `cv2` package
+# and cannot be deduplicated (paddleocr -> paddlex needs `opencv-contrib-python`;
+# ultralytics, python-doctr and base blackletter need `opencv-python`). uv can't
+# rename one into the other, so the best we can do is force a matching version:
+# same OpenCV release means the same cv2 ABI, so whichever wheel writes
+# `site-packages/cv2/` last, `import cv2` stays consistent. `opencv-python-headless`
+# is listed defensively in case a transitive dep reintroduces it. Base blackletter
+# no longer pulls headless as of blackletter #61 / 0.0.14.
+override-dependencies = [
+  "opencv-python==4.10.0.84",
+  "opencv-contrib-python==4.10.0.84",
+  "opencv-python-headless==4.10.0.84",
+]
 
 [tool.uv.sources]
 torch = { index = "pytorch-cpu" }

--- a/scanning/tests/test_views.py
+++ b/scanning/tests/test_views.py
@@ -1886,8 +1886,9 @@ class TestAssignPage(ScanningTestCase):
         self.assertIsNone(self.scan.ocr_results[0]["detected"])
 
     def test_edit_creating_duplicate_flags_page_map(self):
-        """Assigning a number that already exists flags the page (and only
-        the later copy) as a duplicate in the rebuilt page_map."""
+        """Assigning a number that already exists flags every copy of that
+        number as a duplicate in the rebuilt page_map (blackletter #55 flags
+        all copies, not just the later one)."""
         response = self._post(3, "5")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(json.loads(response.content)["duplicate"])
@@ -1895,8 +1896,8 @@ class TestAssignPage(ScanningTestCase):
         flagged = {
             e["pdf_index"] for e in self.scan.page_map if e.get("duplicate")
         }
-        self.assertIn(2, flagged)  # pdf_page 3 -> index 2 (second "5")
-        self.assertNotIn(0, flagged)  # the first "5" stays canonical
+        self.assertIn(2, flagged)  # pdf_page 3 -> index 2 (newly-created "5")
+        self.assertIn(0, flagged)  # the pre-existing "5" is flagged too
 
     def test_clearing_duplicate_unflags_page_map(self):
         """Clearing a duplicated number removes the duplicate flag."""

--- a/uv.lock
+++ b/uv.lock
@@ -144,18 +144,12 @@ wheels = [
 [[package]]
 name = "blackletter"
 version = "0.0.13"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/freelawproject/blackletter.git?branch=split-heavy-deps-into-extras#683ff91548ca0c491dacdf66f3fc9274260ffa03" }
 dependencies = [
     { name = "ocrmypdf" },
-    { name = "opencv-python" },
+    { name = "opencv-python-headless" },
     { name = "pillow" },
     { name = "pymupdf" },
-    { name = "python-doctr" },
-    { name = "ultralytics" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/e7/dfdbf2a8d7fd2a3dba1031f269f6f496ca2cd8ee9475919ef2bff4bacf41/blackletter-0.0.13.tar.gz", hash = "sha256:79bad647267c84963dcd4290e5e23a105f15d301bff04e2ac64030ee34213523", size = 68865677, upload-time = "2026-06-18T19:47:07.262Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/bc/a16ae28fb766f11ab1d508fd3fd6e96adb91e3003a172be2484c902a0f8a/blackletter-0.0.13-py3-none-any.whl", hash = "sha256:497d33390e4be423ce5509154467ceecea7974006a745ba1afbfd6c00fd3e776", size = 68855039, upload-time = "2026-06-18T19:47:03.77Z" },
 ]
 
 [package.optional-dependencies]
@@ -164,6 +158,13 @@ analyze = [
     { name = "paddleocr" },
     { name = "paddlepaddle" },
     { name = "pypdfium2" },
+    { name = "python-doctr" },
+    { name = "ultralytics" },
+]
+detect = [
+    { name = "huggingface-hub" },
+    { name = "python-doctr" },
+    { name = "ultralytics" },
 ]
 
 [[package]]
@@ -1516,6 +1517,25 @@ wheels = [
 ]
 
 [[package]]
+name = "opencv-python-headless"
+version = "5.0.0.93"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/99/76b7c80252aa83c1af16393454aafd125a0287101afe8deb0a6821af0e30/opencv_python_headless-5.0.0.93.tar.gz", hash = "sha256:b82f9831daab90b725c7c1ee1b36cb5732c367096ac76d119e64e14eb70d5f3c", size = 81817738, upload-time = "2026-07-02T07:01:06.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/7c/8c8097891c509d98cd128493835c95631c80be6a8f37ed9d25716c2e16f1/opencv_python_headless-5.0.0.93-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:030ca5e0837a2963ab36ef896baa9767eb8d2b83353fb28af5a521e40dd8756f", size = 48322581, upload-time = "2026-07-02T05:50:34.207Z" },
+    { url = "https://files.pythonhosted.org/packages/90/8c/eab2ad388c3cbab2a350c10c2ef19ce6bd099240afc31789032c996bab52/opencv_python_headless-5.0.0.93-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:1e55af3abfb462eeeabe5c775f12bdb36216d8a93a3583d69e6bd6e1d6ba7d00", size = 34782894, upload-time = "2026-07-02T05:51:39.856Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/78/afca939f40ffe2b2380bfa86f812b2f7d4acc5a27b27dc41b49cad7ce7b4/opencv_python_headless-5.0.0.93-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:10818d91510e05c04568ae12b5cd120779c70c01bf897b001a6221fe430df80f", size = 36521085, upload-time = "2026-07-02T06:55:24.429Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/97/8170e9819764c47e436c130d3ff6cfb73b58f923eae9d3a03d8982b04aec/opencv_python_headless-5.0.0.93-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:09a872a157c1376ab922a69bbf22f9a95bcc7b658a9d8b436a60212b02b2eeb4", size = 56563598, upload-time = "2026-07-02T06:55:47.355Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/98/1a28a7101e31801042b3098871a74b76c61581d328ef40774ff4edb53a56/opencv_python_headless-5.0.0.93-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:840bd717c21e5c11cadadc022a823315ea417f961213d06b4df010e019eb16f4", size = 39648433, upload-time = "2026-07-02T06:56:04.255Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/21/f6ef335f6e65724aa78b8d792b48d40a48c381715f1e62f5a5049e09d07e/opencv_python_headless-5.0.0.93-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ed709fdf9aa0bd1f2ed8549e71d19449b03a675bb581eb292285f6861953be37", size = 61204038, upload-time = "2026-07-02T06:56:41.823Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/8f/b8756467ea991449a293797f6b3fa80fcfdd29598a0a60d1cd5715b96e61/opencv_python_headless-5.0.0.93-cp37-abi3-win32.whl", hash = "sha256:c6bcd96b185975ea240d22cfdb15a1f6d080cc95264cfbe2621f21bb144d89b9", size = 35411237, upload-time = "2026-07-02T05:50:12.901Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/88/763b967f7efd7226b82c9fae16d560cba049b1f0c036647e65c610fd636e/opencv_python_headless-5.0.0.93-cp37-abi3-win_amd64.whl", hash = "sha256:829717b6a95554f273e49e357cee3b3a2a26b6f4842fbc1bed2b45bdd8f87e0e", size = 43825962, upload-time = "2026-07-02T05:50:09.627Z" },
+]
+
+[[package]]
 name = "opt-einsum"
 version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2471,7 +2491,7 @@ name = "scanning"
 version = "1"
 source = { virtual = "." }
 dependencies = [
-    { name = "blackletter", extra = ["analyze"] },
+    { name = "blackletter" },
     { name = "boto3" },
     { name = "daphne" },
     { name = "django" },
@@ -2482,9 +2502,6 @@ dependencies = [
     { name = "factory-boy" },
     { name = "gunicorn" },
     { name = "ocrmypdf" },
-    { name = "opencv-python" },
-    { name = "paddleocr" },
-    { name = "paddlepaddle" },
     { name = "pdfplumber" },
     { name = "pillow" },
     { name = "psycopg", extra = ["binary", "pool"] },
@@ -2492,11 +2509,6 @@ dependencies = [
     { name = "pytesseract" },
     { name = "sentry-sdk", extra = ["django"] },
     { name = "time-machine" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 's390x' and sys_platform == 'darwin'" },
-    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 's390x' or sys_platform != 'darwin'" },
-    { name = "torchvision", version = "0.26.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 's390x' and sys_platform == 'darwin'" },
-    { name = "torchvision", version = "0.26.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 's390x' or sys_platform != 'darwin'" },
-    { name = "ultralytics" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -2511,10 +2523,22 @@ dev = [
     { name = "pytest" },
     { name = "pytest-django" },
 ]
+local-ml = [
+    { name = "blackletter", extra = ["analyze", "detect"] },
+    { name = "opencv-python" },
+    { name = "paddleocr" },
+    { name = "paddlepaddle" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 's390x' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 's390x' or sys_platform != 'darwin'" },
+    { name = "torchvision", version = "0.26.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 's390x' and sys_platform == 'darwin'" },
+    { name = "torchvision", version = "0.26.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 's390x' or sys_platform != 'darwin'" },
+    { name = "ultralytics" },
+]
 
 [package.metadata]
 requires-dist = [
-    { name = "blackletter", extras = ["analyze"], specifier = ">=0.0.10" },
+    { name = "blackletter", git = "https://github.com/freelawproject/blackletter.git?branch=split-heavy-deps-into-extras" },
+    { name = "blackletter", extras = ["detect", "analyze"], marker = "extra == 'local-ml'", git = "https://github.com/freelawproject/blackletter.git?branch=split-heavy-deps-into-extras" },
     { name = "boto3" },
     { name = "daphne" },
     { name = "django", specifier = ">=6.0,<6.1" },
@@ -2530,9 +2554,9 @@ requires-dist = [
     { name = "gunicorn" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "ocrmypdf", specifier = ">=17" },
-    { name = "opencv-python", specifier = "==4.10.0.84" },
-    { name = "paddleocr", specifier = ">=3.4.0" },
-    { name = "paddlepaddle", index = "https://www.paddlepaddle.org.cn/packages/stable/cpu/" },
+    { name = "opencv-python", marker = "extra == 'local-ml'", specifier = "==4.10.0.84" },
+    { name = "paddleocr", marker = "extra == 'local-ml'", specifier = ">=3.4.0" },
+    { name = "paddlepaddle", marker = "extra == 'local-ml'", index = "https://www.paddlepaddle.org.cn/packages/stable/cpu/" },
     { name = "pdfplumber", specifier = ">=0.11" },
     { name = "pillow" },
     { name = "pre-commit", marker = "extra == 'dev'" },
@@ -2543,12 +2567,12 @@ requires-dist = [
     { name = "pytest-django", marker = "extra == 'dev'" },
     { name = "sentry-sdk", extras = ["django"] },
     { name = "time-machine" },
-    { name = "torch", index = "https://download.pytorch.org/whl/cpu" },
-    { name = "torchvision", index = "https://download.pytorch.org/whl/cpu" },
-    { name = "ultralytics", specifier = ">=8.3" },
+    { name = "torch", marker = "extra == 'local-ml'", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "torchvision", marker = "extra == 'local-ml'", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "ultralytics", marker = "extra == 'local-ml'", specifier = ">=8.3" },
     { name = "uvicorn", extras = ["standard"] },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "local-ml"]
 
 [[package]]
 name = "scipy"
@@ -2757,13 +2781,13 @@ resolution-markers = [
     "python_full_version < '3.13' and platform_machine != 's390x' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "platform_machine != 's390x' and sys_platform == 'darwin'" },
-    { name = "fsspec", marker = "platform_machine != 's390x' and sys_platform == 'darwin'" },
-    { name = "jinja2", marker = "platform_machine != 's390x' and sys_platform == 'darwin'" },
-    { name = "networkx", marker = "platform_machine != 's390x' and sys_platform == 'darwin'" },
-    { name = "setuptools", marker = "platform_machine != 's390x' and sys_platform == 'darwin'" },
-    { name = "sympy", marker = "platform_machine != 's390x' and sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "platform_machine != 's390x' and sys_platform == 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:43b35116802c85fb88d99f4a396b8bd4472bfca1dd82e69499e5a4f9b8b4e252", upload-time = "2026-03-23T15:16:58Z" },
@@ -2790,13 +2814,13 @@ resolution-markers = [
     "python_full_version < '3.13' and platform_machine == 's390x' and sys_platform != 'darwin' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "filelock", marker = "platform_machine == 's390x' or sys_platform != 'darwin'" },
-    { name = "fsspec", marker = "platform_machine == 's390x' or sys_platform != 'darwin'" },
-    { name = "jinja2", marker = "platform_machine == 's390x' or sys_platform != 'darwin'" },
-    { name = "networkx", marker = "platform_machine == 's390x' or sys_platform != 'darwin'" },
-    { name = "setuptools", marker = "platform_machine == 's390x' or sys_platform != 'darwin'" },
-    { name = "sympy", marker = "platform_machine == 's390x' or sys_platform != 'darwin'" },
-    { name = "typing-extensions", marker = "platform_machine == 's390x' or sys_platform != 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:2db3ae5404e32cb42b5fcbd94f13607761eaec0cf1687fde95095289d1e26cfb", upload-time = "2026-04-28T00:06:06Z" },
@@ -2822,9 +2846,9 @@ resolution-markers = [
     "python_full_version < '3.13' and platform_machine != 's390x' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", marker = "platform_machine != 's390x' and sys_platform == 'darwin'" },
-    { name = "pillow", marker = "platform_machine != 's390x' and sys_platform == 'darwin'" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 's390x' and sys_platform == 'darwin'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" } },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c409e1c3fdebec7a3834465086dbda8bf7680eff79abf7fd2f10c6b59520a7a4", upload-time = "2026-03-23T15:36:09Z" },
@@ -2851,9 +2875,9 @@ resolution-markers = [
     "python_full_version < '3.13' and platform_machine == 's390x' and sys_platform != 'darwin' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "platform_machine == 's390x' or sys_platform != 'darwin'" },
-    { name = "pillow", marker = "platform_machine == 's390x' or sys_platform != 'darwin'" },
-    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 's390x' or sys_platform != 'darwin'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" } },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.26.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:17f0b542331fc94230b4214c6d123f038af7330fd81019608c0d2402f3bc3079", upload-time = "2026-03-23T15:36:09Z" },

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,13 @@ resolution-markers = [
     "python_full_version < '3.13' and platform_machine == 's390x' and sys_platform != 'darwin' and sys_platform != 'win32'",
 ]
 
+[manifest]
+overrides = [
+    { name = "opencv-contrib-python", specifier = "==4.10.0.84" },
+    { name = "opencv-python", specifier = "==4.10.0.84" },
+    { name = "opencv-python-headless", specifier = "==4.10.0.84" },
+]
+
 [[package]]
 name = "aistudio-sdk"
 version = "0.3.8"
@@ -143,13 +150,17 @@ wheels = [
 
 [[package]]
 name = "blackletter"
-version = "0.0.13"
-source = { git = "https://github.com/freelawproject/blackletter.git?branch=split-heavy-deps-into-extras#683ff91548ca0c491dacdf66f3fc9274260ffa03" }
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ocrmypdf" },
-    { name = "opencv-python-headless" },
+    { name = "opencv-python" },
     { name = "pillow" },
     { name = "pymupdf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/1a/87c3476639697f6e91972d78d3fa4271a7f334a4c91b0d180bc0aab93d98/blackletter-0.1.0.tar.gz", hash = "sha256:b4935073848438bba09034da1f559946a271ee399702c6f85eb4bdd652d3bfbc", size = 68868353, upload-time = "2026-07-10T22:58:18.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/b7/46a1e76680e07f914d9ab9c8ad37bfb473be012ed367977ed35b8ca019a2/blackletter-0.1.0-py3-none-any.whl", hash = "sha256:2bc4d3f4663b0f26ab6b54dfb85a7c00f425358cb8832f8a6bb63b097169d055", size = 68856721, upload-time = "2026-07-10T22:58:10.823Z" },
 ]
 
 [package.optional-dependencies]
@@ -1517,25 +1528,6 @@ wheels = [
 ]
 
 [[package]]
-name = "opencv-python-headless"
-version = "5.0.0.93"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/99/76b7c80252aa83c1af16393454aafd125a0287101afe8deb0a6821af0e30/opencv_python_headless-5.0.0.93.tar.gz", hash = "sha256:b82f9831daab90b725c7c1ee1b36cb5732c367096ac76d119e64e14eb70d5f3c", size = 81817738, upload-time = "2026-07-02T07:01:06.039Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/7c/8c8097891c509d98cd128493835c95631c80be6a8f37ed9d25716c2e16f1/opencv_python_headless-5.0.0.93-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:030ca5e0837a2963ab36ef896baa9767eb8d2b83353fb28af5a521e40dd8756f", size = 48322581, upload-time = "2026-07-02T05:50:34.207Z" },
-    { url = "https://files.pythonhosted.org/packages/90/8c/eab2ad388c3cbab2a350c10c2ef19ce6bd099240afc31789032c996bab52/opencv_python_headless-5.0.0.93-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:1e55af3abfb462eeeabe5c775f12bdb36216d8a93a3583d69e6bd6e1d6ba7d00", size = 34782894, upload-time = "2026-07-02T05:51:39.856Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/78/afca939f40ffe2b2380bfa86f812b2f7d4acc5a27b27dc41b49cad7ce7b4/opencv_python_headless-5.0.0.93-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:10818d91510e05c04568ae12b5cd120779c70c01bf897b001a6221fe430df80f", size = 36521085, upload-time = "2026-07-02T06:55:24.429Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/97/8170e9819764c47e436c130d3ff6cfb73b58f923eae9d3a03d8982b04aec/opencv_python_headless-5.0.0.93-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:09a872a157c1376ab922a69bbf22f9a95bcc7b658a9d8b436a60212b02b2eeb4", size = 56563598, upload-time = "2026-07-02T06:55:47.355Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/98/1a28a7101e31801042b3098871a74b76c61581d328ef40774ff4edb53a56/opencv_python_headless-5.0.0.93-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:840bd717c21e5c11cadadc022a823315ea417f961213d06b4df010e019eb16f4", size = 39648433, upload-time = "2026-07-02T06:56:04.255Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/21/f6ef335f6e65724aa78b8d792b48d40a48c381715f1e62f5a5049e09d07e/opencv_python_headless-5.0.0.93-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ed709fdf9aa0bd1f2ed8549e71d19449b03a675bb581eb292285f6861953be37", size = 61204038, upload-time = "2026-07-02T06:56:41.823Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/8f/b8756467ea991449a293797f6b3fa80fcfdd29598a0a60d1cd5715b96e61/opencv_python_headless-5.0.0.93-cp37-abi3-win32.whl", hash = "sha256:c6bcd96b185975ea240d22cfdb15a1f6d080cc95264cfbe2621f21bb144d89b9", size = 35411237, upload-time = "2026-07-02T05:50:12.901Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/88/763b967f7efd7226b82c9fae16d560cba049b1f0c036647e65c610fd636e/opencv_python_headless-5.0.0.93-cp37-abi3-win_amd64.whl", hash = "sha256:829717b6a95554f273e49e357cee3b3a2a26b6f4842fbc1bed2b45bdd8f87e0e", size = 43825962, upload-time = "2026-07-02T05:50:09.627Z" },
-]
-
-[[package]]
 name = "opt-einsum"
 version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2525,7 +2517,6 @@ dev = [
 ]
 local-ml = [
     { name = "blackletter", extra = ["analyze", "detect"] },
-    { name = "opencv-python" },
     { name = "paddleocr" },
     { name = "paddlepaddle" },
     { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 's390x' and sys_platform == 'darwin'" },
@@ -2537,8 +2528,8 @@ local-ml = [
 
 [package.metadata]
 requires-dist = [
-    { name = "blackletter", git = "https://github.com/freelawproject/blackletter.git?branch=split-heavy-deps-into-extras" },
-    { name = "blackletter", extras = ["detect", "analyze"], marker = "extra == 'local-ml'", git = "https://github.com/freelawproject/blackletter.git?branch=split-heavy-deps-into-extras" },
+    { name = "blackletter", specifier = ">=0.1.0" },
+    { name = "blackletter", extras = ["detect", "analyze"], marker = "extra == 'local-ml'", specifier = ">=0.1.0" },
     { name = "boto3" },
     { name = "daphne" },
     { name = "django", specifier = ">=6.0,<6.1" },
@@ -2554,7 +2545,6 @@ requires-dist = [
     { name = "gunicorn" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "ocrmypdf", specifier = ">=17" },
-    { name = "opencv-python", marker = "extra == 'local-ml'", specifier = "==4.10.0.84" },
     { name = "paddleocr", marker = "extra == 'local-ml'", specifier = ">=3.4.0" },
     { name = "paddlepaddle", marker = "extra == 'local-ml'", index = "https://www.paddlepaddle.org.cn/packages/stable/cpu/" },
     { name = "pdfplumber", specifier = ">=0.11" },


### PR DESCRIPTION
## What

Splits the single scanning image into two, so the web tier stops shipping the ~2.5 GB ML stack it never runs (detection is offloaded to RunPod).

- **`pyproject.toml`**: `torch`, `torchvision`, `ultralytics`, `paddlepaddle`, `paddleocr`, `opencv-python`, and `blackletter[detect,analyze]` move out of base deps into a new **`local-ml`** extra. Base now depends on plain `blackletter` (+ pymupdf/pdfplumber/ocrmypdf/pytesseract), so the web tree carries no torch/paddle.
- **`Dockerfile`**: `deps-prod` → `deps-web` (lean, `uv sync`) + `deps-ml` (heavy, `uv sync --extra local-ml`); `prod` → **`prod-web`** (lean, drops `libgl1`/`libgomp1`, strips blackletter's bundled YOLO weights) + **`prod-ml`** (heavy). `dev` target keeps `--all-extras` so local dev can still run everything with `RUNPOD_ENABLED=False`.
- **`Makefile` / `deploy.yml`**: one Docker Hub repo, two variant tags — `:<sha>-web` and `:<sha>-daemon`. `deploy-web` uses `-web`, `deploy-daemon` uses `-daemon`, and the collectstatic/migrate temp pod uses `-web`.

## Image sizes (compressed, comparable to the current 1.46 GB)

| Image | Target | Size | vs current |
|---|---|---|---|
| web | `prod-web` | **~309 MB** | ~4.7× smaller |
| daemon | `prod-ml` | **~1.2 GB** | ~same (carries the full stack) |

The daemon stays heavy on purpose: it runs detection in-process whenever RunPod is off (no credits / offline / local dev), so it must keep torch/paddle.

## Verified

Built both targets locally. `prod-web` imports `blackletter.api`/`scanner`/`_pair_opinions` + `cv2` with **no** torch/paddle present; `prod-ml` imports torch 2.11.0+cpu, paddle 3.3.1, ultralytics. `docker compose up` is unchanged (both dev services still build `target: dev`).

## ⚠️ Do not merge until blackletter is released

This depends on **freelawproject/blackletter#58** (the base/detect/analyze split). Until it lands on PyPI, `[tool.uv.sources]` pins `blackletter` to that branch. Before merge:

1. Wait for blackletter 0.0.14 to be published.
2. Drop the `blackletter = { git = … }` line in `[tool.uv.sources]`.
3. Bump the `blackletter` specifiers to `>=0.0.14` (base) and in `local-ml`.
4. Re-lock (`uv lock`) and confirm both images still build.

Also note the `:<sha>-prod` tag is no longer produced — confirm no k8s manifest or external reference still points at `-prod`.
