### PR TITLE
Remove gunicorn worker recycling (max-requests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,6 @@ For the **private uploads bucket**:
 | `MEDIA_ROOT` | Local media root (only used when `DEVELOPMENT=True`) | `scanning/assets/media/` |
 | `STATIC_URL` | Static file URL prefix | `static/` |
 | `NUM_WORKERS` | Gunicorn worker count | `4` |
-| `MAX_REQUESTS` | Gunicorn max requests before worker restart | `2500` |
 
 
 ### Step 2: Build the Docker Image
@@ -317,7 +316,6 @@ docker run -d \
 This starts Gunicorn with Uvicorn workers (ASGI). Configuration:
 - **Workers**: `NUM_WORKERS` env var (default: 4)
 - **Timeout**: 180 seconds
-- **Max requests**: `MAX_REQUESTS` env var (default: 2500, with 100 jitter)
 - **Bind**: `0.0.0.0:8000`
 
 
@@ -382,7 +380,6 @@ SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0
 
 # Workers
 NUM_WORKERS=4
-MAX_REQUESTS=2500
 ```
 
 

--- a/docker/django/docker-entrypoint.sh
+++ b/docker/django/docker-entrypoint.sh
@@ -35,8 +35,6 @@ case "$1" in
         --preload \
         --no-control-socket \
         --timeout 180 \
-        --max-requests ${MAX_REQUESTS:-500} \
-        --max-requests-jitter 100 \
         --bind 0.0.0.0:8000
     ;;
 *)


### PR DESCRIPTION
Fixes #132 (option 2).

Removes `--max-requests ${MAX_REQUESTS:-500}` and `--max-requests-jitter 100` from the `web-prod` gunicorn command so workers are long-lived. With recycling on, a slow leak resets before it ever shows in memory graphs; with long-lived workers, RSS climbs monotonically and can be correlated with the node deaths infra is investigating.

No code changes needed elsewhere: with the flag gone, gunicorn defaults `max_requests` to 0, and uvicorn's worker maps that through our custom `UvicornWorker` as `limit_max_requests=sys.maxsize` (recycling disabled).

Also removes the now-dead `MAX_REQUESTS` env var from the README (env table, prod runtime notes, and the sample env file).