### PR TITLE
Make upload size limit configurable, default 3 GB

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ trailing slash or path).
 | `MEDIA_ROOT` | Local media root (only used when `DEVELOPMENT=True`) | `scanning/assets/media/` |
 | `STATIC_URL` | Static file URL prefix | `static/` |
 | `NUM_WORKERS` | Gunicorn worker count | `4` |
+| `MAX_UPLOAD_SIZE_GB` | Max size (whole GB) for a direct-to-S3 original PDF upload. Enforced by the presigned POST policy so S3 rejects anything larger. | `3` |
 
 
 ### Step 2: Build the Docker Image

--- a/scanning/management/commands/cleanup_processing_tmp.py
+++ b/scanning/management/commands/cleanup_processing_tmp.py
@@ -125,7 +125,7 @@ class Command(BaseCommand):
         from scanning import s3_sync, services
         from scanning.models import PendingUpload
 
-        ttl_hours = getattr(settings, "PENDING_UPLOAD_TTL_HOURS", 6.0)
+        ttl_hours = settings.PENDING_UPLOAD_TTL_HOURS
         cutoff = timezone.now() - timedelta(hours=ttl_hours)
         stale = PendingUpload.objects.filter(
             date_created__lt=cutoff

--- a/scanning/s3_sync.py
+++ b/scanning/s3_sync.py
@@ -295,7 +295,7 @@ def _is_preview_pdf(rel: str) -> bool:
 def _is_original_pdf(rel: str) -> bool:
     """Return True if a processing-prefix relative key is the original PDF.
 
-    The (up to 2 GB) ``*.original.pdf`` at the top of the prefix. Used to
+    The (up to 3 GB) ``*.original.pdf`` at the top of the prefix. Used to
     pull only the original -- not the ``images/`` tree -- for the crop
     endpoint, which renders high-res crops from the non-bitonal original.
 

--- a/scanning/settings/project/processing_storage.py
+++ b/scanning/settings/project/processing_storage.py
@@ -15,13 +15,21 @@ PROCESSING_TMP_CLEANUP_INTERVAL_SECONDS = env.int(
     "PROCESSING_TMP_CLEANUP_INTERVAL_SECONDS", default=900
 )
 
+# Maximum accepted size (in bytes) for a direct-to-S3 original PDF upload.
+# Enforced in two places: the presign view pre-checks it for a fast
+# client-facing error, and the presigned POST policy's content-length-range
+# condition lets S3 itself reject anything larger before it lands.
+# Configured in whole GB via MAX_UPLOAD_SIZE_GB (default 3 GB).
+MAX_ORIGINAL_UPLOAD_SIZE = env.int("MAX_UPLOAD_SIZE_GB", default=3) * 1024**3
+
 # How long a presigned direct-to-S3 upload (PendingUpload) may sit
 # unconfirmed before cleanup_processing_tmp deletes it -- and, if the
 # upload never landed, its fileless scan. Covers users who close the tab
 # mid-upload. Deliberately longer than S3_UPLOAD_PRESIGNED_TTL: that TTL
 # only bounds when the browser may *start* the POST (which happens
 # seconds after presign); S3 lets an in-flight upload run past policy
-# expiry, so the real bound is transfer time -- a 2 GB file on a slow
-# uplink (~0.8 Mbps) needs about 6 hours. Sweeping sooner would delete
-# the pending row and fileless scan out from under a live upload.
-PENDING_UPLOAD_TTL_HOURS = env.float("PENDING_UPLOAD_TTL_HOURS", default=6.0)
+# expiry, so the real bound is transfer time -- a 3 GB file (the
+# MAX_UPLOAD_SIZE_GB ceiling) on a slow uplink (~0.8 Mbps) needs about
+# 9 hours. Sweeping sooner would delete the pending row and fileless scan
+# out from under a live upload.
+PENDING_UPLOAD_TTL_HOURS = env.float("PENDING_UPLOAD_TTL_HOURS", default=9.0)

--- a/scanning/templates/scanning/queue_detail.html
+++ b/scanning/templates/scanning/queue_detail.html
@@ -280,7 +280,7 @@
   }
 
   // Direct path: presign -> upload straight to S3 -> confirm. Keeps the
-  // (up to 2 GB) file off the Django request path.
+  // (up to 3 GB) file off the Django request path.
   function directUpload(e, action, file) {
     // Step 1: ask Django for a presigned POST. Reuse the form fields
     // (scan metadata) but swap the file itself for its metadata.

--- a/scanning/tests/test_views.py
+++ b/scanning/tests/test_views.py
@@ -501,7 +501,7 @@ class TestPresignedUpload(ScanningTestCase):
         self.assertFalse(PendingUpload.objects.exists())
 
     def test_presign_rejects_oversized(self):
-        response, _ = self._presign(size=str(3 * 1024**3))
+        response, _ = self._presign(size=str(4 * 1024**3))
         self.assertEqual(response.status_code, 400)
         self.assertFalse(Scan.objects.filter(volume_obj=self.volume).exists())
 

--- a/scanning/views.py
+++ b/scanning/views.py
@@ -45,8 +45,9 @@ from scanning.utils import get_volume, has_s3_credentials
 # Max size for a direct-to-S3 original upload. Enforced by the presigned
 # POST policy (see s3_sync.generate_presigned_post) so S3 rejects anything
 # larger before it lands, and pre-checked in the presign view for a fast
-# client-facing error.
-MAX_ORIGINAL_UPLOAD_SIZE = 2 * 1024**3  # 2 GB
+# client-facing error. Configurable via the MAX_UPLOAD_SIZE_GB env var
+# (default 3 GB); see settings.project.processing_storage.
+MAX_ORIGINAL_UPLOAD_SIZE = settings.MAX_ORIGINAL_UPLOAD_SIZE
 
 logger = logging.getLogger(__name__)
 
@@ -662,7 +663,7 @@ def presign_scan_upload(request, reporter_slug, vol):
     """Authorize a direct browser->S3 upload of a scan's original PDF.
 
     Creates/updates the target scan, then returns a presigned POST the
-    browser uses to upload the (up to 2 GB) PDF straight to the scan's
+    browser uses to upload the (up to 3 GB) PDF straight to the scan's
     S3 processing prefix -- keeping those bytes off the Django request
     path. A ``PendingUpload`` row records the authorization until
     ``confirm_scan_upload`` verifies the object landed.
@@ -696,8 +697,10 @@ def presign_scan_upload(request, reporter_slug, vol):
             {"error": "Only PDF files are accepted."}, status=400
         )
     if size <= 0 or size > MAX_ORIGINAL_UPLOAD_SIZE:
+        limit_gb = MAX_ORIGINAL_UPLOAD_SIZE // 1024**3
         return JsonResponse(
-            {"error": "File is empty or exceeds the 2 GB limit."}, status=400
+            {"error": f"File is empty or exceeds the {limit_gb} GB limit."},
+            status=400,
         )
 
     if not has_s3_credentials():

--- a/scanning/views.py
+++ b/scanning/views.py
@@ -42,13 +42,6 @@ from scanning.models import (
 from scanning.services import apply_upload_action
 from scanning.utils import get_volume, has_s3_credentials
 
-# Max size for a direct-to-S3 original upload. Enforced by the presigned
-# POST policy (see s3_sync.generate_presigned_post) so S3 rejects anything
-# larger before it lands, and pre-checked in the presign view for a fast
-# client-facing error. Configurable via the MAX_UPLOAD_SIZE_GB env var
-# (default 3 GB); see settings.project.processing_storage.
-MAX_ORIGINAL_UPLOAD_SIZE = settings.MAX_ORIGINAL_UPLOAD_SIZE
-
 logger = logging.getLogger(__name__)
 
 
@@ -696,8 +689,8 @@ def presign_scan_upload(request, reporter_slug, vol):
         return JsonResponse(
             {"error": "Only PDF files are accepted."}, status=400
         )
-    if size <= 0 or size > MAX_ORIGINAL_UPLOAD_SIZE:
-        limit_gb = MAX_ORIGINAL_UPLOAD_SIZE // 1024**3
+    if size <= 0 or size > settings.MAX_ORIGINAL_UPLOAD_SIZE:
+        limit_gb = settings.MAX_ORIGINAL_UPLOAD_SIZE // 1024**3
         return JsonResponse(
             {"error": f"File is empty or exceeds the {limit_gb} GB limit."},
             status=400,
@@ -721,7 +714,10 @@ def presign_scan_upload(request, reporter_slug, vol):
     original_name = _original_pdf_name(scan, volume)
     try:
         presigned = s3_sync.generate_presigned_post(
-            scan, original_name, content_type, MAX_ORIGINAL_UPLOAD_SIZE
+            scan,
+            original_name,
+            content_type,
+            settings.MAX_ORIGINAL_UPLOAD_SIZE,
         )
         if not presigned:
             # S3 sync disabled despite credentials being present.


### PR DESCRIPTION
I tried to upload a 2.0 GiB scan (2,172,968,846 bytes) and it was rejected: the file was ~25 MB over the old hard-coded 2 GiB ceiling. This raises the limit to 3 GB and makes it configurable so we can adjust it without a code change next time.

## Changes

- `MAX_ORIGINAL_UPLOAD_SIZE` now lives in `settings.project.processing_storage`, sourced from a new `MAX_UPLOAD_SIZE_GB` env var (default 3 GB), instead of being hard-coded in `views.py`.
- The presign view reads the value from settings and reports the configured limit in its error message (no longer a hard-coded "2 GB" string).
- Bumped `PENDING_UPLOAD_TTL_HOURS` default from 6 to 9. That TTL must stay above the worst-case transfer time so the cleanup sweep never deletes a still-uploading pending row. A 3 GB file on a slow (~0.8 Mbps) uplink needs about 9 hours, up from ~6 hours for 2 GB.
- Updated the stale "2 GB" references in docstrings, the s3_sync helper, and the queue_detail template.

## Both enforcement layers still hold

- Fast client-facing pre-check in `presign_scan_upload`.
- Authoritative `content-length-range` condition baked into the presigned POST policy, so S3 itself rejects anything larger before it lands.

## Testing

- Updated the oversized-upload test to use 4 GB (3 GB is now a valid size).
- `scanning.tests.test_views`, `test_cleanup_command`, and `test_recover_pending_uploads` all pass.