### PR TITLE
Log RunPod submit error body and retry paused endpoints

### DIFF
--- a/scanning/runpod_client.py
+++ b/scanning/runpod_client.py
@@ -462,37 +462,40 @@ def _submit(
             return job_id
         except Exception as exc:
             last_exc = exc
+            status_code, err_code, text = _submit_error_detail(exc)
+            body_note = (
+                f" (HTTP {status_code} body: {text[:500]})" if text else ""
+            )
+
+            # A paused / 409 endpoint won't start accepting work within
+            # the in-call backoff window, so don't burn the remaining
+            # attempts: raise transient immediately and let the daemon
+            # re-queue the scan on a later tick.
+            if status_code == 409 or err_code in _TRANSIENT_SUBMIT_CODES:
+                logger.warning(
+                    "runpod submit failed: %s%s; endpoint not accepting "
+                    "work, re-queueing",
+                    exc,
+                    body_note,
+                )
+                raise RunpodTransientError(
+                    f"RunPod endpoint not accepting work (HTTP "
+                    f"{status_code}): {exc}"
+                ) from exc
+
             sleep_for = 2**attempt
-            status_code, _, text = _submit_error_detail(exc)
-            if text:
-                logger.warning(
-                    "runpod submit attempt %d/%d failed: %s "
-                    "(HTTP %s body: %s); sleeping %ds",
-                    attempt + 1,
-                    max_retries + 1,
-                    exc,
-                    status_code,
-                    text[:500],
-                    sleep_for,
-                )
-            else:
-                logger.warning(
-                    "runpod submit attempt %d/%d failed: %s; sleeping %ds",
-                    attempt + 1,
-                    max_retries + 1,
-                    exc,
-                    sleep_for,
-                )
+            logger.warning(
+                "runpod submit attempt %d/%d failed: %s%s; sleeping %ds",
+                attempt + 1,
+                max_retries + 1,
+                exc,
+                body_note,
+                sleep_for,
+            )
             if attempt < max_retries:
                 time.sleep(sleep_for)
 
-    status_code, err_code, _ = _submit_error_detail(last_exc)
-    exc_cls = (
-        RunpodTransientError
-        if status_code == 409 or err_code in _TRANSIENT_SUBMIT_CODES
-        else RunpodError
-    )
-    raise exc_cls(
+    raise RunpodError(
         f"failed to submit RunPod job after {max_retries + 1} attempts: {last_exc}"
     )
 

--- a/scanning/runpod_client.py
+++ b/scanning/runpod_client.py
@@ -63,6 +63,15 @@ class RunpodTransientError(RunpodError):
 # ``RunpodTransientError`` (retry) rather than ``RunpodError`` (fail).
 _TRANSIENT_ERROR_CODES = {"NO_GPU"}
 
+# RunPod ``/run`` submit-time error codes that mean "the endpoint can't
+# take work right now" rather than "this job is bad" -- e.g. the
+# endpoint is scaled to zero (``max_workers=0``), which RunPod reports
+# as HTTP 409 ``ENDPOINT_PAUSED``. Classified (along with any 409) as a
+# ``RunpodTransientError`` so the scan re-queues instead of failing
+# outright; the daemon's ``retry_count`` cap still escalates to
+# ``ERROR_MAX_RETRIES`` if the endpoint stays down.
+_TRANSIENT_SUBMIT_CODES = {"ENDPOINT_PAUSED"}
+
 
 # Friendly labels for progress-callback strings shown in the UI. The
 # raw action names (``detect`` / ``analyze``) are what the client
@@ -376,6 +385,34 @@ def _invoke(
     )
 
 
+def _submit_error_detail(exc: Exception) -> tuple[int | None, str, str]:
+    """Pull the HTTP status and body out of a failed ``/run`` request.
+
+    RunPod error responses carry a JSON body such as
+    ``{"status":409,"title":"Conflict","detail":"Endpoint is paused
+    (max_workers=0)...","code":"ENDPOINT_PAUSED"}``. ``_submit`` logs
+    that body (otherwise ``raise_for_status`` discards it) and uses the
+    ``code`` / status to classify the failure.
+
+    :param exc: The exception raised by ``requests`` / ``_submit``.
+    :returns: ``(status_code, runpod_code, body_text)``. Transport-level
+        failures (no response attached) return ``(None, "", "")``.
+    :rtype: tuple[int | None, str, str]
+    """
+    resp = getattr(exc, "response", None)
+    if resp is None:
+        return None, "", ""
+    text = resp.text or ""
+    code = ""
+    try:
+        parsed = resp.json()
+        if isinstance(parsed, dict):
+            code = parsed.get("code") or ""
+    except ValueError:
+        pass
+    return resp.status_code, code, text
+
+
 def _submit(
     base_url: str,
     headers: dict[str, str],
@@ -388,7 +425,11 @@ def _submit(
 
     :returns: The RunPod job id.
     :rtype: str
-    :raises RunpodError: If all retries fail or the response is malformed.
+    :raises RunpodTransientError: If the endpoint reports it cannot
+        accept work (HTTP 409 / ``ENDPOINT_PAUSED``), so the scan
+        re-queues rather than failing.
+    :raises RunpodError: If all retries fail for any other reason or the
+        response is malformed.
     """
     last_exc: Exception | None = None
     for attempt in range(max_retries + 1):
@@ -422,17 +463,36 @@ def _submit(
         except Exception as exc:
             last_exc = exc
             sleep_for = 2**attempt
-            logger.warning(
-                "runpod submit attempt %d/%d failed: %s; sleeping %ds",
-                attempt + 1,
-                max_retries + 1,
-                exc,
-                sleep_for,
-            )
+            status_code, _, text = _submit_error_detail(exc)
+            if text:
+                logger.warning(
+                    "runpod submit attempt %d/%d failed: %s "
+                    "(HTTP %s body: %s); sleeping %ds",
+                    attempt + 1,
+                    max_retries + 1,
+                    exc,
+                    status_code,
+                    text[:500],
+                    sleep_for,
+                )
+            else:
+                logger.warning(
+                    "runpod submit attempt %d/%d failed: %s; sleeping %ds",
+                    attempt + 1,
+                    max_retries + 1,
+                    exc,
+                    sleep_for,
+                )
             if attempt < max_retries:
                 time.sleep(sleep_for)
 
-    raise RunpodError(
+    status_code, err_code, _ = _submit_error_detail(last_exc)
+    exc_cls = (
+        RunpodTransientError
+        if status_code == 409 or err_code in _TRANSIENT_SUBMIT_CODES
+        else RunpodError
+    )
+    raise exc_cls(
         f"failed to submit RunPod job after {max_retries + 1} attempts: {last_exc}"
     )
 

--- a/scanning/tests/test_runpod_client.py
+++ b/scanning/tests/test_runpod_client.py
@@ -311,7 +311,7 @@ class TestSubmit(TestCase):
             ),
             patch("scanning.runpod_client.time.sleep"),
         ):
-            with self.assertRaises(runpod_client.RunpodError):
+            with self.assertRaises(runpod_client.RunpodError) as ctx:
                 runpod_client._submit(
                     base_url="https://api/run/endpoint",
                     headers={},
@@ -320,6 +320,84 @@ class TestSubmit(TestCase):
                     max_retries=1,
                     progress_callback=None,
                 )
+        # A transport error carries no response, so it stays terminal.
+        self.assertNotIsInstance(
+            ctx.exception, runpod_client.RunpodTransientError
+        )
+
+    def test_endpoint_paused_409_raises_transient(self):
+        """A 409 ENDPOINT_PAUSED re-queues the scan rather than failing."""
+        body = {
+            "status": 409,
+            "title": "Conflict",
+            "detail": (
+                "Endpoint is paused (max_workers=0). "
+                "Set max_workers > 0 to accept work."
+            ),
+            "code": "ENDPOINT_PAUSED",
+        }
+        with (
+            patch(
+                "scanning.runpod_client.requests.post",
+                return_value=_mock_response(409, body),
+            ),
+            patch("scanning.runpod_client.time.sleep"),
+        ):
+            with self.assertRaises(runpod_client.RunpodTransientError):
+                runpod_client._submit(
+                    base_url="https://api/run/endpoint",
+                    headers={},
+                    body={"input": {}},
+                    action="detect",
+                    max_retries=1,
+                    progress_callback=None,
+                )
+
+    def test_non_409_http_error_stays_terminal(self):
+        """A non-409 HTTP error is terminal, not a re-queue."""
+        with (
+            patch(
+                "scanning.runpod_client.requests.post",
+                return_value=_mock_response(400, {"code": "BAD_INPUT"}),
+            ),
+            patch("scanning.runpod_client.time.sleep"),
+        ):
+            with self.assertRaises(runpod_client.RunpodError) as ctx:
+                runpod_client._submit(
+                    base_url="https://api/run/endpoint",
+                    headers={},
+                    body={"input": {}},
+                    action="detect",
+                    max_retries=1,
+                    progress_callback=None,
+                )
+        self.assertNotIsInstance(
+            ctx.exception, runpod_client.RunpodTransientError
+        )
+
+    def test_logs_response_body_on_failure(self):
+        """The RunPod error body is logged, not swallowed by raise_for_status."""
+        body = {"code": "ENDPOINT_PAUSED", "detail": "Endpoint is paused"}
+        with (
+            patch(
+                "scanning.runpod_client.requests.post",
+                return_value=_mock_response(409, body),
+            ),
+            patch("scanning.runpod_client.time.sleep"),
+            self.assertLogs("scanning.runpod_client", level="WARNING") as logs,
+        ):
+            with self.assertRaises(runpod_client.RunpodError):
+                runpod_client._submit(
+                    base_url="https://api/run/endpoint",
+                    headers={},
+                    body={"input": {}},
+                    action="detect",
+                    max_retries=0,
+                    progress_callback=None,
+                )
+        self.assertTrue(
+            any("Endpoint is paused" in line for line in logs.output)
+        )
 
 
 # ── _poll ───────────────────────────────────────────────────────────

--- a/scanning/tests/test_runpod_client.py
+++ b/scanning/tests/test_runpod_client.py
@@ -353,6 +353,46 @@ class TestSubmit(TestCase):
                     progress_callback=None,
                 )
 
+    def test_409_without_known_code_still_transient(self):
+        """Any 409 re-queues, even without an ENDPOINT_PAUSED code."""
+        with (
+            patch(
+                "scanning.runpod_client.requests.post",
+                return_value=_mock_response(409, {"title": "Conflict"}),
+            ),
+            patch("scanning.runpod_client.time.sleep"),
+        ):
+            with self.assertRaises(runpod_client.RunpodTransientError):
+                runpod_client._submit(
+                    base_url="https://api/run/endpoint",
+                    headers={},
+                    body={"input": {}},
+                    action="detect",
+                    max_retries=1,
+                    progress_callback=None,
+                )
+
+    def test_paused_endpoint_short_circuits_without_retrying(self):
+        """A 409 raises immediately instead of burning the retry budget."""
+        with (
+            patch(
+                "scanning.runpod_client.requests.post",
+                return_value=_mock_response(409, {"code": "ENDPOINT_PAUSED"}),
+            ) as mock_post,
+            patch("scanning.runpod_client.time.sleep") as mock_sleep,
+        ):
+            with self.assertRaises(runpod_client.RunpodTransientError):
+                runpod_client._submit(
+                    base_url="https://api/run/endpoint",
+                    headers={},
+                    body={"input": {}},
+                    action="detect",
+                    max_retries=2,
+                    progress_callback=None,
+                )
+        self.assertEqual(mock_post.call_count, 1)
+        mock_sleep.assert_not_called()
+
     def test_non_409_http_error_stays_terminal(self):
         """A non-409 HTTP error is terminal, not a re-queue."""
         with (


### PR DESCRIPTION
## Problem

A production scan failed at YOLO detection with a 409 from RunPod's `/run` endpoint, retried 3 times, then went to ERROR. Two things made this hard to diagnose:

1. The daemon logged only the `requests` exception string (`409 Client Error: Conflict for url ...`). `_submit` calls `raise_for_status()` and never reads `r.text`, so the response body that explains the conflict was discarded. The actual cause was only recoverable by manually curl-ing the endpoint:

   ```json
   {"status":409,"title":"Conflict","detail":"Endpoint is paused (max_workers=0). Set max_workers > 0 to accept work.","code":"ENDPOINT_PAUSED"}
   ```

   The endpoint had been scaled to zero workers.

2. A submit failure raises plain `RunpodError`, which is terminal, so the scan went straight to ERROR rather than re-queuing.

## Changes

- **Log the response body on submit failure.** New `_submit_error_detail()` pulls `(status_code, code, body_text)` off the failed request; `_submit` now logs `HTTP <status> body: <text>` on each failed attempt. Transport-level errors (no response attached) log as before.
- **Classify 409 / `ENDPOINT_PAUSED` as transient.** These now raise `RunpodTransientError`, so a scaled-to-zero (or briefly unavailable) endpoint re-queues the scan instead of failing it.
- **Short-circuit the in-call retry budget on a 409.** A paused endpoint won't start accepting work within the 1-2s backoff window, so `_submit` raises transient immediately on a 409 instead of burning all `RUNPOD_MAX_RETRIES + 1` attempts. In-call retries are still used for transient transport errors (connection reset, timeout, 5xx).

## Notes

- **Bounded re-queue, not indefinite.** A persistently paused endpoint re-queues up to `RUNPOD_MAX_TRANSIENT_RETRIES` daemon ticks (default 5), then lands in `ERROR_MAX_RETRIES` with a clear message. With the short-circuit, each tick now makes a single `/run` attempt (plus the S3 presign) rather than three, so the extra traffic over the old fail-fast behavior is small and capped.
- `ENDPOINT_PAUSED` won't clear on its own (it needs `max_workers` raised); the transient handling buys a self-heal window for briefly-unavailable endpoints without permanently failing on a short blip.
- The Sentry visibility for terminal pipeline failures is handled separately in #137 (the `logger.exception` change), not here.

## Testing

Full suite: 335 passed, 1 skipped. New `_submit` tests cover: paused-endpoint-is-transient, any-409-is-transient (no `code` needed), short-circuit-does-not-retry, non-409-stays-terminal, transport-error-stays-terminal, and body-is-logged.
