### PR TITLE
Clarify admin re-queue actions for errored scans

### DIFF
--- a/scanning/admin.py
+++ b/scanning/admin.py
@@ -134,7 +134,7 @@ class ScanAdmin(admin.ModelAdmin):
     ]
     date_hierarchy = "date_created"
     actions = [
-        "reset_to_queued",
+        "requeue_scans",
         "requeue_retry_cap_scans",
         "requeue_interrupted_scans",
     ]
@@ -284,50 +284,82 @@ class ScanAdmin(admin.ModelAdmin):
         for volume in Volume.objects.filter(pk__in=volume_ids):
             refresh_volume_queue_status(volume)
 
+    # Statuses a scan can be re-queued FROM: any error flavor, plus a
+    # scan stuck in PROCESSING after its daemon was killed. Anything
+    # else (QUEUED, PENDING_REVIEW, DONE, ...) is left alone.
+    _REQUEUEABLE_STATUSES = (
+        Status.ERROR,
+        Status.ERROR_MAX_RETRIES,
+        Status.ERROR_INTERRUPTED,
+        Status.PROCESSING,
+    )
+
     @admin.action(
         description=(
-            "Reset selected scans to QUEUED "
-            "(recover scans stuck in PROCESSING)"
+            "Re-queue selected scans (any Error / stuck Processing) "
+            "-- the general recovery action; resets retry & "
+            "interruption counters"
         )
     )
-    def reset_to_queued(self, request, queryset):
-        """Flip selected scans back to QUEUED so the daemon re-runs them.
+    def requeue_scans(self, request, queryset):
+        """Re-queue selected scans regardless of which error flavor.
 
-        Use this to recover a scan whose daemon process was killed (OOM,
-        pod restart, SIGKILL, etc.) and which remained stuck in
-        ``PROCESSING`` with a frozen progress message. Waiting for
-        ``_recover_stale()`` to pick it up takes up to
-        ``DAEMON_PROCESSING_TIMEOUT`` (default 3600s); this action is
-        the manual shortcut.
+        This is the general-purpose recovery action: use it whenever you
+        just want an errored scan to run again and don't care which cap
+        it hit. It re-queues scans in any error status (plain ``ERROR``,
+        ``ERROR_MAX_RETRIES``, ``ERROR_INTERRUPTED``) or stuck in
+        ``PROCESSING`` after a killed daemon (OOM, pod restart, SIGKILL),
+        and resets both ``retry_count`` and ``interruption_count`` so
+        they start fresh.
+
+        Selected scans not in an error/processing state (QUEUED,
+        PENDING_REVIEW, DONE, ...) are skipped and reported, so a stray
+        selection is never silently reset. For surgically re-queuing only
+        one error flavor, use the retry-cap / interrupted actions instead.
 
         :param request: The admin HTTP request.
         :param queryset: Selected Scan queryset.
         :return: None.
         """
-        updated = queryset.update(
+        updated = queryset.filter(
+            status__in=self._REQUEUEABLE_STATUSES
+        ).update(
             status=Status.QUEUED,
+            retry_count=0,
+            interruption_count=0,
             progress_message="Re-queued via admin",
             progress_current=0,
             progress_total=0,
         )
+        skipped = queryset.count() - updated
+        message = (
+            f"Re-queued {updated} scan(s) and reset retry/interruption "
+            "counters. The daemon will pick them up on the next tick."
+        )
+        if skipped:
+            message += (
+                f" Skipped {skipped} scan(s) not in an Error or "
+                "Processing state."
+            )
         self.message_user(
             request,
-            f"Re-queued {updated} scan(s). The daemon will pick them up "
-            "on the next tick.",
-            level=messages.SUCCESS,
+            message,
+            level=messages.SUCCESS if updated else messages.WARNING,
         )
 
     @admin.action(
         description=(
-            "Re-queue selected scans that hit the retry cap "
-            "(resets retry_count so the daemon will try again)"
+            "Re-queue: retry cap hit only "
+            "(status 'Error (retry cap hit)'; resets retry_count)"
         )
     )
     def requeue_retry_cap_scans(self, request, queryset):
-        """Re-queue scans stopped after hitting the transient retry cap.
+        """Re-queue only scans stopped after hitting the transient retry cap.
 
-        Resets ``status``, ``retry_count``, and ``progress_message`` so
-        the daemon will pick them up and attempt processing again.
+        Narrower than ``requeue_scans``: touches only
+        ``ERROR_MAX_RETRIES`` scans and resets just ``retry_count``. Warns
+        (rather than silently reporting 0) when the selection contains no
+        such scan, pointing at the general action.
 
         :param request: The admin HTTP request.
         :param queryset: Selected Scan queryset.
@@ -340,26 +372,37 @@ class ScanAdmin(admin.ModelAdmin):
             progress_current=0,
             progress_total=0,
         )
-        self.message_user(
-            request,
-            f"Re-queued {updated} scan(s) with retry_count reset. "
-            "The daemon will try them again on the next tick.",
-            level=messages.SUCCESS,
-        )
+        if updated:
+            self.message_user(
+                request,
+                f"Re-queued {updated} scan(s) with retry_count reset. "
+                "The daemon will try them again on the next tick.",
+                level=messages.SUCCESS,
+            )
+        else:
+            self.message_user(
+                request,
+                "None of the selected scans were in 'Error (retry cap "
+                "hit)'. For a plain 'Error' scan, use 'Re-queue selected "
+                "scans (any Error / stuck Processing)'.",
+                level=messages.WARNING,
+            )
 
     @admin.action(
         description=(
-            "Re-queue selected scans flagged as interrupted too often "
-            "(resets interruption_count so the daemon will try again)"
+            "Re-queue: interrupted too often only "
+            "(status 'Error (interrupted too often)'; "
+            "resets interruption_count)"
         )
     )
     def requeue_interrupted_scans(self, request, queryset):
-        """Re-queue scans flagged ERROR_INTERRUPTED by the daemon guard.
+        """Re-queue only scans flagged ERROR_INTERRUPTED by the daemon guard.
 
-        Resets ``status``, ``interruption_count``, and ``progress_message``
-        so the daemon picks them up again. Use once the underlying pod churn
-        (deploys, evictions, OOM) that interrupted them has settled (issue
-        #124).
+        Narrower than ``requeue_scans``: touches only
+        ``ERROR_INTERRUPTED`` scans and resets just ``interruption_count``.
+        Use once the underlying pod churn (deploys, evictions, OOM) that
+        interrupted them has settled (issue #124). Warns when the
+        selection contains no such scan.
 
         :param request: The admin HTTP request.
         :param queryset: Selected Scan queryset.
@@ -372,12 +415,21 @@ class ScanAdmin(admin.ModelAdmin):
             progress_current=0,
             progress_total=0,
         )
-        self.message_user(
-            request,
-            f"Re-queued {updated} scan(s) with interruption_count reset. "
-            "The daemon will try them again on the next tick.",
-            level=messages.SUCCESS,
-        )
+        if updated:
+            self.message_user(
+                request,
+                f"Re-queued {updated} scan(s) with interruption_count "
+                "reset. The daemon will try them again on the next tick.",
+                level=messages.SUCCESS,
+            )
+        else:
+            self.message_user(
+                request,
+                "None of the selected scans were in 'Error (interrupted "
+                "too often)'. For a plain 'Error' scan, use 'Re-queue "
+                "selected scans (any Error / stuck Processing)'.",
+                level=messages.WARNING,
+            )
 
 
 @admin.register(OpinionScan)

--- a/scanning/admin.py
+++ b/scanning/admin.py
@@ -294,6 +294,64 @@ class ScanAdmin(admin.ModelAdmin):
         Status.PROCESSING,
     )
 
+    def _requeue(
+        self,
+        request,
+        queryset,
+        *,
+        statuses,
+        counter_resets,
+        progress_message,
+        no_match_message,
+        success_message,
+        skipped_message,
+    ):
+        """Re-queue the selected scans whose status is in ``statuses``.
+
+        Shared body of the three re-queue actions: filter the selection to
+        the statuses this action owns, reset the relevant counters and the
+        progress fields, then report. Reporting is deliberately never a
+        silent success: with nothing matched it warns and stops, and a
+        partial match warns with the skipped count appended, because a
+        selection the action ignored is exactly the surprise an operator
+        needs to see.
+
+        :param request: The admin HTTP request.
+        :param queryset: Selected Scan queryset.
+        :param statuses: Statuses this action re-queues from.
+        :param counter_resets: Extra ``update()`` kwargs zeroing whichever
+            counters this action owns.
+        :param progress_message: Value for the scan's ``progress_message``.
+        :param no_match_message: Warning shown when nothing matched.
+        :param success_message: Message template taking ``updated``.
+        :param skipped_message: Message template taking ``skipped``,
+            appended when part of the selection was left alone.
+        :return: None.
+        """
+        updated = queryset.filter(status__in=statuses).update(
+            status=Status.QUEUED,
+            progress_message=progress_message,
+            progress_current=0,
+            progress_total=0,
+            **counter_resets,
+        )
+        if not updated:
+            self.message_user(
+                request, no_match_message, level=messages.WARNING
+            )
+            return
+        # ``queryset`` is re-evaluated here, so this counts the original
+        # selection, not the post-update rows.
+        skipped = queryset.count() - updated
+        message = success_message.format(updated=updated)
+        if skipped:
+            message += " " + skipped_message.format(skipped=skipped)
+        self.message_user(
+            request,
+            message,
+            level=messages.WARNING if skipped else messages.SUCCESS,
+        )
+
     @admin.action(
         description=(
             "Re-queue selected scans (any Error / stuck Processing) "
@@ -321,40 +379,24 @@ class ScanAdmin(admin.ModelAdmin):
         :param queryset: Selected Scan queryset.
         :return: None.
         """
-        updated = queryset.filter(
-            status__in=self._REQUEUEABLE_STATUSES
-        ).update(
-            status=Status.QUEUED,
-            retry_count=0,
-            interruption_count=0,
-            progress_message="Re-queued via admin",
-            progress_current=0,
-            progress_total=0,
-        )
-        if not updated:
-            self.message_user(
-                request,
-                "None of the selected scans were in an Error or Processing "
-                "state; nothing re-queued.",
-                level=messages.WARNING,
-            )
-            return
-        skipped = queryset.count() - updated
-        message = (
-            f"Re-queued {updated} scan(s) and reset retry/interruption "
-            "counters. The daemon will pick them up on the next tick."
-        )
-        if skipped:
-            message += (
-                f" Skipped {skipped} scan(s) not in an Error or "
-                "Processing state."
-            )
-        self.message_user(
+        self._requeue(
             request,
-            message,
-            # Skipped scans are exactly the surprise this action exists to
-            # surface, so a partial run warns rather than reads as clean.
-            level=messages.WARNING if skipped else messages.SUCCESS,
+            queryset,
+            statuses=self._REQUEUEABLE_STATUSES,
+            counter_resets={"retry_count": 0, "interruption_count": 0},
+            progress_message="Re-queued via admin",
+            no_match_message=(
+                "None of the selected scans were in an Error or Processing "
+                "state; nothing re-queued."
+            ),
+            success_message=(
+                "Re-queued {updated} scan(s) and reset retry/interruption "
+                "counters. The daemon will pick them up on the next tick."
+            ),
+            skipped_message=(
+                "Skipped {skipped} scan(s) not in an Error or Processing "
+                "state."
+            ),
         )
 
     @admin.action(
@@ -375,36 +417,25 @@ class ScanAdmin(admin.ModelAdmin):
         :param queryset: Selected Scan queryset.
         :return: None.
         """
-        updated = queryset.filter(status=Status.ERROR_MAX_RETRIES).update(
-            status=Status.QUEUED,
-            retry_count=0,
+        self._requeue(
+            request,
+            queryset,
+            statuses=[Status.ERROR_MAX_RETRIES],
+            counter_resets={"retry_count": 0},
             progress_message="Re-queued via admin (retry cap reset)",
-            progress_current=0,
-            progress_total=0,
-        )
-        if not updated:
-            self.message_user(
-                request,
+            no_match_message=(
                 "None of the selected scans were in 'Error (retry cap "
                 "hit)'. For a plain 'Error' scan, use 'Re-queue selected "
-                "scans (any Error / stuck Processing)'.",
-                level=messages.WARNING,
-            )
-            return
-        skipped = queryset.count() - updated
-        message = (
-            f"Re-queued {updated} scan(s) with retry_count reset. "
-            "The daemon will try them again on the next tick."
-        )
-        if skipped:
-            message += (
-                f" Left {skipped} other selected scan(s) untouched (not "
+                "scans (any Error / stuck Processing)'."
+            ),
+            success_message=(
+                "Re-queued {updated} scan(s) with retry_count reset. "
+                "The daemon will try them again on the next tick."
+            ),
+            skipped_message=(
+                "Left {skipped} other selected scan(s) untouched (not "
                 "'Error (retry cap hit)')."
-            )
-        self.message_user(
-            request,
-            message,
-            level=messages.WARNING if skipped else messages.SUCCESS,
+            ),
         )
 
     @admin.action(
@@ -427,36 +458,25 @@ class ScanAdmin(admin.ModelAdmin):
         :param queryset: Selected Scan queryset.
         :return: None.
         """
-        updated = queryset.filter(status=Status.ERROR_INTERRUPTED).update(
-            status=Status.QUEUED,
-            interruption_count=0,
+        self._requeue(
+            request,
+            queryset,
+            statuses=[Status.ERROR_INTERRUPTED],
+            counter_resets={"interruption_count": 0},
             progress_message="Re-queued via admin (interruption cap reset)",
-            progress_current=0,
-            progress_total=0,
-        )
-        if not updated:
-            self.message_user(
-                request,
+            no_match_message=(
                 "None of the selected scans were in 'Error (interrupted "
                 "too often)'. For a plain 'Error' scan, use 'Re-queue "
-                "selected scans (any Error / stuck Processing)'.",
-                level=messages.WARNING,
-            )
-            return
-        skipped = queryset.count() - updated
-        message = (
-            f"Re-queued {updated} scan(s) with interruption_count reset. "
-            "The daemon will try them again on the next tick."
-        )
-        if skipped:
-            message += (
-                f" Left {skipped} other selected scan(s) untouched (not "
+                "selected scans (any Error / stuck Processing)'."
+            ),
+            success_message=(
+                "Re-queued {updated} scan(s) with interruption_count "
+                "reset. The daemon will try them again on the next tick."
+            ),
+            skipped_message=(
+                "Left {skipped} other selected scan(s) untouched (not "
                 "'Error (interrupted too often)')."
-            )
-        self.message_user(
-            request,
-            message,
-            level=messages.WARNING if skipped else messages.SUCCESS,
+            ),
         )
 
 

--- a/scanning/admin.py
+++ b/scanning/admin.py
@@ -331,6 +331,14 @@ class ScanAdmin(admin.ModelAdmin):
             progress_current=0,
             progress_total=0,
         )
+        if not updated:
+            self.message_user(
+                request,
+                "None of the selected scans were in an Error or Processing "
+                "state; nothing re-queued.",
+                level=messages.WARNING,
+            )
+            return
         skipped = queryset.count() - updated
         message = (
             f"Re-queued {updated} scan(s) and reset retry/interruption "
@@ -344,7 +352,9 @@ class ScanAdmin(admin.ModelAdmin):
         self.message_user(
             request,
             message,
-            level=messages.SUCCESS if updated else messages.WARNING,
+            # Skipped scans are exactly the surprise this action exists to
+            # surface, so a partial run warns rather than reads as clean.
+            level=messages.WARNING if skipped else messages.SUCCESS,
         )
 
     @admin.action(
@@ -372,14 +382,7 @@ class ScanAdmin(admin.ModelAdmin):
             progress_current=0,
             progress_total=0,
         )
-        if updated:
-            self.message_user(
-                request,
-                f"Re-queued {updated} scan(s) with retry_count reset. "
-                "The daemon will try them again on the next tick.",
-                level=messages.SUCCESS,
-            )
-        else:
+        if not updated:
             self.message_user(
                 request,
                 "None of the selected scans were in 'Error (retry cap "
@@ -387,6 +390,22 @@ class ScanAdmin(admin.ModelAdmin):
                 "scans (any Error / stuck Processing)'.",
                 level=messages.WARNING,
             )
+            return
+        skipped = queryset.count() - updated
+        message = (
+            f"Re-queued {updated} scan(s) with retry_count reset. "
+            "The daemon will try them again on the next tick."
+        )
+        if skipped:
+            message += (
+                f" Left {skipped} other selected scan(s) untouched (not "
+                "'Error (retry cap hit)')."
+            )
+        self.message_user(
+            request,
+            message,
+            level=messages.WARNING if skipped else messages.SUCCESS,
+        )
 
     @admin.action(
         description=(
@@ -415,14 +434,7 @@ class ScanAdmin(admin.ModelAdmin):
             progress_current=0,
             progress_total=0,
         )
-        if updated:
-            self.message_user(
-                request,
-                f"Re-queued {updated} scan(s) with interruption_count "
-                "reset. The daemon will try them again on the next tick.",
-                level=messages.SUCCESS,
-            )
-        else:
+        if not updated:
             self.message_user(
                 request,
                 "None of the selected scans were in 'Error (interrupted "
@@ -430,6 +442,22 @@ class ScanAdmin(admin.ModelAdmin):
                 "selected scans (any Error / stuck Processing)'.",
                 level=messages.WARNING,
             )
+            return
+        skipped = queryset.count() - updated
+        message = (
+            f"Re-queued {updated} scan(s) with interruption_count reset. "
+            "The daemon will try them again on the next tick."
+        )
+        if skipped:
+            message += (
+                f" Left {skipped} other selected scan(s) untouched (not "
+                "'Error (interrupted too often)')."
+            )
+        self.message_user(
+            request,
+            message,
+            level=messages.WARNING if skipped else messages.SUCCESS,
+        )
 
 
 @admin.register(OpinionScan)

--- a/scanning/tests/test_admin.py
+++ b/scanning/tests/test_admin.py
@@ -79,9 +79,13 @@ class ScanAdminRequeueActionTests(TestCase):
             Scan.objects.filter(pk__in=pks, status=Status.QUEUED).count(), 4
         )
 
-    def test_requeue_scans_skips_non_error_and_reports(self):
+    def test_requeue_scans_skips_non_error_leaves_it_untouched(self):
         err = ScanFactory(status=Status.ERROR)
-        done = ScanFactory(status=Status.PENDING_REVIEW)
+        done = ScanFactory(
+            status=Status.PENDING_REVIEW,
+            retry_count=2,
+            interruption_count=1,
+        )
         msgs = self._run(
             "requeue_scans",
             Scan.objects.filter(pk__in=[err.pk, done.pk]),
@@ -89,14 +93,37 @@ class ScanAdminRequeueActionTests(TestCase):
         err.refresh_from_db()
         done.refresh_from_db()
         self.assertEqual(err.status, Status.QUEUED)
+        # The skipped scan keeps its status AND its counters.
         self.assertEqual(done.status, Status.PENDING_REVIEW)
+        self.assertEqual(done.retry_count, 2)
+        self.assertEqual(done.interruption_count, 1)
+        # A partial run warns and reports the skip.
+        self.assertEqual(msgs[0].level, messages.WARNING)
         self.assertIn("Skipped 1", msgs[0].message)
+
+    def test_requeue_scans_resets_progress_fields(self):
+        scan = ScanFactory(
+            status=Status.ERROR,
+            progress_message="frozen mid-OCR",
+            progress_current=137,
+            progress_total=943,
+        )
+        self._run("requeue_scans", Scan.objects.filter(pk=scan.pk))
+        scan.refresh_from_db()
+        self.assertEqual(scan.progress_message, "Re-queued via admin")
+        self.assertEqual(scan.progress_current, 0)
+        self.assertEqual(scan.progress_total, 0)
 
     def test_requeue_scans_warns_when_nothing_matched(self):
         scan = ScanFactory(status=Status.PENDING_REVIEW)
         msgs = self._run("requeue_scans", Scan.objects.filter(pk=scan.pk))
         scan.refresh_from_db()
         self.assertEqual(scan.status, Status.PENDING_REVIEW)
+        self.assertEqual(msgs[0].level, messages.WARNING)
+        self.assertIn("nothing re-queued", msgs[0].message)
+
+    def test_requeue_scans_empty_selection_warns(self):
+        msgs = self._run("requeue_scans", Scan.objects.none())
         self.assertEqual(msgs[0].level, messages.WARNING)
 
     # ── requeue_retry_cap_scans (scoped) ─────────────────────────────
@@ -109,6 +136,22 @@ class ScanAdminRequeueActionTests(TestCase):
         self.assertEqual(scan.status, Status.QUEUED)
         self.assertEqual(scan.retry_count, 0)
         self.assertEqual(msgs[0].level, messages.SUCCESS)
+
+    def test_retry_cap_action_leaves_non_matching_untouched(self):
+        cap = ScanFactory(status=Status.ERROR_MAX_RETRIES, retry_count=5)
+        plain = ScanFactory(status=Status.ERROR, retry_count=1)
+        msgs = self._run(
+            "requeue_retry_cap_scans",
+            Scan.objects.filter(pk__in=[cap.pk, plain.pk]),
+        )
+        cap.refresh_from_db()
+        plain.refresh_from_db()
+        # Only the retry-cap scan is touched; the plain Error is left as-is.
+        self.assertEqual(cap.status, Status.QUEUED)
+        self.assertEqual(plain.status, Status.ERROR)
+        self.assertEqual(plain.retry_count, 1)
+        self.assertEqual(msgs[0].level, messages.WARNING)
+        self.assertIn("Left 1", msgs[0].message)
 
     def test_retry_cap_action_warns_on_plain_error(self):
         scan = ScanFactory(status=Status.ERROR)

--- a/scanning/tests/test_admin.py
+++ b/scanning/tests/test_admin.py
@@ -1,0 +1,142 @@
+"""Tests for ``scanning.admin`` re-queue actions.
+
+The ``ScanAdmin`` re-queue actions are called directly on the admin
+instance with a ``RequestFactory`` request wired for the messages
+framework; nothing goes through the admin HTTP views.
+
+Covers:
+
+- ``requeue_scans`` (general recovery): re-queues any error / stuck
+  Processing scan, resets both counters, skips and reports non-error
+  selections.
+- ``requeue_retry_cap_scans`` / ``requeue_interrupted_scans``: narrow
+  status-scoped variants that warn (rather than silently succeed) when
+  the selection contains no matching scan.
+"""
+
+from django.contrib import messages
+from django.contrib.admin.sites import AdminSite
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.test import RequestFactory, TestCase
+
+from scanning.admin import ScanAdmin
+from scanning.factories import ScanFactory
+from scanning.models import Scan, Status
+
+
+def _request_with_messages():
+    """Build a POST request wired for ``ModelAdmin.message_user``."""
+    request = RequestFactory().post("/admin/scanning/scan/")
+    SessionMiddleware(lambda r: None).process_request(request)
+    request.session.save()
+    request._messages = FallbackStorage(request)
+    return request
+
+
+class ScanAdminRequeueActionTests(TestCase):
+    """``ScanAdmin`` re-queue actions."""
+
+    def setUp(self):
+        self.admin = ScanAdmin(Scan, AdminSite())
+
+    def _run(self, action_name, queryset):
+        """Invoke an action and return the captured messages list."""
+        request = _request_with_messages()
+        getattr(self.admin, action_name)(request, queryset)
+        return list(request._messages)
+
+    # ── requeue_scans (general) ──────────────────────────────────────
+    def test_requeue_scans_requeues_plain_error(self):
+        scan = ScanFactory(status=Status.ERROR)
+        msgs = self._run("requeue_scans", Scan.objects.filter(pk=scan.pk))
+        scan.refresh_from_db()
+        self.assertEqual(scan.status, Status.QUEUED)
+        self.assertEqual(msgs[0].level, messages.SUCCESS)
+
+    def test_requeue_scans_resets_both_counters(self):
+        scan = ScanFactory(
+            status=Status.ERROR_MAX_RETRIES,
+            retry_count=5,
+            interruption_count=3,
+        )
+        self._run("requeue_scans", Scan.objects.filter(pk=scan.pk))
+        scan.refresh_from_db()
+        self.assertEqual(scan.status, Status.QUEUED)
+        self.assertEqual(scan.retry_count, 0)
+        self.assertEqual(scan.interruption_count, 0)
+
+    def test_requeue_scans_covers_all_error_and_processing(self):
+        scans = [
+            ScanFactory(status=Status.ERROR),
+            ScanFactory(status=Status.ERROR_MAX_RETRIES),
+            ScanFactory(status=Status.ERROR_INTERRUPTED),
+            ScanFactory(status=Status.PROCESSING),
+        ]
+        pks = [s.pk for s in scans]
+        self._run("requeue_scans", Scan.objects.filter(pk__in=pks))
+        self.assertEqual(
+            Scan.objects.filter(pk__in=pks, status=Status.QUEUED).count(), 4
+        )
+
+    def test_requeue_scans_skips_non_error_and_reports(self):
+        err = ScanFactory(status=Status.ERROR)
+        done = ScanFactory(status=Status.PENDING_REVIEW)
+        msgs = self._run(
+            "requeue_scans",
+            Scan.objects.filter(pk__in=[err.pk, done.pk]),
+        )
+        err.refresh_from_db()
+        done.refresh_from_db()
+        self.assertEqual(err.status, Status.QUEUED)
+        self.assertEqual(done.status, Status.PENDING_REVIEW)
+        self.assertIn("Skipped 1", msgs[0].message)
+
+    def test_requeue_scans_warns_when_nothing_matched(self):
+        scan = ScanFactory(status=Status.PENDING_REVIEW)
+        msgs = self._run("requeue_scans", Scan.objects.filter(pk=scan.pk))
+        scan.refresh_from_db()
+        self.assertEqual(scan.status, Status.PENDING_REVIEW)
+        self.assertEqual(msgs[0].level, messages.WARNING)
+
+    # ── requeue_retry_cap_scans (scoped) ─────────────────────────────
+    def test_retry_cap_action_requeues_matching(self):
+        scan = ScanFactory(status=Status.ERROR_MAX_RETRIES, retry_count=5)
+        msgs = self._run(
+            "requeue_retry_cap_scans", Scan.objects.filter(pk=scan.pk)
+        )
+        scan.refresh_from_db()
+        self.assertEqual(scan.status, Status.QUEUED)
+        self.assertEqual(scan.retry_count, 0)
+        self.assertEqual(msgs[0].level, messages.SUCCESS)
+
+    def test_retry_cap_action_warns_on_plain_error(self):
+        scan = ScanFactory(status=Status.ERROR)
+        msgs = self._run(
+            "requeue_retry_cap_scans", Scan.objects.filter(pk=scan.pk)
+        )
+        scan.refresh_from_db()
+        self.assertEqual(scan.status, Status.ERROR)
+        self.assertEqual(msgs[0].level, messages.WARNING)
+
+    # ── requeue_interrupted_scans (scoped) ───────────────────────────
+    def test_interrupted_action_requeues_matching(self):
+        scan = ScanFactory(
+            status=Status.ERROR_INTERRUPTED, interruption_count=4
+        )
+        msgs = self._run(
+            "requeue_interrupted_scans", Scan.objects.filter(pk=scan.pk)
+        )
+        scan.refresh_from_db()
+        self.assertEqual(scan.status, Status.QUEUED)
+        self.assertEqual(scan.interruption_count, 0)
+        self.assertEqual(msgs[0].level, messages.SUCCESS)
+
+    def test_interrupted_action_warns_on_plain_error(self):
+        scan = ScanFactory(status=Status.ERROR)
+        msgs = self._run(
+            "requeue_interrupted_scans", Scan.objects.filter(pk=scan.pk)
+        )
+        scan.refresh_from_db()
+        self.assertEqual(scan.status, Status.ERROR)
+        self.assertEqual(msgs[0].level, messages.WARNING)


### PR DESCRIPTION
## Problem

An operator looking at a scan in `Error` status in the Django admin couldn't tell which of the three re-queue actions to pick. The action names didn't line up with the status labels, and the two status-scoped actions (`requeue_retry_cap_scans`, `requeue_interrupted_scans`) silently reported "Re-queued 0 scan(s)" as a **success** when run on a plain `Error` scan, so it looked like nothing happened for no reason.

There are three distinct error statuses (`Error`, `Error (retry cap hit)`, `Error (interrupted too often)`), plus a scan can be stuck in `Processing` after a killed daemon.

## Changes

- **New general action: "Re-queue selected scans (any Error / stuck Processing)".** Replaces the old `reset_to_queued`. Requeues a scan in any error status or stuck `Processing`, and resets both `retry_count` and `interruption_count`. This is the obvious pick for a plain `Error` scan. Unlike the old action it filters to error/processing statuses, so a stray selection (a `Pending Review` or `Approved` scan) is skipped and reported rather than silently reset.
- **Scoped actions relabeled to name their exact status** ("retry cap hit only", "interrupted too often only") so it's clear what each targets and what counter it resets.
- **No more misleading silent success.** All three actions now warn (instead of reporting a clean success) when the selection contained no matching scan, or when only part of the selection matched, and they report how many were skipped/left untouched. The scoped actions stay surgical: they only ever touch their one status.

## Behavior notes

- The general action treats `Processing` as re-queueable, so it will reset an actively-processing scan, not just a stuck one (the admin can't distinguish them). This matches, and is safer than, the old unfiltered `reset_to_queued`.
- No DB schema change; actions only touch `status`, the two counters, and the `progress_*` fields.

## Testing

Full suite: 342 passed, 1 skipped. New `scanning/tests/test_admin.py` covers the general action (plain error, all error/processing statuses, dual-counter reset, progress-field reset, skip-and-report, empty selection, warn-on-no-match) and the scoped actions (match, warn-on-plain-error, and mixed-selection leaving non-matching scans fully untouched).
