### PR TITLE
fix(scanning): correct light and dark mode contrast in scan templates

### DIFF
--- a/scanning/assets/tailwind/tailwind.config.js
+++ b/scanning/assets/tailwind/tailwind.config.js
@@ -46,6 +46,9 @@ module.exports = {
 
       /* JS files that could contain Tailwind CSS classes */
       '../static-global/js/**/*.js',
+
+      /* App JS that builds markup at runtime (the process page viewer) */
+      '../../static/**/*.js',
     ],
   },
   theme: {

--- a/scanning/static/scanning/checker.css
+++ b/scanning/static/scanning/checker.css
@@ -1,9 +1,10 @@
 * { box-sizing: border-box; margin: 0; padding: 0; }
 
+/* Background and text color come from the Tailwind base layer so they follow
+   the light/dark scheme. Setting them here would win on source order and pin
+   the whole page to a light theme. */
 body {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-    background: #f5f5f5;
-    color: #333;
 }
 
 .navbar {
@@ -248,20 +249,15 @@ a.doc-name:hover { text-decoration: underline; }
 .dismiss-btn { background: #059669; font-size: 11px; padding: 3px 12px; }
 .dismiss-btn:hover { background: #047857; }
 
+/* Layout only. Background, border and hover come from the scheme-aware
+   Tailwind classes on the element itself. */
 .issue-card {
     padding: 10px 12px;
     margin-top: 8px;
     border-radius: 6px;
     cursor: pointer;
-    border-left: 4px solid #ddd;
-    background: #fafafa;
     transition: background 0.15s;
 }
-.issue-card:hover { background: #f0f0f0; }
-.issue-card.ok { border-left-color: #22c55e; background: #f0fdf4; }
-.issue-card.error { border-left-color: #ef4444; }
-.issue-card.warning { border-left-color: #f59e0b; }
-.issue-card.info { border-left-color: #3b82f6; }
 
 .issue-header { display: flex; align-items: center; gap: 8px; }
 .severity-badge {
@@ -344,8 +340,11 @@ a.doc-name:hover { text-decoration: underline; }
 }
 
 /* Page containers */
+/* Scanned pages stay white paper in both schemes, so they carry their own
+   dark text color rather than inheriting the scheme-aware one. */
 .page-container {
     background: white;
+    color: #333;
     box-shadow: 0 2px 8px rgba(0,0,0,0.3);
     position: relative;
 }
@@ -560,6 +559,7 @@ a.doc-name:hover { text-decoration: underline; }
 }
 .dupe-modal {
     background: white;
+    color: #333;
     border-radius: 10px;
     padding: 20px;
     max-width: 92vw;
@@ -643,10 +643,6 @@ a.doc-name:hover { text-decoration: underline; }
     max-height: 400px;
     overflow-y: auto;
     font-family: monospace;
-}
-.opinion-card.selected, .issue-card.selected {
-    border-left-color: #7c3aed;
-    background: #ede9fe;
 }
 /* Detection overlay boxes */
 .detection-box {

--- a/scanning/static/scanning/viewer_progress.js
+++ b/scanning/static/scanning/viewer_progress.js
@@ -84,7 +84,7 @@
                 (r.pdf_page - 1) +
                 "\" onclick=\"goToPage(this)\">";
             html +=
-                '<span><span class="font-medium text-gray-500">' +
+                '<span><span class="font-medium text-gray-500 dark:text-gray-400">' +
                 r.pdf_page +
                 "</span>";
             if (r.detected) {

--- a/scanning/templates/scanning/opinion_detail.html
+++ b/scanning/templates/scanning/opinion_detail.html
@@ -9,7 +9,7 @@
   <!-- Left panel: info -->
   <aside class="w-80 flex-shrink-0 border-r border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-850 overflow-y-auto">
     <div class="p-4">
-      <a href="{% url 'opinion_list' %}" class="inline-flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400 hover:text-primary-600 mb-4">
+      <a href="{% url 'opinion_list' %}" class="inline-flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-400 mb-4">
         <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
         Back to opinions
       </a>
@@ -63,7 +63,7 @@
 
     {% if user.is_staff %}
     <div class="border-t border-gray-200 dark:border-gray-700 px-4 py-3">
-      <a href="{% url 'admin:scanning_opinionscan_change' opinion.pk %}" class="text-xs text-gray-400 hover:text-primary-600">Edit in admin</a>
+      <a href="{% url 'admin:scanning_opinionscan_change' opinion.pk %}" class="text-xs text-gray-500 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-400">Edit in admin</a>
     </div>
     {% endif %}
   </aside>

--- a/scanning/templates/scanning/opinion_detail.html
+++ b/scanning/templates/scanning/opinion_detail.html
@@ -7,7 +7,7 @@
 {% block full_width_content %}
 <div class="flex" style="height: calc(100vh - 64px);">
   <!-- Left panel: info -->
-  <aside class="w-80 flex-shrink-0 border-r border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-850 overflow-y-auto">
+  <aside class="w-80 flex-shrink-0 border-r border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 overflow-y-auto">
     <div class="p-4">
       <a href="{% url 'opinion_list' %}" class="inline-flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-400 mb-4">
         <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
@@ -28,7 +28,7 @@
           {% if opinion.scan %}
           <tr class="border-b border-gray-100 dark:border-gray-700/50">
             <td class="px-4 py-2.5 text-gray-500 dark:text-gray-400 font-medium">Book</td>
-            <td class="px-4 py-2.5"><a href="{% url 'scan_process' pk=opinion.scan.pk %}" class="text-primary-600 hover:underline">#{{ opinion.scan.pk }}</a></td>
+            <td class="px-4 py-2.5"><a href="{% url 'scan_process' pk=opinion.scan.pk %}" class="text-primary-600 dark:text-primary-400 hover:underline">#{{ opinion.scan.pk }}</a></td>
           </tr>
           {% endif %}
           {% if opinion.uploaded_by %}

--- a/scanning/templates/scanning/page_detail.html
+++ b/scanning/templates/scanning/page_detail.html
@@ -4,16 +4,16 @@
 
 {% block content %}
 <div class="mb-4 text-sm text-gray-500 dark:text-gray-400">
-  <a href="{% url 'scan_list' %}" class="hover:text-primary-600">Scans</a>
+  <a href="{% url 'scan_list' %}" class="hover:text-primary-600 dark:hover:text-primary-400">Scans</a>
   <span class="mx-1 text-gray-300 dark:text-gray-600">/</span>
-  <a href="{% url 'scan_pages_list' pk=scan.pk %}" class="hover:text-primary-600">{{ scan.reporter.short_name }} vol. {{ scan.volume }} pages</a>
+  <a href="{% url 'scan_pages_list' pk=scan.pk %}" class="hover:text-primary-600 dark:hover:text-primary-400">{{ scan.reporter.short_name }} vol. {{ scan.volume }} pages</a>
   <span class="mx-1 text-gray-300 dark:text-gray-600">/</span>
   <span>Page {{ page.page_index|add:1 }}</span>
 </div>
 
 <div class="flex items-center justify-between mb-4">
   <div>
-    <h1 class="text-xl font-bold">Page {{ page.page_index|add:1 }}{% if page.book_page %} <span class="text-gray-500 dark:text-gray-400 text-base font-normal">(book page {{ page.book_page }})</span>{% endif %}{% if page.is_blank %} <span class="text-gray-400 text-base font-normal">— blank</span>{% endif %}</h1>
+    <h1 class="text-xl font-bold">Page {{ page.page_index|add:1 }}{% if page.book_page %} <span class="text-gray-500 dark:text-gray-400 text-base font-normal">(book page {{ page.book_page }})</span>{% endif %}{% if page.is_blank %} <span class="text-gray-500 dark:text-gray-400 text-base font-normal">— blank</span>{% endif %}</h1>
     <p class="text-sm text-gray-500 dark:text-gray-400">
       Status: {{ page.get_status_display }}
       {% if page.extracted_by %} · Extracted by: {{ page.get_extracted_by_display }}{% endif %}
@@ -40,7 +40,7 @@
   <div class="space-y-4">
     <div class="card">
       <h2 class="font-semibold text-sm mb-2">User prompt
-        {% if page.user_prompt_id %}<a href="{% url 'admin:ai_prompt_change' page.user_prompt_id %}" class="text-xs text-gray-400 hover:text-primary-600">edit in admin</a>{% endif %}
+        {% if page.user_prompt_id %}<a href="{% url 'admin:ai_prompt_change' page.user_prompt_id %}" class="text-xs text-gray-500 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-400">edit in admin</a>{% endif %}
       </h2>
       {% if page.user_prompt %}
         <pre class="text-xs whitespace-pre-wrap bg-gray-50 dark:bg-gray-900 p-3 rounded max-h-96 overflow-auto">{{ page.user_prompt.text }}</pre>
@@ -59,11 +59,11 @@
     <div class="card text-xs">
       <h2 class="font-semibold text-sm mb-2">Metadata</h2>
       <dl class="grid grid-cols-2 gap-y-1">
-        <dt class="text-gray-500">PDF path</dt><dd>{{ page.pdf_path|default:"—" }}</dd>
-        <dt class="text-gray-500">Page index (0-based)</dt><dd>{{ page.page_index }}</dd>
-        <dt class="text-gray-500">Book page</dt><dd>{{ page.book_page|default:"—" }}</dd>
-        <dt class="text-gray-500">Opinion starts/ends</dt><dd>{{ page.expected_opinion_starts }} / {{ page.expected_opinion_ends }}</dd>
-        <dt class="text-gray-500">Blank</dt><dd>{{ page.is_blank|yesno:"yes,no" }}</dd>
+        <dt class="text-gray-500 dark:text-gray-400">PDF path</dt><dd>{{ page.pdf_path|default:"—" }}</dd>
+        <dt class="text-gray-500 dark:text-gray-400">Page index (0-based)</dt><dd>{{ page.page_index }}</dd>
+        <dt class="text-gray-500 dark:text-gray-400">Book page</dt><dd>{{ page.book_page|default:"—" }}</dd>
+        <dt class="text-gray-500 dark:text-gray-400">Opinion starts/ends</dt><dd>{{ page.expected_opinion_starts }} / {{ page.expected_opinion_ends }}</dd>
+        <dt class="text-gray-500 dark:text-gray-400">Blank</dt><dd>{{ page.is_blank|yesno:"yes,no" }}</dd>
       </dl>
     </div>
   </div>

--- a/scanning/templates/scanning/pages_list.html
+++ b/scanning/templates/scanning/pages_list.html
@@ -4,9 +4,9 @@
 
 {% block content %}
 <div class="mb-4">
-  <a href="{% url 'scan_list' %}" class="text-sm text-gray-500 dark:text-gray-400 hover:text-primary-600">&laquo; Back to scans</a>
+  <a href="{% url 'scan_list' %}" class="text-sm text-gray-500 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-400">&laquo; Back to scans</a>
   <span class="text-gray-300 dark:text-gray-600 mx-1">·</span>
-  <a href="{% url 'scan_process' pk=scan.pk %}?step=3" class="text-sm text-gray-500 dark:text-gray-400 hover:text-primary-600">Process viewer</a>
+  <a href="{% url 'scan_process' pk=scan.pk %}?step=3" class="text-sm text-gray-500 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-400">Process viewer</a>
 </div>
 
 <h1 class="text-xl font-bold mb-1">{{ scan.reporter }} vol. {{ scan.volume }} · pages</h1>
@@ -57,15 +57,15 @@
       {% for p in pages %}
       <tr class="hover:bg-gray-50 dark:hover:bg-gray-800/50">
         <td class="px-3 py-2">
-          <a href="{% url 'page_detail' pk=p.pk %}" class="text-primary-600 hover:underline">{{ p.page_index|add:1 }}</a>
+          <a href="{% url 'page_detail' pk=p.pk %}" class="text-primary-600 dark:text-primary-400 hover:underline">{{ p.page_index|add:1 }}</a>
         </td>
-        <td class="px-3 py-2">{{ p.book_page|default:"—" }}{% if p.is_blank %} <span class="text-gray-400">(blank)</span>{% endif %}</td>
+        <td class="px-3 py-2">{{ p.book_page|default:"—" }}{% if p.is_blank %} <span class="text-gray-500 dark:text-gray-400">(blank)</span>{% endif %}</td>
         <td class="px-3 py-2">{{ p.get_status_display }}</td>
         <td class="px-3 py-2">{{ p.get_extracted_by_display|default:"—" }}</td>
         <td class="px-3 py-2">{% if p.needs_review %}<span class="text-amber-600 font-medium">review</span>{% else %}—{% endif %}</td>
         <td class="px-3 py-2">{% if p.xml_content %}✓{% else %}—{% endif %}</td>
-        <td class="px-3 py-2">{% if p.user_prompt_id %}<a href="{% url 'admin:ai_prompt_change' p.user_prompt_id %}" class="text-primary-600 hover:underline">#{{ p.user_prompt_id }}</a>{% else %}—{% endif %}</td>
-        <td class="px-3 py-2 text-gray-500">{{ p.expected_opinion_starts }} / {{ p.expected_opinion_ends }}</td>
+        <td class="px-3 py-2">{% if p.user_prompt_id %}<a href="{% url 'admin:ai_prompt_change' p.user_prompt_id %}" class="text-primary-600 dark:text-primary-400 hover:underline">#{{ p.user_prompt_id }}</a>{% else %}—{% endif %}</td>
+        <td class="px-3 py-2 text-gray-500 dark:text-gray-400">{{ p.expected_opinion_starts }} / {{ p.expected_opinion_ends }}</td>
         <td class="px-3 py-2 text-right">
           {% if p.pdf_path %}
             <a href="{% url 'serve_page_pdf' pk=p.pk %}" target="_blank" rel="noopener" class="btn-outline text-xs px-2 py-1">PDF</a>
@@ -78,7 +78,7 @@
 </div>
 {% else %}
 <div class="card text-center text-gray-500 dark:text-gray-400">
-  No pages yet. Run <a href="{% url 'scan_process' pk=scan.pk %}?step=3" class="text-primary-600 hover:underline">Generate Files</a> to populate them.
+  No pages yet. Run <a href="{% url 'scan_process' pk=scan.pk %}?step=3" class="text-primary-600 dark:text-primary-400 hover:underline">Generate Files</a> to populate them.
 </div>
 {% endif %}
 {% endblock %}

--- a/scanning/templates/scanning/queue_detail.html
+++ b/scanning/templates/scanning/queue_detail.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <div class="mb-4">
-  <a href="{% url 'queue' %}" class="text-sm text-gray-500 dark:text-gray-400 hover:text-primary-600">&laquo; Back to Queue</a>
+  <a href="{% url 'queue' %}" class="text-sm text-gray-500 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-400">&laquo; Back to Queue</a>
 </div>
 
 <!-- Header -->

--- a/scanning/templates/scanning/scan_process.html
+++ b/scanning/templates/scanning/scan_process.html
@@ -81,7 +81,7 @@
       <h2 class="text-sm font-bold mb-2 pt-3">Issues (<span id="issues-count">{{ issues|length }}</span>)</h2>
       {% for issue in issues %}
       <div class="issue-card rounded border px-2 py-1.5 mb-1 cursor-pointer text-xs
-           {% if issue.severity == 'error' %}border-red-300 bg-red-50 dark:border-red-700 dark:bg-red-900/20{% elif issue.severity == 'warning' %}border-yellow-300 bg-yellow-50 dark:border-yellow-700 dark:bg-yellow-900/20{% else %}border-blue-300 bg-blue-50 dark:border-blue-700 dark:bg-blue-900/20{% endif %}"
+           {% if issue.severity == 'error' %}border-red-300 bg-red-50 hover:bg-red-100 dark:border-red-700 dark:bg-red-900/20 dark:hover:bg-red-900/40{% elif issue.severity == 'warning' %}border-yellow-300 bg-yellow-50 hover:bg-yellow-100 dark:border-yellow-700 dark:bg-yellow-900/20 dark:hover:bg-yellow-900/40{% else %}border-blue-300 bg-blue-50 hover:bg-blue-100 dark:border-blue-700 dark:bg-blue-900/20 dark:hover:bg-blue-900/40{% endif %}"
            data-message="{{ issue.message }}"
            data-check="{{ issue.check_name }}"
            {% if issue.check_name == 'duplicate_page' and issue.page_number %}data-page="{{ issue.page_number }}" onclick="if(window.showDuplicates) showDuplicates(this.dataset.page); else goToPage(this)"
@@ -89,7 +89,7 @@
            {% elif issue.page_number %}data-page="{{ issue.page_number }}" onclick="goToPage(this)"{% endif %}>
         <div class="flex items-center gap-1.5">
           <span class="font-bold uppercase text-[10px]">{{ issue.get_severity_display }}</span>
-          {% if issue.page_number %}<span class="text-gray-500">Page {{ issue.page_number }}</span>{% endif %}
+          {% if issue.page_number %}<span class="text-gray-500 dark:text-gray-400">Page {{ issue.page_number }}</span>{% endif %}
         </div>
         <p class="mt-0.5 text-gray-700 dark:text-gray-300">{{ issue.message }}</p>
         <div class="flex gap-1 mt-1">
@@ -137,7 +137,7 @@
            {% else %}bg-green-50 dark:bg-green-900/20{% endif %}"
            data-pdf-index="{{ r.pdf_page|add:'-1' }}" onclick="goToPage(this)">
         <span>
-          <span class="font-medium text-gray-500">{{ r.pdf_page }}</span>
+          <span class="font-medium text-gray-500 dark:text-gray-400">{{ r.pdf_page }}</span>
           {% if r.detected %}
           <span class="{% if r.seq_issue == 'backward' %}text-red-700 dark:text-red-300{% elif r.is_duplicate %}text-orange-700 dark:text-orange-300{% elif r.seq_issue == 'gap' %}text-yellow-700 dark:text-yellow-300{% else %}text-green-700 dark:text-green-300{% endif %} font-semibold ml-1">#{{ r.detected }}</span>
           {% else %}
@@ -160,7 +160,7 @@
       </div>
       <h2 class="text-sm font-bold mb-2">Generated ({{ opinion_scans|length }})</h2>
       {% for s in opinion_scans %}
-      <div class="rounded border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/20 px-2 py-1.5 mb-1 cursor-pointer text-xs issue-card"
+      <div class="rounded border border-blue-200 dark:border-blue-800 bg-blue-50 hover:bg-blue-100 dark:bg-blue-900/20 dark:hover:bg-blue-900/40 px-2 py-1.5 mb-1 cursor-pointer text-xs issue-card"
            data-redacted="{{ s.redacted_filename }}"
            data-unredacted="{{ s.unredacted_filename }}"
            data-opinion-pk="{{ s.pk }}"
@@ -243,7 +243,7 @@
       {% if op.uncovered_headnote_pages %}
       <div class="ml-4 mb-1 flex flex-wrap gap-0.5">
         {% for pg in op.uncovered_headnote_pages %}
-        <span class="text-[10px]" style="border: 1px solid; padding: 3px; background-color: yellow"
+        <span class="text-[10px] px-1 py-0.5 rounded border border-yellow-500 bg-yellow-300 text-yellow-950 cursor-pointer hover:bg-yellow-400"
               data-pdf-index="{{ pg.idx }}" onclick="event.stopPropagation(); goToPage(this)"
               title="Uncovered headnote on page {{ pg.num }}">Page {{ pg.num }}</span>
         {% endfor %}
@@ -274,9 +274,9 @@
            data-ocr-by-page='{{ ocr_by_page_json }}'
            {% if step == 3 %}data-opinion-edit="true"{% endif %}>
         {% if step == 3 %}
-        <div class="flex items-center justify-center h-full text-gray-400 text-sm">Select an opinion from the sidebar to view it.</div>
+        <div class="flex items-center justify-center h-full text-gray-300 text-sm">Select an opinion from the sidebar to view it.</div>
         {% else %}
-        <div class="flex items-center justify-center h-full text-gray-400 text-sm">Loading PDF...</div>
+        <div class="flex items-center justify-center h-full text-gray-300 text-sm">Loading PDF...</div>
         {% endif %}
       </div>
     </main>


### PR DESCRIPTION
Several elements on the process page were unreadable when the OS is in dark mode. The `Issues (N)` and `Pages (N)` sidebar headings disappeared into the sidebar, and inside an issue card the severity line and the Dismiss button looked fine while the message paragraph was invisible.

Closes #140.

## Root cause

`scanning/static/scanning/checker.css` is a pre-Tailwind stylesheet loaded only by `scan_process.html`, and `{% block head %}` puts it after the Tailwind bundle. Its selectors are bare elements or single classes, so they tie with Tailwind utilities on specificity and win on source order. Two rules did the damage:

- `body { background: #f5f5f5; color: #333 }` beat Tailwind's `dark:text-gray-100`, so every element without an explicit color class inherited dark grey. The sidebar `h2`s carry no color class, which put them at 1.4:1 against the `gray-900` sidebar. Note that the custom palette maps `gray-900` to `#101828`, which is why it reads as navy.
- `.issue-card { background: #fafafa }` beat the template's `dark:bg-blue-900/20`, so cards stayed near white while the message paragraph rendered in `dark:text-gray-300`, also 1.4:1. This is also why the severity label and Dismiss button looked correct: they resolved to `#333` and `bg-green-600 text-white` respectively. The same rule was quietly defeating `bg-red-50` / `bg-yellow-50` / `bg-blue-50` in light mode too, so severity tinting on issue cards starts working now.

After the fix: heading 16.1:1, issue message 11.0:1, severity label 14.8:1, page label 6.3:1.

## Changes

`checker.css` stops imposing a light theme:

- Dropped `background` and `color` from `body`. The Tailwind base layer already sets both per scheme, and the headings simply inherit correctly once this is out of the way.
- Dropped `.issue-card`'s `background`, `border-left`, `:hover` and its four never-applied severity variants. The scheme-aware Tailwind classes on the element now own its color. Kept the padding and margin, which currently override `px-2 py-1.5 mb-1`, so removing them would shift spacing.
- Pinned explicit text colors on `.page-container` and `.dupe-modal`, the surfaces that are white in both schemes and were relying on the inherited `#333`.
- Deleted the `.opinion-card.selected, .issue-card.selected` rule. It is unreachable: `.selected` only ever lands on `.opinion-nav` and `.opinion-card`, no `.opinion-card` element is ever created, and step 3 marks the active card with `style.outline` instead.

Templates and viewer JS:

- Replaced the uncovered-headnote chip's inline `background-color: yellow` with `bg-yellow-300 text-yellow-950`. It depended on the inherited `#333` and would otherwise have gone light on yellow.
- Added the `hover:` and `dark:hover:` pairs that replace the deleted `.issue-card:hover`, on both the step 1 and step 3 cards. The `dark:hover:` half is required, not decorative: `.hover\:bg-red-100:hover` is 0-2-0 and would beat `.dark\:bg-red-900\/20` at 0-1-0, flashing light red on hover in dark mode.
- Paired the remaining unpaired grey and primary text across `scan_process.html`, `page_detail.html`, `pages_list.html`, `queue_detail.html`, `opinion_detail.html` and `viewer_progress.js`. Two of these were failing in light mode rather than dark, and the `text-primary-600` links were at 2.1:1 in dark mode because the base layer's `dark:text-primary-400` sits on the bare `a` selector and loses to the element's own class regardless of order. Seven `hover:text-primary-600` links had no dark pairing, so hovering made them harder to read than not hovering.

## Tailwind content glob

Second commit, separable. `tailwind.config.js` listed `../static-global/js/**/*.js`, a directory that does not exist, and the five viewer JS files that build markup at runtime live in `scanning/static/scanning/` and were never scanned. Any Tailwind class used only in those files silently failed to compile.

Measured rather than assumed: built the bundle with and without the added glob and diffed the generated selectors. 10 new, 0 lost. One is `border-orange-400`, the real fix. The other nine (`contents`, `filter`, `grow`, `outline`, `resize`, `transform`, `visible`, `ease-in-out`, `!container`) are false positives where the extractor picks up ordinary JS words that happen to be utility names; no element carries any of them as a class, so they are inert, about 1.5KB. The real rebuild matched that prediction exactly at 396 selectors.

**One visible change to expect:** the DUP divider in the processing sidebar (`viewer_progress.js:58`) currently renders in `currentColor` because `border-orange-400` was missing. It will now be orange, matching its own label and the GAP and ORDER dividers that already worked.

## Testing

335 tests pass, though this is CSS and templates so that only confirms nothing else moved.

Worth a look in both schemes, since the visual check is the real one here. Load `/scans/<pk>/process/` at `?step=1`, `?step=2` and `?step=3`:

- Sidebar headings, issue cards and their hover, page rows, opinion rows, unmatched caption and key icon rows, generated file list.
- PDF viewer chrome unchanged: white page containers with dark labels on the dark backdrop, zoom toolbar, page label buttons still wrapping at narrow widths.
- The duplicate comparison modal, reachable from a `duplicate_page` issue.
- The processing sidebar, which is regenerated by `viewer_progress.js` rather than rendered from the template.

## Known side effect

Deferring `body` to the base layer changes the light mode page background from `#f5f5f5` to `gray-25` `#FCFCFD`, and in dark mode the sidebar's `dark:bg-gray-900` is now the same value as the page background. Only the border separates them, in both schemes. Happy to add a surface tint if that reads badly.

## Left alone deliberately

- The dead rules in `checker.css` (navbar, doc cards, report layout, issues panel, OCR summary, stepper). Several class names there are assembled in JS strings, so deadness needs per-rule checking rather than a grep. Tracked in #141.
- `.viewer-panel` forces `#525659` in both schemes, so its placeholder text was 2.9:1. Bumped the two placeholders to `text-gray-300`, but the panel itself is viewer chrome and belongs with #141.
- `queue.html` and `opinion_detail.html` pair `text-gray-400` with `dark:text-gray-500`, which is weak in both schemes (2.6:1 and 3.5:1). That is a deliberate looking choice about how muted secondary text should be, so it wants one decision applied consistently rather than a drive-by here.
