### PR TITLE
Stop embedding a Tesseract text layer in the processing pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ uv sync --all-extras
 ## Testing
 
 - Use `django.test.TestCase`, NOT pytest style classes
-- All tests live in `scanning/tests.py`
+- Tests live in the `scanning/tests/` package, one module per area (`test_services.py`, `test_views.py`, ...). Shared synthetic-PDF builders are in `scanning/tests/pdf_fixtures.py`
 - Test classes inherit from `ScanningTestCase` which provides `make_user()`, `make_staff_user()`, `make_pdf()`, `make_image()` helpers
 - Use `ScanFactory` and `UserFactory` from `scanning/factories.py` for test data
 - Factory docstrings describe default declarations as a prose list, not `:param:` entries (they are class attributes, not `__init__` parameters)

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -146,7 +146,9 @@ FROM python:3.12-slim AS prod-web
 
 # Runtime-only apt libs for the lean tier:
 #   libpq5              - PostgreSQL client library
-#   tesseract-ocr*      - OCR engine + English data (pytesseract / ocrmypdf)
+#   tesseract-ocr*      - OCR engine + English data. blackletter.analyze
+#                         reads page-number crops with it; ocrmypdf only
+#                         runs when LLM_PAGE_TEXT_LAYER is on.
 #   libgl1, libglib2.0-0 - required by opencv-python (cv2) in base blackletter
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
@@ -206,7 +208,9 @@ FROM python:3.12-slim AS prod-ml
 
 # Runtime-only apt libs for the heavy tier:
 #   libpq5           - PostgreSQL client library
-#   tesseract-ocr*   - OCR engine + English data (pytesseract / ocrmypdf)
+#   tesseract-ocr*   - OCR engine + English data. blackletter.analyze reads
+#                      page-number crops with it; ocrmypdf only runs when
+#                      LLM_PAGE_TEXT_LAYER is on.
 #   libgl1, libglib2 - OpenCV (full) / PaddleOCR shared libs
 #   libgomp1         - OpenMP runtime for torch / paddle CPU kernels
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,9 @@ dependencies = [
   # validation and the ink geometry — no torch/paddle. The heavy in-process
   # inference stack lives in the `local-ml` extra so the web/daemon images stay
   # lean whenever detection is offloaded to RunPod (RUNPOD_ENABLED=True).
-  # This app needs the ink geometry (blackletter #68), which is unreleased: the
-  # version floor stays at the last release and [tool.uv.sources] pins the
-  # branch. Both are corrected together when 0.2.0 ships.
-  "blackletter>=0.1.1",
+  # 0.2.0 is the floor: it is the release that carries the ink geometry
+  # (blackletter #68/#69) this app reads instead of measuring it here.
+  "blackletter>=0.2.0",
   # No longer called directly: the pipeline embeds no text layer. Declared
   # so LLM_PAGE_TEXT_LAYER (blackletter's add_text_layer) has an engine, and
   # because base blackletter requires it anyway.
@@ -70,7 +69,7 @@ dev = [
 # wherever detection runs locally instead of on RunPod: local dev, CI, the
 # offline daemon, and the RunPod worker image. Excluded from the lean web image.
 local-ml = [
-  "blackletter[detect,analyze]>=0.1.1",
+  "blackletter[detect,analyze]>=0.2.0",
   "torch",
   "torchvision",
   "ultralytics>=8.3",
@@ -131,10 +130,6 @@ override-dependencies = [
 ]
 
 [tool.uv.sources]
-# TEMPORARY: the ink geometry this app depends on is unreleased. Drop this entry
-# and raise the version floor to 0.2.0 once blackletter has been tagged.
-# See https://github.com/freelawproject/blackletter/pull/69.
-blackletter = { git = "https://github.com/freelawproject/blackletter", branch = "68-make-the-tesseract-text-layer-pass-optional-and-usable-after-redaction" }
 torch = { index = "pytorch-cpu" }
 torchvision = { index = "pytorch-cpu" }
 paddlepaddle = { index = "paddle-cpu" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,16 +30,28 @@ dependencies = [
   "pillow",
   "psycopg[binary,pool]",
   # Base blackletter only: pairing, redaction (skip_doctr=True), margins,
-  # validation and OCR — no torch/paddle. The heavy in-process inference stack
-  # lives in the `local-ml` extra so the web/daemon images stay lean whenever
-  # detection is offloaded to RunPod (RUNPOD_ENABLED=True).
+  # validation and the ink geometry — no torch/paddle. The heavy in-process
+  # inference stack lives in the `local-ml` extra so the web/daemon images stay
+  # lean whenever detection is offloaded to RunPod (RUNPOD_ENABLED=True).
+  # This app needs the ink geometry (blackletter #68), which is unreleased: the
+  # version floor stays at the last release and [tool.uv.sources] pins the
+  # branch. Both are corrected together when 0.2.0 ships.
   "blackletter>=0.1.1",
+  # No longer called directly: the pipeline embeds no text layer. Declared
+  # so LLM_PAGE_TEXT_LAYER (blackletter's add_text_layer) has an engine, and
+  # because base blackletter requires it anyway.
   "ocrmypdf>=17",
+  # Used by ai.user_prompt to crop text off the generated LLM pages. Those
+  # crops only return anything when LLM_PAGE_TEXT_LAYER is on; the pipeline
+  # itself measures geometry from the page ink and needs no text.
   "pdfplumber>=0.11",
   "pymupdf>=1.25",
   "sentry-sdk[django]",
   "time-machine",
   "uvicorn[standard]",
+  # Load-bearing despite nothing here importing it: blackletter.analyze uses
+  # it as a per-crop digit fallback when PaddleOCR cannot read a page number,
+  # and blackletter does not declare it itself.
   "pytesseract>=0.3.13",
 ]
 
@@ -119,6 +131,10 @@ override-dependencies = [
 ]
 
 [tool.uv.sources]
+# TEMPORARY: the ink geometry this app depends on is unreleased. Drop this entry
+# and raise the version floor to 0.2.0 once blackletter has been tagged.
+# See https://github.com/freelawproject/blackletter/pull/69.
+blackletter = { git = "https://github.com/freelawproject/blackletter", branch = "68-make-the-tesseract-text-layer-pass-optional-and-usable-after-redaction" }
 torch = { index = "pytorch-cpu" }
 torchvision = { index = "pytorch-cpu" }
 paddlepaddle = { index = "paddle-cpu" }

--- a/scanning/s3_sync.py
+++ b/scanning/s3_sync.py
@@ -1,7 +1,7 @@
 """Sync intermediate processing files between MEDIA_ROOT, S3, and /tmp/.
 
-Files produced by the scanning pipeline (bitonal PDF, OCR PDF,
-detections.json, stamped PDF, page images, original PDF) are small
+Files produced by the scanning pipeline (bitonal PDF, detections.json,
+stamped PDF, page images, original PDF) are small
 enough that re-running the pipeline to regenerate them is expensive.
 Pushing them to S3 lets us recover after pod redeploys without a full
 re-run. Pulling them to /tmp/ when the viewer opens gives editing
@@ -272,13 +272,13 @@ def _is_preview_pdf(rel: str) -> bool:
     """Return True if a processing-prefix relative key is a preview PDF.
 
     A "preview" is the small, browser-viewable PDF the process viewer
-    shows: the OCR PDF if present, else ``bitonal.pdf``. This mirrors the
+    shows: ``bitonal.pdf``, or a legacy OCR PDF beside it. This mirrors the
     exclusion rules in ``utils.find_ocr_pdf`` and adds ``bitonal.pdf``.
     Deliberately excludes the multi-GB ``*.original.pdf`` and anything
     under a subdirectory (``images/``, ``redacted/``, etc.).
 
     :param rel: Object key relative to the scan's processing prefix.
-    :returns: Whether the key is the bitonal or OCR preview PDF.
+    :returns: Whether the key is a preview PDF.
     :rtype: bool
     """
     if "/" in rel or not rel.endswith(".pdf"):
@@ -341,6 +341,11 @@ def _download_matching(scan: Scan, predicate, kind: str) -> Path | None:
                 "Size", -1
             ):
                 continue
+            # Keys can be nested (``redacted/<opinion>.pdf``), and
+            # ``download_file`` writes through a temp file in the target's
+            # own directory, so a missing parent fails as a
+            # FileNotFoundError on that temp name rather than on the key.
+            local_path.parent.mkdir(parents=True, exist_ok=True)
             s3.download_file(bucket, key, str(local_path))
             downloaded += 1
 
@@ -360,8 +365,8 @@ def _download_matching(scan: Scan, predicate, kind: str) -> Path | None:
 def download_preview_pdf(scan: Scan) -> Path | None:
     """Download only the small preview PDF(s) from S3 to /tmp/.
 
-    Pulls the bitonal and/or OCR PDF -- the reviewable previews -- and
-    skips the multi-GB original and the ``images/`` tree. Used by the PDF
+    Pulls ``bitonal.pdf`` -- the reviewable preview, plus a legacy OCR PDF
+    on scans processed before scanning #145 -- and skips the multi-GB original and the ``images/`` tree. Used by the PDF
     viewer endpoint so opening a scan never drags the whole processing
     prefix (or the original) across the network, which blew past the
     gunicorn worker timeout for large scans.
@@ -371,6 +376,29 @@ def download_preview_pdf(scan: Scan) -> Path | None:
     :rtype: Path | None
     """
     return _download_matching(scan, _is_preview_pdf, "preview PDF")
+
+
+def download_processing_file(scan: Scan, rel_key: str) -> Path | None:
+    """Download one named object from a scan's processing prefix.
+
+    For serving a single generated file (an opinion PDF, an LLM page) when
+    it is not on this machine. ``download_processing_files`` would fetch
+    the whole prefix instead: for a 1292-page volume that is the multi-GB
+    original plus every opinion, LLM page and crop, gigabytes to serve one
+    file. Worse, under ASGI all sync views share one thread-sensitive
+    executor, so a pull that long stalls every other request in the
+    process, which looks like the whole portal hanging.
+
+    :param scan: Scan whose processing prefix to pull from.
+    :param rel_key: Object key relative to that prefix, which is also the
+        path relative to the scan's output dir (e.g.
+        ``"redacted/a3d.222.0001-0027.pdf"``).
+    :returns: The local tmp path, or None if sync is disabled.
+    :rtype: Path | None
+    """
+    return _download_matching(
+        scan, lambda rel: rel == rel_key, f"file {rel_key}"
+    )
 
 
 def download_original_pdf(scan: Scan) -> Path | None:

--- a/scanning/services.py
+++ b/scanning/services.py
@@ -18,9 +18,11 @@ from pathlib import Path
 
 import django
 import fitz
-import pdfplumber
 from blackletter.api import (
     bitonal as bl_bitonal,
+)
+from blackletter.api import (
+    build_redactions as bl_build_redactions,
 )
 from blackletter.api import (
     pair as bl_pair,
@@ -37,13 +39,18 @@ from blackletter.models import (
 from blackletter.models import (
     Document as BLDoc,
 )
-from blackletter.process import compute_redaction_rects
-from blackletter.scanner import _pair_opinions
+from blackletter.process import compute_redaction_rects, page_body_covered
+from blackletter.scanner import (
+    _pair_opinions,
+    snap_document_columns,
+    snap_text_columns_to_ink,
+)
 from blackletter.validate import (
     _auto_correct,
-    _build_issues,
-    _parse_expected_range,
     _split_in_out_of_range,
+    build_analysis,
+    build_issues,
+    parse_expected_range,
 )
 from django.conf import settings
 from django.db.models import Case, F, Value, When
@@ -60,7 +67,13 @@ from scanning.models import (
     Status,
     Volume,
 )
-from scanning.utils import ensure_output_dir, find_ocr_pdf, has_s3_credentials
+from scanning.utils import (
+    ensure_output_dir,
+    find_ocr_pdf,
+    find_processing_pdf,
+    has_s3_credentials,
+    processing_pdf_path,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -406,160 +419,6 @@ def _ensure_bitonal(scan: "Scan", output_dir: Path) -> Path:
     return bitonal_path
 
 
-def _run_ocr(
-    scan_pk: int,
-    bitonal_path: str,
-    output_dir: str,
-    reporter: str,
-    volume: str,
-    first_page: int,
-) -> str:
-    """Run Tesseract OCR via blackletter.
-
-    :param scan_pk: Primary key of the scan (for progress updates).
-    :param bitonal_path: Path to the bitonal PDF.
-    :param output_dir: Directory to write the OCR'd PDF into.
-    :param reporter: Reporter short name (e.g. "f3d").
-    :param volume: Volume number as a string.
-    :param first_page: First logical page number in the PDF.
-    :return: Path to the OCR'd PDF.
-    """
-    with fitz.open(bitonal_path) as pdf:
-        total_pages = pdf.page_count
-    _update_progress(
-        scan_pk,
-        f"Running Tesseract OCR (0/{total_pages} pages)...",
-        current=0,
-        total=total_pages,
-    )
-    ocr_path = _ocr(
-        scan_pk,
-        bitonal_path,
-        output_dir,
-        reporter=reporter,
-        volume=volume,
-        first_page=first_page,
-        total_pages=total_pages,
-    )
-    # Persist the OCR PDF as soon as it exists (see _ensure_bitonal).
-    _push_generated_file_to_s3(scan_pk, Path(ocr_path).name)
-    return ocr_path
-
-
-def _ocr(
-    scan_pk: int,
-    pdf_path: str | Path,
-    output_dir: str | Path,
-    reporter: str = "",
-    volume: str = "",
-    first_page: int = 1,
-    total_pages: int = 0,
-    language: str = "eng",
-) -> Path:
-    """OCR a PDF (add text layer via ocrmypdf/Tesseract).
-
-    Temporary local copy of blackletter's ``ocr`` function with
-    progress callback support. Will be moved to blackletter once
-    validated.
-
-    :param scan_pk: Primary key of the scan (for progress updates).
-    :param pdf_path: Path to the input PDF.
-    :param output_dir: Directory to write the OCR'd PDF into.
-    :param reporter: Reporter short name (e.g. "f3d").
-    :param volume: Volume number as a string.
-    :param first_page: First logical page number in the PDF.
-    :param total_pages: Total page count (for progress messages).
-    :param language: Tesseract language code.
-    :return: Path to the OCR'd PDF.
-    """
-    import logging
-
-    import ocrmypdf
-    from ocrmypdf import hookimpl
-    from ocrmypdf._plugin_manager import get_plugin_manager
-
-    pdf_path = Path(pdf_path)
-    output_dir = Path(output_dir)
-
-    # Build output filename
-    last_page = first_page + total_pages - 1
-    parts = [
-        p
-        for p in [reporter, str(volume), str(first_page), str(last_page)]
-        if p
-    ]
-    scan_name = ".".join(parts) if parts else pdf_path.stem
-    output_path = output_dir / f"{scan_name}.pdf"
-
-    # Suppress noisy loggers
-    for name in (
-        "pikepdf",
-        "fontTools",
-        "fontTools.subset",
-        "fontTools.ttLib",
-        "ocrmypdf",
-    ):
-        logging.getLogger(name).setLevel(logging.ERROR)
-    for _n in list(logging.root.manager.loggerDict):
-        if _n.startswith("ocrmypdf"):
-            logging.getLogger(_n).setLevel(logging.ERROR)
-
-    # Progress bar class that updates the scan record per page
-    class _ScanProgressBar:
-        def __init__(
-            self, *, total=None, desc=None, unit=None, disable=False, **kw
-        ):
-            self._total = total or total_pages
-            self._unit = unit
-            self._desc = desc
-            self._current = 0
-            logger.info(
-                "[progress] unit=%r desc=%r total=%s", unit, desc, total
-            )
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *a):
-            return False
-
-        def update(self, n=1, *, completed=None):
-            self._current += n
-            if self._unit == "page" and (
-                self._current % 10 == 0 or self._current == self._total
-            ):
-                _update_progress(
-                    scan_pk,
-                    f"Tesseract OCR: {self._current}/{self._total} pages...",
-                    current=self._current,
-                    total=self._total,
-                )
-
-    class _ScanProgressPlugin:
-        @hookimpl
-        def get_progressbar_class(self):
-            return _ScanProgressBar
-
-    pm = get_plugin_manager()
-    pm._pm.register(_ScanProgressPlugin())
-
-    with _log_stage(
-        "OCR", f"{total_pages} pages ({os.cpu_count() or 1} CPUs)"
-    ):
-        ocrmypdf.ocr(
-            str(pdf_path),
-            str(output_path),
-            pdf_renderer="auto",
-            optimize=1,
-            output_type="pdf",
-            language=[language],
-            tesseract_timeout=120,
-            progress_bar=True,
-            plugin_manager=pm,
-        )
-    return output_path
-
-
 def _run_yolo(scan_pk: int, pdf_path: str, output_dir: str) -> None:
     """Run YOLO detection via runpod_client (local or remote).
 
@@ -641,6 +500,67 @@ def _run_yolo(scan_pk: int, pdf_path: str, output_dir: str) -> None:
     _update_progress(scan_pk, f"YOLO: {len(detections)} detections")
 
 
+def _snap_text_columns_to_ink(scan_pk: int, pdf_path: str) -> int:
+    """Widen this scan's ``TEXT_COLUMN`` detections onto the text they clip.
+
+    Thin wrapper over :func:`blackletter.scanner.snap_text_columns_to_ink`,
+    which does the measuring. What is app-specific is the persistence: the
+    corrected boxes are written back to the ``Detection`` rows, so the
+    viewer overlay and ``detections.json`` show what the geometry actually
+    used, and no later step has to re-measure the ink to agree with it.
+
+    Only the x-bounds move, so header and footer geometry is untouched.
+
+    :param scan_pk: Primary key of the scan.
+    :param pdf_path: The PDF the detections were measured against.
+    :return: Number of detections widened.
+    """
+    by_page: dict[int, list] = {}
+    for det in Detection.objects.filter(
+        scan_id=scan_pk, active=True, label="TEXT_COLUMN"
+    ).order_by("page_index", "x0"):
+        by_page.setdefault(det.page_index, []).append(det)
+    if not by_page:
+        return 0
+
+    changed = []
+    with fitz.open(str(pdf_path)) as doc:
+        for page_index, columns in sorted(by_page.items()):
+            if page_index >= doc.page_count:
+                continue
+            fitz_page = doc[page_index]
+            page = Page(
+                index=page_index,
+                pdf_width=fitz_page.rect.width,
+                pdf_height=fitz_page.rect.height,
+                img_width=columns[0].img_width or 1,
+                img_height=columns[0].img_height or 1,
+            )
+            page.detections = [
+                BLDetection(
+                    bbox=BBox(x1=d.x0, y1=d.y0, x2=d.x1, y2=d.y1),
+                    label=Label.TEXT_COLUMN,
+                    confidence=d.confidence,
+                    page_index=page_index,
+                )
+                for d in columns
+            ]
+            if not snap_text_columns_to_ink(fitz_page, page):
+                continue
+            for det, snapped in zip(columns, page.detections):
+                new_x0 = round(snapped.bbox.x1, 1)
+                new_x1 = round(snapped.bbox.x2, 1)
+                if abs(new_x0 - det.x0) < 1 and abs(new_x1 - det.x1) < 1:
+                    continue
+                det.x0 = new_x0
+                det.x1 = new_x1
+                changed.append(det)
+
+    if changed:
+        Detection.objects.bulk_update(changed, ["x0", "x1"])
+    return len(changed)
+
+
 def _import_detections_from_json(scan_pk: int, output_dir: str) -> list:
     """Load detections.json from disk into Detection model.
 
@@ -713,61 +633,6 @@ def _delete_page_and_detections(
     )
 
 
-def _detect_sequence_issues(
-    ocr_results: list, out_of_range_pages: set
-) -> list[tuple]:
-    """Classify duplicate / backward / gap page-number runs.
-
-    Walks ocr_results in order, tracks the previous detected page number,
-    and yields an issue tuple whenever the difference between consecutive
-    pages is 0 (duplicate), negative (backward), or > 2 (gap).
-
-    :param ocr_results: List of per-page OCR result dicts.
-    :param out_of_range_pages: PDF page numbers already flagged as
-        out-of-range; these are skipped so they don't anchor the
-        prev_num chain.
-    :returns: List of issue tuples. GAP tuples include a trailing list
-        of missing page numbers; others have 5 elements.
-    :rtype: list[tuple]
-    """
-    seq_issues: list[tuple] = []
-    prev_num = prev_pdf = None
-    for r in ocr_results:
-        if not r["detected"] or r.get("type") == "range":
-            prev_num = None
-            continue
-        try:
-            num = int(r["detected"])
-        except ValueError:
-            continue
-        if r["pdf_page"] in out_of_range_pages:
-            continue
-        if prev_num is not None:
-            diff = num - prev_num
-            if diff == 0:
-                seq_issues.append(
-                    ("DUPLICATE", r["pdf_page"], num, prev_pdf, prev_num)
-                )
-            elif diff < 0:
-                seq_issues.append(
-                    ("BACKWARD", r["pdf_page"], num, prev_pdf, prev_num)
-                )
-            elif diff > 2:
-                seq_issues.append(
-                    (
-                        "GAP",
-                        r["pdf_page"],
-                        num,
-                        prev_pdf,
-                        prev_num,
-                        list(range(prev_num + 1, num)),
-                    )
-                )
-        prev_num = num
-        prev_pdf = r["pdf_page"]
-    return seq_issues
-
-
 def _page_number_lookup(scan: "Scan") -> dict:
     """Build {page_index: (page_number, page_number_end)} from ocr_results.
 
@@ -834,7 +699,7 @@ def _push_processing_files_to_s3(scan_pk: int) -> None:
 def _push_generated_file_to_s3(scan_pk: int, relative_path: str) -> None:
     """Upload a single just-generated processing file to S3 immediately.
 
-    Persists derived artifacts (``bitonal.pdf``, the OCR PDF) the moment
+    Persists derived artifacts (``bitonal.pdf``) the moment
     they are produced rather than only at the end-of-pipeline push, so a
     later crash, or a ``reprocess`` run that never does the full push,
     still leaves them in S3. Mirrors the credential guard in
@@ -1020,94 +885,22 @@ def _compute_and_save_redaction_rects(scan_pk: int, pdf_path: str) -> list:
 
     with _log_stage("Redaction rects"):
         document = _build_document_from_detections(scan, det_data, pdf_path)
+        # Every blackletter entry point corrects the column boxes before
+        # reading them, and the margin strips of this same scan are computed
+        # from corrected ones. Skipping it here is how a hand-added
+        # TEXT_COLUMN (which reaches the DB exactly as the reviewer drew it)
+        # would give the headnote rects a different column to the margins on
+        # the same page.
+        snap_document_columns(document)
         opinions = _pair_opinions(document)
+        # ``ocr_applied`` is set on the Document, so blackletter measures
+        # this geometry from the page ink itself (see
+        # ``scanner._measure_from_ink``), and finishes each headnote rect
+        # against the page detections: snapped to its column box, cut at the
+        # headnote boundaries inside it, then grown onto adjoining ink. The
+        # app ran those three passes itself until blackletter #68 moved them
+        # where every consumer gets them.
         rects = compute_redaction_rects(document, opinions, skip_doctr=True)
-
-    # Snap headnote rect x-bounds to TEXT_COLUMN detections for consistency.
-    # Only snap to a TEXT_COLUMN on the same side of the page midpoint —
-    # otherwise a missing left TEXT_COLUMN causes the left rect to be
-    # snapped to the right column, destroying it.
-    tc_by_page = {}
-    for d in Detection.objects.filter(scan=scan, active=True, label_id=16):
-        tc_by_page.setdefault(d.page_index, []).append(d)
-    img_mid = document.pages[0].img_width / 2 if document.pages else 850
-    for page_entry in rects:
-        pi = page_entry["page_index"]
-        cols = tc_by_page.get(pi, [])
-        if not cols:
-            continue
-        for r in page_entry["rects"]:
-            if r.get("type") != "headnote":
-                continue
-            cx = (r["x0"] + r["x1"]) / 2
-            # Only consider TEXT_COLUMNs on the same side of the midpoint
-            same_side = (
-                [c for c in cols if (c.x0 + c.x1) / 2 < img_mid]
-                if cx < img_mid
-                else [c for c in cols if (c.x0 + c.x1) / 2 >= img_mid]
-            )
-            if not same_side:
-                continue
-            best = min(same_side, key=lambda c: abs((c.x0 + c.x1) / 2 - cx))
-            r["x0"] = round(best.x0, 1)
-            r["x1"] = round(best.x1, 1)
-
-    # Split headnote blocks at HEADNOTE detection boundaries
-    _GAP = 6
-    hn_dets_by_page = {}
-    for d in Detection.objects.filter(
-        scan=scan, active=True, label="HEADNOTE"
-    ):
-        hn_dets_by_page.setdefault(d.page_index, []).append(d)
-    for page_entry in rects:
-        pi = page_entry["page_index"]
-        if pi not in hn_dets_by_page:
-            continue
-        hn_dets = sorted(hn_dets_by_page[pi], key=lambda d: d.y0)
-        new_page_rects = []
-        for r in page_entry["rects"]:
-            if r.get("type") != "headnote":
-                new_page_rects.append(r)
-                continue
-            col_dets = sorted(
-                (
-                    d
-                    for d in hn_dets
-                    if r["y0"] + _GAP < d.y0 < r["y1"] - _GAP
-                    and d.x0 < r["x1"]
-                    and d.x1 > r["x0"]
-                ),
-                key=lambda d: d.y0,
-            )
-            merged = []
-            for d in col_dets:
-                if merged and d.y0 < merged[-1][1]:
-                    merged[-1] = (merged[-1][0], max(merged[-1][1], d.y1))
-                else:
-                    merged.append((d.y0, d.y1))
-            splits = [m[0] for m in merged]
-            if not splits:
-                new_page_rects.append(r)
-                continue
-            prev_y = r["y0"]
-            for sp in splits:
-                if sp - _GAP / 2 > prev_y:
-                    new_page_rects.append(
-                        {
-                            **r,
-                            "y0": round(prev_y, 1),
-                            "y1": round(sp - _GAP / 2, 1),
-                        }
-                    )
-                prev_y = sp + _GAP / 2
-            new_page_rects.append(
-                {
-                    **r,
-                    "y0": round(prev_y, 1),
-                    "y1": round(r["y1"], 1),
-                }
-            )
-        page_entry["rects"] = new_page_rects
 
     Scan.objects.filter(pk=scan_pk).update(
         redaction_rects=rects,
@@ -1115,14 +908,92 @@ def _compute_and_save_redaction_rects(scan_pk: int, pdf_path: str) -> list:
     return rects
 
 
+def _load_detections(output_dir: str | Path) -> list:
+    """Read ``detections.json`` from a scan's output dir.
+
+    :param output_dir: The scan's output directory.
+    :return: The detection list, or an empty list when absent/unreadable.
+    """
+    det_path = Path(output_dir) / "detections.json"
+    if not det_path.exists():
+        return []
+    try:
+        return json.loads(det_path.read_text())
+    except (OSError, ValueError):
+        logger.exception("Unreadable detections.json in %s", output_dir)
+        return []
+
+
+def _detections_for_geometry(scan_pk: int, output_dir: str | Path) -> list:
+    """Detection dicts for the geometry helpers, DB first.
+
+    ``detections.json`` is written by whichever process ran the pipeline, so
+    another one may not have it yet: ``/tmp`` is per-container in dev and
+    per-pod in production. Reading the DB avoids depending on that, and the
+    DB is the source of truth anyway once a reviewer starts editing
+    detections. The file is only a fallback, for a scan whose rows have not
+    been imported.
+
+    :param scan_pk: Primary key of the scan.
+    :param output_dir: The scan's output directory, for the fallback.
+    :return: Detection dicts shaped as ``detections.json`` stores them.
+    """
+    rows = Detection.objects.filter(scan_id=scan_pk, active=True).order_by(
+        "page_index", "y0"
+    )
+    dets = [
+        {
+            "page_index": d.page_index,
+            "label": d.label,
+            "label_id": d.label_id,
+            "confidence": d.confidence,
+            "bbox": [d.x0, d.y0, d.x1, d.y1],
+            "img_width": d.img_width,
+            "img_height": d.img_height,
+        }
+        for d in rows
+    ]
+    return dets or _load_detections(output_dir)
+
+
+def _pages_for_geometry(
+    scan: "Scan", pdf_path: str, output_dir: str | Path, snap: bool = True
+) -> list:
+    """The detected pages blackletter's geometry should be measured against.
+
+    Wraps the detection lookup and the column correction that every
+    geometry consumer needs, so the rects and the margin strips of one scan
+    cannot be computed from differently-corrected boxes.
+
+    :param scan: The scan being processed.
+    :param pdf_path: The PDF the detections were measured against.
+    :param output_dir: The scan's output directory, for the JSON fallback.
+    :param snap: Correct the ``TEXT_COLUMN`` boxes against the page ink.
+        The pipeline already persisted corrected boxes, and the correction
+        converges, so this changes nothing unless a box reached the DB
+        uncorrected, which a hand-added column detection does. It is not
+        free: it renders every page at 100 dpi, so pass ``False`` where the
+        column boxes are not read (see :func:`_build_combined_redactions`).
+    :return: ``Page`` objects, empty when the scan has no detections yet.
+    """
+    det_data = _detections_for_geometry(scan.pk, output_dir)
+    if not det_data:
+        return []
+    document = _build_document_from_detections(scan, det_data, pdf_path)
+    if snap:
+        snap_document_columns(document)
+    return document.pages
+
+
 def _compute_and_save_margin_rects(
     scan_pk: int, pdf_path: str, output_dir: str
 ) -> list:
-    """Compute margin rects, adjust for detections, and save to the Scan model.
+    """Compute margin rects and save them to the Scan model.
 
-    After computing raw margins from the PDF, shrink any margin rect
-    that overlaps with an active detection so that key icons, captions,
-    and other content near page edges are not masked.
+    The strips are pulled back off any real detection they would cover, so
+    key icons, captions and other content near a page edge survive. That
+    happens inside :func:`blackletter.margins.compute_margin_rects`, which
+    also uses the detections to tighten the content box.
 
     :param scan_pk: Primary key of the scan.
     :param pdf_path: Path to the PDF to compute margins for.
@@ -1132,13 +1003,53 @@ def _compute_and_save_margin_rects(
     scan = Scan.objects.get(pk=scan_pk)
     if scan.margin_rects:
         return scan.margin_rects
-    output_dir = Path(output_dir)
-    margin_rects = compute_margin_rects(str(pdf_path))
-    margin_rects = _adjust_margins_for_detections(margin_rects, output_dir)
+    pages = _pages_for_geometry(scan, pdf_path, Path(output_dir))
+    if not pages:
+        # Without detections the bounds would come from the page's marks
+        # alone, so bleed-through at a page edge suppresses that page's top
+        # strip: a worse answer than none, and one that must not be cached or
+        # it never gets recomputed once the detections land. Refuse before
+        # measuring rather than after. The viewer asks for these on a sync
+        # request and does not cache the reply, so computing them here would
+        # render the whole volume at 100 dpi on every poll.
+        logger.warning(
+            "No margin rects for scan %s: no detections yet", scan_pk
+        )
+        return []
+    margin_rects = compute_margin_rects(str(pdf_path), pages=pages)
     Scan.objects.filter(pk=scan_pk).update(
         margin_rects=margin_rects,
     )
     return margin_rects
+
+
+def _add_llm_page_text_layer(scan_pk: int, llm_dir: Path) -> int:
+    """Optionally make the per-page LLM PDFs searchable.
+
+    ``ai.user_prompt`` crops three text snippets off each page (the caption's
+    first line, a column-top continuation, the footnote band) and layers them
+    on top of the structural roadmap it builds from the detections. Those
+    crops need a text layer, and since scanning #145 nothing in the pipeline
+    produces one, so they come back empty and the roadmap ships without them.
+
+    Rather than reinstate the pass for the whole pipeline, this adds it here
+    only, over pages that have already been redacted and masked, and only
+    when ``LLM_PAGE_TEXT_LAYER`` is set. It is off by default because the
+    model reads the page image anyway and the pass costs an OCR run over
+    every page of the volume.
+
+    :param scan_pk: Primary key of the scan, for progress reporting.
+    :param llm_dir: The ``llm/`` directory of per-page PDFs.
+    :return: Number of files given a text layer.
+    """
+    if not settings.LLM_PAGE_TEXT_LAYER or not llm_dir.is_dir():
+        return 0
+    from blackletter.api import add_text_layer
+
+    _update_progress(scan_pk, "Adding a text layer to the LLM pages...")
+    added = add_text_layer(llm_dir)
+    print(f"  Text layer added to {len(added)} LLM pages", flush=True)
+    return len(added)
 
 
 def _build_combined_redactions(scan_pk: int) -> Path:
@@ -1147,197 +1058,54 @@ def _build_combined_redactions(scan_pk: int) -> Path:
     All coordinates in the output are in PDF points. This file is passed
     to blackletter's ``generate`` API as the single source of redaction data.
 
+    The merging, the pixel-to-point conversion and the opinion filenames all
+    come from :func:`blackletter.api.build_redactions`, so the payload
+    ``generate`` reads is built by the same library that consumes it.
+
     :param scan_pk: Primary key of the scan.
     :return: Path to the generated redactions.json.
     """
     scan = Scan.objects.get(pk=scan_pk)
     output_dir = Path(scan.output_dir)
+    pdf_path = processing_pdf_path(scan)
 
-    det_path = output_dir / "detections.json"
+    # ``snap=False``: this step reads only each page's dimensions and scale,
+    # never its column boxes, so correcting them would render the whole
+    # volume at 100 dpi to change nothing.
+    pages = _pages_for_geometry(scan, pdf_path, output_dir, snap=False)
 
-    margins_data = scan.margin_rects
-    rects_data = scan.redaction_rects
-    opinions = scan.opinions_json
-
-    # Add filenames based on reporter, volume, and page numbers
-    reporter = scan.reporter.short_name or ""
-    volume = str(scan.volume) or ""
-    prefix = f"{reporter}.{volume}" if reporter and volume else ""
-    for op in opinions:
-        if prefix:
-            first = op.get("first_page_number", 0)
-            last = op.get("last_page_number", first)
-            op["filename"] = f"{prefix}.{first:04d}-{last:04d}.pdf"
-
-    # Image dims for pixel→PDF conversion
-    img_dims = {}
-    if det_path.exists():
-        for d in json.loads(det_path.read_text()):
-            pi = d["page_index"]
-            if pi not in img_dims:
-                img_dims[pi] = (d.get("img_width", 1), d.get("img_height", 1))
-
-    # PDF page dims
-    pdf_path = find_ocr_pdf(scan.output_dir) or scan.pdf_path
-    pdf_dims = {}
-    with fitz.open(str(pdf_path)) as src:
-        for i in range(src.page_count):
-            r = src[i].rect
-            pdf_dims[i] = (r.width, r.height)
-
-    pages: dict[int, list] = {}
-
-    # Margin rects (already in PDF points)
-    for entry in margins_data:
-        pi = entry["page_index"]
-        if pi not in pages:
-            pages[pi] = []
-        for r in entry.get("rects", []):
-            pages[pi].append(
-                {
-                    "x0": round(r["x0"], 1),
-                    "y0": round(r["y0"], 1),
-                    "x1": round(r["x1"], 1),
-                    "y1": round(r["y1"], 1),
-                    "fill": "white",
-                    "type": "margin",
-                }
-            )
-
-    # Redaction rects (pixels → PDF points)
-    for entry in rects_data:
-        pi = entry["page_index"]
-        if pi not in pages:
-            pages[pi] = []
-
-        iw, ih = img_dims.get(pi, (1, 1))
-        pdf_w, pdf_h = pdf_dims.get(pi, (612.0, 792.0))
-        to_x = pdf_w / iw if iw > 1 else 1.0
-        to_y = pdf_h / ih if ih > 1 else 1.0
-
-        for r in entry.get("rects", []):
-            x0 = r["x0"] * to_x
-            y0 = r["y0"] * to_y
-            x1 = r["x1"] * to_x
-            y1 = r["y1"] * to_y
-            if x0 >= x1 or y0 >= y1:
-                continue
-            pages[pi].append(
-                {
-                    "x0": round(x0, 1),
-                    "y0": round(y0, 1),
-                    "x1": round(x1, 1),
-                    "y1": round(y1, 1),
-                    "fill": r["fill"],
-                    "type": r["type"],
-                }
-            )
-
-    combined = {
-        "opinions": opinions,
-        "pages": {str(k): v for k, v in sorted(pages.items())},
-    }
+    try:
+        combined = bl_build_redactions(
+            pages,
+            scan.redaction_rects,
+            scan.margin_rects,
+            scan.opinions_json,
+            reporter=scan.reporter.short_name or "",
+            volume=str(scan.volume) or "",
+        )
+    except KeyError as exc:
+        # The rects are a saved snapshot and the pages come from the live
+        # detections, so deactivating the last detection on a page that still
+        # has rects leaves a page blackletter cannot scale. Refusing is right,
+        # since guessing the scale would put the rect in the wrong place, but
+        # say what to do about it.
+        raise RuntimeError(
+            f"scan {scan_pk}: saved redaction rects reference a page with no "
+            f"detections left, so their pixel coordinates cannot be converted "
+            f"to points. Recompute the redaction rects and try again. ({exc})"
+        ) from exc
 
     out_path = output_dir / "redactions.json"
     out_path.write_text(json.dumps(combined))
+    pages = combined["pages"]
     n_rects = sum(len(v) for v in pages.values())
     logger.info(
         "Combined redactions: %s pages, %s rects, %s opinions",
         len(pages),
         n_rects,
-        len(opinions),
+        len(combined["opinions"]),
     )
     return out_path
-
-
-def _adjust_margins_for_detections(
-    margin_rects: list, output_dir: Path
-) -> list:
-    """Shrink margin rects that overlap with active detections.
-
-    For each page, convert detection bboxes from image coords to PDF
-    coords and push back the edge of any margin rect that would cover
-    a detection.
-
-    :param margin_rects: List of ``{"page_index": int, "rects": [...]}``
-        dicts from ``compute_margin_rects``.
-    :param output_dir: Output directory containing detections.json.
-    :return: The adjusted margin rects list (modified in place).
-    """
-    det_path = output_dir / "detections.json"
-    if not det_path.exists():
-        return margin_rects
-
-    detections = json.loads(det_path.read_text())
-
-    # Labels that should not push back margins (noisy edge detections)
-    ignore_labels = {"PAGE_NUMBER", "PAGE_HEADER", "STATE_ABBREVIATION"}
-
-    # Group detections by page_index, skipping ignored labels
-    dets_by_page: dict[int, list] = {}
-    for d in detections:
-        if d.get("label", "") in ignore_labels:
-            continue
-        dets_by_page.setdefault(d["page_index"], []).append(d)
-
-    padding = 0.0  # extra PDF-pt clearance around detections
-
-    for page_entry in margin_rects:
-        if not page_entry["rects"]:
-            continue
-        page_idx = page_entry["page_index"]
-        page_dets = dets_by_page.get(page_idx)
-        if not page_dets:
-            continue
-
-        # Get image dimensions from the first detection on this page
-        img_w = page_dets[0].get("img_width", 1)
-        img_h = page_dets[0].get("img_height", 1)
-        if not img_w or not img_h:
-            continue
-
-        # Determine PDF page size from the margin rects themselves
-        # (full-width rects span x0=0 to x1=page_width, etc.)
-        pdf_w = max(r["x1"] for r in page_entry["rects"])
-        pdf_h = max(r["y1"] for r in page_entry["rects"])
-        sx = pdf_w / img_w
-        sy = pdf_h / img_h
-
-        # Convert detection bboxes to PDF coords
-        pdf_dets = []
-        for d in page_dets:
-            bb = d["bbox"]
-            pdf_dets.append((bb[0] * sx, bb[1] * sy, bb[2] * sx, bb[3] * sy))
-
-        # Adjust each margin rect
-        for rect in page_entry["rects"]:
-            for dx0, dy0, dx1, dy1 in pdf_dets:
-                # Check if detection overlaps this rect
-                if (
-                    dx0 < rect["x1"]
-                    and dx1 > rect["x0"]
-                    and dy0 < rect["y1"]
-                    and dy1 > rect["y0"]
-                ):
-                    # Shrink the rect edge that intrudes on the detection
-                    # Bottom margin (rect covers lower portion of page)
-                    if rect["y0"] > 0 and rect["y1"] >= pdf_h - 1:
-                        rect["y0"] = max(rect["y0"], dy1 + padding)
-                    # Top margin (rect covers upper portion of page)
-                    if rect["y0"] <= 1 and rect["y1"] < pdf_h - 1:
-                        rect["y1"] = min(rect["y1"], dy0 - padding)
-                    # Left margin (rect covers left portion of page)
-                    if rect["x0"] <= 1 and rect["x1"] < pdf_w - 1:
-                        rect["x1"] = min(rect["x1"], dx0 - padding)
-                    # Right margin (rect covers right portion of page)
-                    if (
-                        rect["x0"] > 0
-                        and rect["y0"] <= 1
-                        and rect["y1"] >= pdf_h - 1
-                    ):
-                        rect["x0"] = max(rect["x0"], dx1 + padding)
-
-    return margin_rects
 
 
 def _re_pair_opinions(scan_pk: int) -> list:
@@ -1351,7 +1119,7 @@ def _re_pair_opinions(scan_pk: int) -> list:
     if not det_data:
         return []
 
-    pdf_path = find_ocr_pdf(scan.output_dir) or scan.pdf_path
+    pdf_path = processing_pdf_path(scan)
     with _log_stage("Opinion pairing"):
         opinions = bl_pair(
             det_data,
@@ -1494,6 +1262,7 @@ def run_incremental_validation(scan_pk: int, pdf_path: str) -> None:
             )
     if all_detections:
         Detection.objects.bulk_create(all_detections)
+        _snap_text_columns_to_ink(scan_pk, pdf_path)
 
     Scan.objects.filter(pk=scan_pk).update(
         ocr_results=all_results,
@@ -1507,99 +1276,6 @@ def run_incremental_validation(scan_pk: int, pdf_path: str) -> None:
 # ---------------------------------------------------------------------------
 # Recalculate (rebuild issues without re-running OCR)
 # ---------------------------------------------------------------------------
-
-
-def _split_detected(
-    ocr_results: list, exp_start: int | None, exp_end: int | None
-) -> tuple[list, dict]:
-    """Partition detected single page numbers into out-of-range and in-range.
-
-    A detected number is out of range when it is below 1 or, when an expected
-    range is known, falls more than 5 outside it. Range pages and pages
-    without a detected number are skipped.
-
-    :param ocr_results: Per-page OCR results.
-    :param exp_start: Expected first page number, or None.
-    :param exp_end: Expected last page number, or None.
-    :returns: ``(out_of_range, seen_nums)`` where ``seen_nums`` maps each
-        in-range number to the list of PDF pages it appears on.
-    :rtype: tuple[list, dict]
-    """
-    out_of_range: list = []
-    seen_nums: dict = {}
-    for r in ocr_results:
-        if not r["detected"] or r.get("type") == "range":
-            continue
-        try:
-            num = int(r["detected"])
-        except (ValueError, TypeError):
-            continue
-        if num < 1:
-            out_of_range.append(r)
-        elif exp_start is not None and (
-            num < exp_start - 5 or num > exp_end + 5
-        ):
-            out_of_range.append(r)
-        else:
-            seen_nums.setdefault(num, []).append(r["pdf_page"])
-    return out_of_range, seen_nums
-
-
-def _build_analysis(
-    ocr_results: list, exp_start: int | None, exp_end: int | None
-) -> dict:
-    """Analyze ocr_results into the structure ``_build_issues`` expects.
-
-    Computes out-of-range, duplicate, sequence, and missing-page data from
-    the current page numbers without re-running OCR or opening the PDF.
-
-    :param ocr_results: Per-page OCR results (already finalized).
-    :param exp_start: Expected first page number, or None.
-    :param exp_end: Expected last page number, or None.
-    :returns: The analysis dict consumed by ``_build_issues``.
-    :rtype: dict
-    """
-    out_of_range, seen_nums = _split_detected(ocr_results, exp_start, exp_end)
-    out_of_range_pages = {r["pdf_page"] for r in out_of_range}
-    all_nums = sorted(seen_nums.keys())
-    duplicates = {k: v for k, v in seen_nums.items() if len(v) > 1}
-    seq_issues = _detect_sequence_issues(ocr_results, out_of_range_pages)
-
-    range_re = re.compile(r"^(\d{1,4})\s*[–\-]\s*(\d{1,4})$")
-    range_pages = set()
-    ranges_found = [r for r in ocr_results if r.get("type") == "range"]
-    for r in ranges_found:
-        m = range_re.match(r["detected"].replace("–", "-"))
-        if m:
-            for pg in range(int(m.group(1)), int(m.group(2)) + 1):
-                range_pages.add(pg)
-
-    if exp_start is not None and all_nums:
-        missing_pages = sorted(
-            (set(range(exp_start, exp_end + 1)) - set(all_nums))
-            - range_pages
-            - {0}
-        )
-    elif all_nums:
-        missing_pages = sorted(
-            (set(range(all_nums[0], all_nums[-1] + 1)) - set(all_nums))
-            - range_pages
-            - {0}
-        )
-    else:
-        missing_pages = []
-
-    return {
-        "results": ocr_results,
-        "seq_issues": seq_issues,
-        "duplicates": duplicates,
-        "seen_nums": seen_nums,
-        "all_nums": all_nums,
-        "missing_pages": missing_pages,
-        "ranges_found": ranges_found,
-        "not_detected": [r for r in ocr_results if not r["detected"]],
-        "out_of_range": out_of_range,
-    }
 
 
 def rebuild_page_map(scan: "Scan") -> None:
@@ -1617,11 +1293,11 @@ def rebuild_page_map(scan: "Scan") -> None:
     if not ocr_results:
         return
     try:
-        exp_start, exp_end = _parse_expected_range(scan.pdf_path)
+        exp_start, exp_end = parse_expected_range(scan.pdf_path)
     except FileNotFoundError:
-        exp_start, exp_end = _parse_expected_range(scan.original_pdf.name)
-    analysis = _build_analysis(ocr_results, exp_start, exp_end)
-    result = _build_issues(
+        exp_start, exp_end = parse_expected_range(scan.original_pdf.name)
+    analysis = build_analysis(ocr_results, exp_start, exp_end)
+    result = build_issues(
         analysis, scan.page_count, exp_start=exp_start, exp_end=exp_end
     )
     scan.page_map = result["page_map"]
@@ -1639,9 +1315,11 @@ def recalculate_issues(scan: "Scan") -> None:
     if not ocr_results:
         return
 
-    exp_start, exp_end = _parse_expected_range(scan.pdf_path)
+    exp_start, exp_end = parse_expected_range(scan.pdf_path)
 
-    out_of_range, seen_nums = _split_detected(ocr_results, exp_start, exp_end)
+    out_of_range, seen_nums = _split_in_out_of_range(
+        ocr_results, exp_start, exp_end
+    )
 
     auto_corrected = []
     if out_of_range and seen_nums:
@@ -1690,9 +1368,9 @@ def recalculate_issues(scan: "Scan") -> None:
                 ocr_results = new_results
                 scan.ocr_results = ocr_results
 
-    analysis = _build_analysis(ocr_results, exp_start, exp_end)
+    analysis = build_analysis(ocr_results, exp_start, exp_end)
 
-    result = _build_issues(
+    result = build_issues(
         analysis, scan.page_count, exp_start=exp_start, exp_end=exp_end
     )
 
@@ -1765,10 +1443,16 @@ def run_validate_with_bitonal(scan_pk: int) -> None:
 
 
 def run_full_pipeline(scan_pk: int) -> None:
-    """Run the full processing pipeline: bitonal → OCR → YOLO → validate → pair → rects.
+    """Run the full processing pipeline: bitonal → YOLO → validate → pair → rects.
 
     Designed to run in the daemon process. After this completes, the scan
     is ready for review -- the user only needs to approve and generate.
+
+    No text layer is embedded here. The ocrmypdf/Tesseract pass used to
+    run between bitonal conversion and detection and dominated the
+    pipeline's wall clock, while nothing in steps 1 and 2 reads the text
+    it produced; ``bitonal.pdf`` is now the processing PDF end to end
+    (see ``utils.find_processing_pdf``).
 
     :param scan_pk: Primary key of the scan to process.
     """
@@ -1788,41 +1472,28 @@ def run_full_pipeline(scan_pk: int) -> None:
         # 2. Bitonal conversion
         bitonal_path = _ensure_bitonal(scan, output_dir)
 
-        # 3. Tesseract OCR (on bitonal)
-        scan.refresh_from_db()
-        ocr_pdf = find_ocr_pdf(str(output_dir))
-        if not ocr_pdf:
-            ocr_pdf = _run_ocr(
-                scan_pk,
-                str(bitonal_path),
-                str(output_dir),
-                reporter=scan.reporter.short_name or "",
-                volume=str(scan.volume) or "",
-                first_page=scan.start_page or 1,
-            )
-
-        # 4. YOLO detection (all 3 models on bitonal)
+        # 3. YOLO detection (all 3 models on bitonal)
         _run_yolo(scan_pk, str(bitonal_path), str(output_dir))
 
-        # 5. Import detections into DB
+        # 4. Import detections into DB
         _update_progress(scan_pk, "Importing detections...")
         dets = _import_detections_from_json(scan_pk, str(output_dir))
+        _snap_text_columns_to_ink(scan_pk, str(bitonal_path))
 
-        # 6. PaddleOCR validation (on original PDF for better OCR)
+        # 5. PaddleOCR validation (on original PDF for better OCR)
         _update_progress(
             scan_pk,
             f"{len(dets)} detections imported. Running page number validation...",
         )
         run_paddleocr_validation(scan_pk, scan.pdf_path)
 
-        # 7. Pair opinions
+        # 6. Pair opinions
         _update_progress(scan_pk, "Pairing opinions...")
         opinions = _re_pair_opinions(scan_pk)
 
-        # 8. Compute redaction rects (margin rects computed lazily when viewer requests them)
+        # 7. Compute redaction rects (margin rects computed lazily when viewer requests them)
         _update_progress(scan_pk, "Computing redaction rects...")
-        pdf_path = str(ocr_pdf) if ocr_pdf else scan.pdf_path
-        _compute_and_save_redaction_rects(scan_pk, pdf_path)
+        _compute_and_save_redaction_rects(scan_pk, str(bitonal_path))
 
         Scan.objects.filter(pk=scan_pk).update(
             status=Status.PENDING_REVIEW,
@@ -1837,7 +1508,7 @@ def run_full_pipeline(scan_pk: int) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Reprocess (apply fixes, re-bitonal, re-OCR, re-validate)
+# Reprocess (apply fixes, re-bitonal, re-detect, re-validate)
 # ---------------------------------------------------------------------------
 
 
@@ -1846,6 +1517,18 @@ def _rebuild_issues_from_results(scan_pk: int, all_results: list) -> None:
 
     Preserves the actual OCR results (including manual assignments) but
     recalculates sequence issues, missing pages, duplicates, etc.
+
+    The analysis now comes from :func:`blackletter.validate.build_analysis`
+    rather than being assembled here, which makes this path agree with
+    ``recalculate_issues`` and ``rebuild_page_map`` where it used to differ
+    in three ways, all of them this path being wrong:
+
+    - a page printed as a range ("677-685") now accounts for every number it
+      covers, so those no longer show up as missing
+    - out-of-range readings now reach ``build_issues``, which both reports
+      them and stops them anchoring duplicate detection
+    - a scan with no ``end_page`` now gets missing-page findings across the
+      span it actually detected, instead of none at all
 
     :param scan_pk: Primary key of the scan to rebuild issues for.
     :param all_results: List of per-page OCR result dicts.
@@ -1866,35 +1549,13 @@ def _rebuild_issues_from_results(scan_pk: int, all_results: list) -> None:
             all_results, exp_start, exp_end
         )
 
-    all_nums = sorted(seen_nums.keys())
-    duplicates = {k: v for k, v in seen_nums.items() if len(v) > 1}
-    not_detected = [x for x in all_results if not x["detected"]]
-    out_of_range_pages = {r["pdf_page"] for r in out_of_range}
+    # Auto-correction can move a page in or out of range, so the split done
+    # above is the one that applies and blackletter must not recompute it.
+    analysis = build_analysis(
+        all_results, exp_start, exp_end, out_of_range=out_of_range
+    )
 
-    seq_issues = _detect_sequence_issues(all_results, out_of_range_pages)
-
-    if exp_start is not None and exp_end is not None:
-        expected = set(range(exp_start, exp_end + 1))
-        found = {n for n in seen_nums if exp_start <= n <= exp_end}
-        missing_pages = sorted(expected - found)
-    else:
-        missing_pages = []
-
-    ranges_found = [r for r in all_results if r.get("type") == "range"]
-
-    analysis = {
-        "total_pages": total,
-        "results": all_results,
-        "seen_nums": seen_nums,
-        "all_nums": all_nums,
-        "duplicates": duplicates,
-        "not_detected": not_detected,
-        "seq_issues": seq_issues,
-        "missing_pages": missing_pages,
-        "ranges_found": ranges_found,
-    }
-
-    result = _build_issues(analysis, total, exp_start, exp_end)
+    result = build_issues(analysis, total, exp_start, exp_end)
 
     scan.refresh_from_db()
     scan.page_count = total
@@ -1918,7 +1579,8 @@ def _rebuild_issues_from_results(scan_pk: int, all_results: list) -> None:
 def run_reprocess(scan_pk: int) -> None:
     """Apply PDF fixes (inserts/deletions) using smart edits.
 
-    Only OCRs newly inserted pages. Deleted pages are removed from
+    Reads page numbers off newly inserted pages only. Deleted pages are
+    removed from
     ocr_results. Manual page assignments are preserved.
 
     Designed to run in the daemon process.
@@ -1998,7 +1660,7 @@ def run_reprocess(scan_pk: int) -> None:
 
             scan.inserts.all().delete()
 
-        # run_smart_insert already handled OCR, detection, validation,
+        # run_smart_insert already handled detection, validation,
         # re-pairing, and rect computation for each insert. Reload the
         # final state from the DB.
         scan.refresh_from_db()
@@ -2010,7 +1672,7 @@ def run_reprocess(scan_pk: int) -> None:
         _re_pair_opinions(scan_pk)
 
         if output_dir:
-            pdf_path = find_ocr_pdf(str(output_dir)) or scan.pdf_path
+            pdf_path = processing_pdf_path(scan)
             Scan.objects.filter(pk=scan_pk).update(
                 margin_rects="", redaction_rects=""
             )
@@ -2036,9 +1698,10 @@ def run_reprocess(scan_pk: int) -> None:
 def run_smart_delete(scan_pk: int, pdf_page: int) -> None:
     """Delete a single page and patch detections/validation in place.
 
-    Removes the page from the original PDF, bitonal PDF, and OCR PDF;
-    deletes detections on that page; shifts subsequent detection
-    page_index values down by 1; re-runs PaddleOCR validation and re-pairs.
+    Removes the page from every PDF the scan keeps on disk (the original,
+    ``bitonal.pdf``, and a legacy OCR PDF if one is still there); deletes
+    detections on that page; shifts subsequent detection page_index
+    values down by 1; re-runs PaddleOCR validation and re-pairs.
 
     :param scan_pk: Primary key of the scan to edit.
     :param pdf_page: 1-based PDF page number to delete.
@@ -2062,53 +1725,7 @@ def run_smart_delete(scan_pk: int, pdf_page: int) -> None:
     _re_pair_opinions(scan_pk)
 
     if output_dir:
-        pdf_path = find_ocr_pdf(str(output_dir)) or scan.pdf_path
-        _compute_and_save_redaction_rects(scan_pk, pdf_path)
-
-
-def _ocr_single_page(ocr_pdf_path: str, page_idx: int) -> None:
-    """Run Tesseract OCR on a single page of a PDF to add a text layer.
-
-    Extracts the page to a temp file, OCRs it, then replaces the page
-    in the original PDF with the OCR'd version.
-
-    :param ocr_pdf_path: Path to the OCR PDF to update.
-    :param page_idx: Zero-based page index to OCR.
-    """
-    import tempfile
-
-    import ocrmypdf
-
-    ocr_pdf_path = str(ocr_pdf_path)
-    with tempfile.TemporaryDirectory() as tmp:
-        tmp = Path(tmp)
-        # Extract the single page
-        single_path = tmp / "page.pdf"
-        with fitz.open(ocr_pdf_path) as doc:
-            with fitz.open() as single:
-                single.insert_pdf(doc, from_page=page_idx, to_page=page_idx)
-                single.save(str(single_path))
-
-            # OCR it
-            ocrd_path = tmp / "page_ocr.pdf"
-            ocrmypdf.ocr(
-                str(single_path),
-                str(ocrd_path),
-                pdf_renderer="auto",
-                optimize=1,
-                output_type="pdf",
-                language=["eng"],
-                tesseract_timeout=120,
-                progress_bar=False,
-            )
-
-            # Replace the page in the OCR PDF
-            with fitz.open(str(ocrd_path)) as ocrd_doc:
-                doc.delete_page(page_idx)
-                doc.insert_pdf(
-                    ocrd_doc, from_page=0, to_page=0, start_at=page_idx
-                )
-                doc.saveIncr()
+        _compute_and_save_redaction_rects(scan_pk, processing_pdf_path(scan))
 
 
 def run_smart_insert(
@@ -2116,9 +1733,10 @@ def run_smart_insert(
 ) -> None:
     """Insert a page and run detection/validation on just that page.
 
-    Inserts the page image into the original PDF, bitonal PDF, and OCR PDF
-    at the correct position; shifts subsequent detection page_index values up
-    by 1; re-validates and re-pairs.
+    Inserts the page image into every PDF the scan keeps on disk (the
+    original, ``bitonal.pdf``, and a legacy OCR PDF if one is still
+    there) at the correct position; shifts subsequent detection
+    page_index values up by 1; re-validates and re-pairs.
 
     :param scan_pk: Primary key of the scan to edit.
     :param logical_page_number: The logical page number to insert at.
@@ -2159,12 +1777,6 @@ def run_smart_insert(
                 new_page.insert_image(new_page.rect, filename=str(image_path))
             doc.saveIncr()
 
-    # OCR the inserted page in the OCR PDF so it gets a text layer
-    if output_dir:
-        ocr_pdf_path = find_ocr_pdf(str(output_dir))
-        if ocr_pdf_path:
-            _ocr_single_page(ocr_pdf_path, insert_idx)
-
     # Shift subsequent detections up
     Detection.objects.filter(
         scan_id=scan_pk, page_index__gte=insert_idx
@@ -2181,18 +1793,16 @@ def run_smart_insert(
 
     # Re-validate, re-pair, recompute rects
     scan.refresh_from_db()
-    pdf_path = find_ocr_pdf(str(output_dir)) if output_dir else scan.pdf_path
-    run_incremental_validation(scan_pk, pdf_path or scan.pdf_path)
+    pdf_path = processing_pdf_path(scan)
+    run_incremental_validation(scan_pk, pdf_path)
     _re_pair_opinions(scan_pk)
 
     if output_dir:
         Scan.objects.filter(pk=scan_pk).update(
             margin_rects="", redaction_rects=""
         )
-        _compute_and_save_margin_rects(
-            scan_pk, pdf_path or scan.pdf_path, str(output_dir)
-        )
-        _compute_and_save_redaction_rects(scan_pk, pdf_path or scan.pdf_path)
+        _compute_and_save_margin_rects(scan_pk, pdf_path, str(output_dir))
+        _compute_and_save_redaction_rects(scan_pk, pdf_path)
 
 
 def _collect_pdf_paths(scan: "Scan", output_dir: str | None) -> list[Path]:
@@ -2219,21 +1829,22 @@ def _collect_pdf_paths(scan: "Scan", output_dir: str | None) -> list[Path]:
 # ---------------------------------------------------------------------------
 
 
-def _stamp_original_images(scan: "Scan", ocr_pdf_path: str) -> str:
-    """Overlay original-quality image regions onto a *copy* of the OCR'd PDF.
+def _stamp_original_images(scan: "Scan", base_pdf_path: str) -> str:
+    """Overlay original-quality image regions onto a *copy* of the base PDF.
 
     For each active IMAGE detection, renders the bounding box from the
-    original scan PDF and inserts it into a copy of the OCR'd PDF at the
-    same position.  This preserves full-quality photographs/illustrations
-    that would otherwise be degraded by bitonal conversion.
+    original scan PDF and inserts it into a copy of the processing PDF
+    (normally ``bitonal.pdf``) at the same position. This preserves
+    full-quality photographs/illustrations that would otherwise be
+    degraded by bitonal conversion.
 
     :param scan: The Scan instance with the original PDF path.
-    :param ocr_pdf_path: Path to the OCR'd PDF to stamp onto.
-    :return: Path to the stamped copy, or the original path if no
-        images needed stamping (so the OCR PDF is never modified).
+    :param base_pdf_path: Path to the processing PDF to stamp onto.
+    :return: Path to the stamped copy. Always a copy, so the processing
+        PDF is never modified by downstream steps.
     """
 
-    stamped_path = os.path.join(os.path.dirname(ocr_pdf_path), "stamped.pdf")
+    stamped_path = os.path.join(os.path.dirname(base_pdf_path), "stamped.pdf")
 
     image_dets = list(
         Detection.objects.filter(scan=scan, label="IMAGE", active=True)
@@ -2243,30 +1854,30 @@ def _stamp_original_images(scan: "Scan", ocr_pdf_path: str) -> str:
         )
     )
     if not image_dets:
-        # Always copy so the OCR PDF is never modified by downstream steps
-        shutil.copy2(ocr_pdf_path, stamped_path)
+        # Always copy so the processing PDF is never modified downstream
+        shutil.copy2(base_pdf_path, stamped_path)
         return stamped_path
 
     # Save extracted images to images/ directory
-    images_dir = Path(os.path.dirname(ocr_pdf_path)) / "images"
+    images_dir = Path(os.path.dirname(base_pdf_path)) / "images"
     images_dir.mkdir(exist_ok=True)
     page_numbers = _page_number_lookup(scan)
     img_count_by_page: dict[int, int] = {}
 
     with (
         fitz.open(scan.pdf_path) as original_doc,
-        fitz.open(ocr_pdf_path) as ocr_doc,
+        fitz.open(base_pdf_path) as base_doc,
     ):
         for det in image_dets:
             page_idx = det["page_index"]
             if (
                 page_idx >= original_doc.page_count
-                or page_idx >= ocr_doc.page_count
+                or page_idx >= base_doc.page_count
             ):
                 continue
 
             orig_page = original_doc[page_idx]
-            ocr_page = ocr_doc[page_idx]
+            base_page = base_doc[page_idx]
 
             # Convert image-pixel bbox to PDF points
             page_rect = orig_page.rect
@@ -2286,8 +1897,8 @@ def _stamp_original_images(scan: "Scan", ocr_pdf_path: str) -> str:
             pix = orig_page.get_pixmap(clip=pdf_rect, dpi=150)
             png_bytes = pix.tobytes("png")
 
-            # Stamp onto the OCR'd PDF
-            ocr_page.insert_image(pdf_rect, stream=png_bytes)
+            # Stamp onto the processing PDF copy
+            base_page.insert_image(pdf_rect, stream=png_bytes)
 
             # Save image to images/ directory
             pn = page_numbers.get(page_idx)
@@ -2298,7 +1909,7 @@ def _stamp_original_images(scan: "Scan", ocr_pdf_path: str) -> str:
             img_name = f"{page_num}-{img_count_by_page[page_idx]:03d}.png"
             (images_dir / img_name).write_bytes(png_bytes)
 
-        ocr_doc.save(stamped_path, garbage=3, deflate=True)
+        base_doc.save(stamped_path, garbage=3, deflate=True)
     return stamped_path
 
 
@@ -2320,18 +1931,29 @@ def run_generate_files(scan_pk: int) -> None:
         )
 
         output = Path(scan.output_dir)
-        ocr_pdf = find_ocr_pdf(str(output))
-        if not ocr_pdf:
-            raise ValueError("No OCR'd PDF found in output directory")
+        base_pdf = find_processing_pdf(str(output))
+        if not base_pdf:
+            raise ValueError(
+                "No processing PDF (bitonal.pdf) found in output directory"
+            )
 
-        # Stamp original-quality images into a copy, leaves OCR PDF untouched
-        gen_pdf = _stamp_original_images(scan, str(ocr_pdf))
+        # Stamp original-quality images into a copy, leaves base PDF untouched
+        gen_pdf = _stamp_original_images(scan, str(base_pdf))
 
         # Write current DB detections -> detections.json (includes page numbers)
         det_data = _sync_detections_to_disk(scan_pk)
         Scan.objects.filter(pk=scan_pk).update(
             progress_message=f"Generating files ({len(det_data or [])} detections)..."
         )
+
+        # Margin rects are otherwise only computed on demand, by the viewer
+        # asking for them or by a reprocess. A scan taken straight from
+        # review to Generate without the margins overlay ever being switched
+        # on therefore shipped with no whiteouts at all: the platen bands,
+        # fold shadows and corner bleed stayed in the deliverable. Computing
+        # them here makes the output independent of what the reviewer
+        # happened to look at; it no-ops when they already exist.
+        _compute_and_save_margin_rects(scan_pk, str(base_pdf), str(output))
 
         # Build combined redactions.json (margins + redaction rects + opinions)
         Scan.objects.filter(pk=scan_pk).update(
@@ -2355,9 +1977,12 @@ def run_generate_files(scan_pk: int) -> None:
             llm=True,
         )
 
+        _add_llm_page_text_layer(scan_pk, output / "llm")
+
         opinion_count = result.get("opinion_count", 0)
         full_redacted = result.get("full_redacted", "")
         redacted_dir = Path(result.get("redacted_dir", output / "redacted"))
+
         unredacted_dir = output / "unredacted"
 
         redacted_files = (
@@ -2466,37 +2091,40 @@ def _page_has_headnote(redactions_pages: dict, page_index: int) -> bool:
     )
 
 
-def _page_body_textless(
+def _page_body_covered(
+    redactions_pages: dict,
+    page_index: int,
     pdf_path: Path,
-    header_height_pts: float = 60.0,
-    text_floor: int = 5,
 ) -> bool:
-    """Return True when the rendered page has no text below the header.
+    """Return True when rects cover essentially all of a page's body.
 
-    The per-page PDFs handed to the LLM are post-redaction, so a body
-    entirely covered by ``headnote`` rects extracts to nothing. Used as
-    the boundary-case confirmation for the sandwich rule: when only
-    one neighbor of a page has headnotes (the page is the leading or
-    trailing edge of a multi-page block), we verify the redaction
-    actually wiped the body text before calling the page blank.
+    Boundary-case confirmation for the sandwich rule: when only one
+    neighbor of a page has headnotes (the page is the leading or trailing
+    edge of a multi-page block), we check that the redaction geometry
+    actually wipes the whole body before calling the page blank.
 
-    Returns False on any exception so a corrupt PDF doesn't mis-flag
+    The measurement is :func:`blackletter.process.page_body_covered`; what
+    is app-specific is looking the page's rects up in ``redactions.json``
+    and reading the page size off the generated PDF.
+
+    Returns False on any exception so an unreadable PDF cannot mis-flag
     a page as blank.
 
-    :param pdf_path: Filesystem path to the per-page PDF.
-    :param header_height_pts: PDF-point band at the top of the page
-        treated as "header" and excluded from the text check. The
-        printed page number lives here.
-    :param text_floor: Chars of body text below which the page is
-        considered effectively empty.
-    :return: True if the cropped body extracts to fewer than
-        ``text_floor`` chars.
+    :param redactions_pages: ``redactions["pages"]`` -- dict keyed by
+        stringified page_index, each value a list of rect dicts with
+        ``x0``/``y0``/``x1``/``y1`` in PDF points.
+    :param page_index: 0-based PDF page index.
+    :param pdf_path: Filesystem path to the per-page PDF, used only to
+        read the page size.
+    :return: True if essentially all of the body is covered.
     """
+    rects = redactions_pages.get(str(page_index), [])
+    if not rects:
+        return False
     try:
-        with pdfplumber.open(pdf_path) as pdf:
-            pg = pdf.pages[0]
-            body = pg.crop((0, header_height_pts, pg.width, pg.height))
-            return len((body.extract_text() or "").strip()) < text_floor
+        with fitz.open(str(pdf_path)) as doc:
+            page_rect = doc[0].rect
+        return page_body_covered(rects, page_rect.width, page_rect.height)
     except Exception:
         return False
 
@@ -2539,9 +2167,9 @@ def _is_blank_via_sandwich(
         fires directly.
       * **Boundary sandwich** — only one neighbor has headnotes
         (this page is the leading or trailing edge of the block).
-        Confirm with a text-extraction check on the rendered PDF;
-        since the per-page PDFs are post-redaction, an actually-empty
-        body extracts to nothing.
+        Confirm by measuring how much of the body the page's rects
+        cover, since a body made entirely of redaction rects has
+        nothing left to extract.
 
     :param page_index: 0-based PDF page index.
     :param opinions: ``scan.opinions_json`` — the curated opinion
@@ -2551,9 +2179,9 @@ def _is_blank_via_sandwich(
         list keyed by stringified page_index.
     :param page_detections: All YOLO detections on this page (used
         only to check for ``FOOTNOTES``).
-    :param pdf_path: Path to the per-page PDF, used for the boundary
-        text-extraction check. If omitted, the boundary case can't
-        fire and only strict sandwich pages are flagged.
+    :param pdf_path: Path to the per-page PDF, read for its page size
+        by the boundary coverage check. If omitted, the boundary case
+        can't fire and only strict sandwich pages are flagged.
     :return: True iff the page's body is effectively blank under the
         rule above.
     """
@@ -2572,11 +2200,11 @@ def _is_blank_via_sandwich(
         next_hn = _page_has_headnote(redactions_pages, page_index + 1)
         if prev_hn and next_hn:
             return True
-        # Boundary case: only one side has headnotes. Confirm via the
-        # rendered PDF — if the body is genuinely empty (post-redaction),
-        # it really is a blank page even though sandwich doesn't fire.
+        # Boundary case: only one side has headnotes. Confirm from the
+        # rect geometry — if the whole body is redacted away, it really
+        # is a blank page even though sandwich doesn't fire.
         if (prev_hn or next_hn) and pdf_path is not None:
-            if _page_body_textless(pdf_path):
+            if _page_body_covered(redactions_pages, page_index, pdf_path):
                 return True
     return False
 
@@ -2733,22 +2361,11 @@ def run_detect(scan_pk: int) -> None:
     try:
         output_dir = Path(scan.output_dir)
         bitonal = output_dir / "bitonal.pdf"
-
-        # OCR if needed (no existing OCR PDF)
-        if not find_ocr_pdf(str(output_dir)) and bitonal.exists():
-            _run_ocr(
-                scan_pk,
-                str(bitonal),
-                str(output_dir),
-                reporter=scan.reporter.short_name or "",
-                volume=str(scan.volume) or "",
-                first_page=scan.start_page or 1,
-            )
-
         pdf_path = str(bitonal) if bitonal.exists() else scan.pdf_path
 
         _run_yolo(scan_pk, pdf_path, str(output_dir))
         dets = _import_detections_from_json(scan_pk, str(output_dir))
+        _snap_text_columns_to_ink(scan_pk, pdf_path)
 
         _update_progress(
             scan_pk,

--- a/scanning/services.py
+++ b/scanning/services.py
@@ -546,7 +546,11 @@ def _snap_text_columns_to_ink(scan_pk: int, pdf_path: str) -> int:
             ]
             if not snap_text_columns_to_ink(fitz_page, page):
                 continue
-            for det, snapped in zip(columns, page.detections):
+            # strict: the snap rewrites boxes in place and must hand back
+            # one per column. A length change would mean it reordered or
+            # dropped one, and pairing the survivors by position would
+            # silently write a column's new bounds onto its neighbour.
+            for det, snapped in zip(columns, page.detections, strict=True):
                 new_x0 = round(snapped.bbox.x1, 1)
                 new_x1 = round(snapped.bbox.x2, 1)
                 if abs(new_x0 - det.x0) < 1 and abs(new_x1 - det.x1) < 1:
@@ -1047,7 +1051,7 @@ def _add_llm_page_text_layer(scan_pk: int, llm_dir: Path) -> int:
 
     _update_progress(scan_pk, "Adding a text layer to the LLM pages...")
     added = add_text_layer(llm_dir)
-    print(f"  Text layer added to {len(added)} LLM pages", flush=True)
+    logger.info("Text layer added to %s LLM pages", len(added))
     return len(added)
 
 

--- a/scanning/services.py
+++ b/scanning/services.py
@@ -972,11 +972,13 @@ def _pages_for_geometry(
     :param pdf_path: The PDF the detections were measured against.
     :param output_dir: The scan's output directory, for the JSON fallback.
     :param snap: Correct the ``TEXT_COLUMN`` boxes against the page ink.
-        The pipeline already persisted corrected boxes, and the correction
-        converges, so this changes nothing unless a box reached the DB
-        uncorrected, which a hand-added column detection does. It is not
-        free: it renders every page at 100 dpi, so pass ``False`` where the
-        column boxes are not read (see :func:`_build_combined_redactions`).
+        Boxes reach the DB uncorrected: nothing on the upload path snaps
+        them (that would be a full-volume render review 1 does not need),
+        and a hand-added column detection is stored exactly as drawn. The
+        correction converges, so this is a no-op once ``run_generate_files``
+        has persisted it, but it is not free before then: it renders every
+        page at 100 dpi, so pass ``False`` where the column boxes are not
+        read (see :func:`_build_combined_redactions`).
     :return: ``Page`` objects, empty when the scan has no detections yet.
     """
     det_data = _detections_for_geometry(scan.pk, output_dir)
@@ -1502,7 +1504,7 @@ def run_validate_with_bitonal(scan_pk: int) -> None:
 
 
 def run_full_pipeline(scan_pk: int) -> None:
-    """Run the full processing pipeline: bitonal → YOLO → validate → pair → rects.
+    """Run the full processing pipeline: bitonal → YOLO → validate → pair.
 
     Designed to run in the daemon process. After this completes, the scan
     is ready for review -- the user only needs to approve and generate.
@@ -1512,6 +1514,14 @@ def run_full_pipeline(scan_pk: int) -> None:
     pipeline's wall clock, while nothing in steps 1 and 2 reads the text
     it produced; ``bitonal.pdf`` is now the processing PDF end to end
     (see ``utils.find_processing_pdf``).
+
+    No redaction geometry is computed here either, for the same reason.
+    The column correction and the redaction rects cost three full-volume
+    renders at 100 dpi between them, and review 1 reads neither: it asks
+    whether the volume is complete and shows no detection overlay. Both
+    now run in :func:`run_generate_files`, where the geometry is actually
+    read, so a scanner waits for detection and pairing only. The step 2
+    overlay still gets rects on demand through ``compute_redactions_api``.
 
     :param scan_pk: Primary key of the scan to process.
     """
@@ -1537,7 +1547,6 @@ def run_full_pipeline(scan_pk: int) -> None:
         # 4. Import detections into DB
         _update_progress(scan_pk, "Importing detections...")
         dets = _import_detections_from_json(scan_pk, str(output_dir))
-        _snap_text_columns_to_ink(scan_pk, str(bitonal_path))
 
         # 5. PaddleOCR validation (on original PDF for better OCR)
         _update_progress(
@@ -1550,9 +1559,8 @@ def run_full_pipeline(scan_pk: int) -> None:
         _update_progress(scan_pk, "Pairing opinions...")
         opinions = _re_pair_opinions(scan_pk)
 
-        # 7. Compute redaction rects (margin rects computed lazily when viewer requests them)
-        _update_progress(scan_pk, "Computing redaction rects...")
-        _compute_and_save_redaction_rects(scan_pk, str(bitonal_path))
+        # Redaction and margin geometry is deliberately not computed here;
+        # Generate Files does it. See this function's docstring.
 
         Scan.objects.filter(pk=scan_pk).update(
             status=Status.PENDING_REVIEW,
@@ -2004,6 +2012,15 @@ def run_generate_files(scan_pk: int) -> None:
         # Stamp original-quality images into a copy, leaves base PDF untouched
         gen_pdf = _stamp_original_images(scan, str(base_pdf))
 
+        # Correct the TEXT_COLUMN boxes against the page ink before anything
+        # reads them. The upload path used to do this so that step 2 showed
+        # corrected boxes, but review 1 has no detection overlay to show them
+        # in, so it was a full-volume render nobody was waiting on. Here it
+        # runs before the detections are written out, which is what the
+        # geometry below and the pairing are measured from.
+        _update_progress(scan_pk, "Correcting column boxes...")
+        _snap_text_columns_to_ink(scan_pk, str(base_pdf))
+
         # Write current DB detections -> detections.json (includes page numbers)
         det_data = _sync_detections_to_disk(scan_pk)
         Scan.objects.filter(pk=scan_pk).update(
@@ -2018,6 +2035,17 @@ def run_generate_files(scan_pk: int) -> None:
         # them here makes the output independent of what the reviewer
         # happened to look at; it no-ops when they already exist.
         _compute_and_save_margin_rects(scan_pk, str(base_pdf), str(output))
+
+        # Redaction rects, same story: off the upload path, computed here
+        # unless something already produced them. That "something" is either
+        # the step 2 overlay asking for them or a reprocess, and in the step 2
+        # case a reviewer may since have moved or deleted individual rects
+        # through ``save_redaction_rect``. Recomputing would discard those
+        # edits, so the stored set wins whenever there is one.
+        scan.refresh_from_db()
+        if not scan.redaction_rects:
+            _update_progress(scan_pk, "Computing redaction rects...")
+            _compute_and_save_redaction_rects(scan_pk, str(base_pdf))
 
         # Build combined redactions.json (margins + redaction rects + opinions)
         Scan.objects.filter(pk=scan_pk).update(

--- a/scanning/services.py
+++ b/scanning/services.py
@@ -1085,14 +1085,18 @@ def _build_combined_redactions(scan_pk: int) -> Path:
         )
     except KeyError as exc:
         # The rects are a saved snapshot and the pages come from the live
-        # detections, so deactivating the last detection on a page that still
-        # has rects leaves a page blackletter cannot scale. Refusing is right,
-        # since guessing the scale would put the rect in the wrong place, but
-        # say what to do about it.
+        # detections, so a page with rects but no detections left cannot be
+        # scaled. Deleting the last detection prunes that page's rects (see
+        # ``views_api._drop_orphaned_redaction_rects``), so reaching this
+        # means something else desynchronised them. Refusing is right --
+        # guessing the scale would put a blackout in the wrong place -- but
+        # name recovery a reviewer can actually carry out.
         raise RuntimeError(
             f"scan {scan_pk}: saved redaction rects reference a page with no "
             f"detections left, so their pixel coordinates cannot be converted "
-            f"to points. Recompute the redaction rects and try again. ({exc})"
+            f"to points. Re-add a detection on that page, or delete the "
+            f"leftover rect from the redaction overlay, then generate again. "
+            f"({exc})"
         ) from exc
 
     out_path = output_dir / "redactions.json"

--- a/scanning/settings/project/processing_storage.py
+++ b/scanning/settings/project/processing_storage.py
@@ -33,3 +33,13 @@ MAX_ORIGINAL_UPLOAD_SIZE = env.int("MAX_UPLOAD_SIZE_GB", default=3) * 1024**3
 # 9 hours. Sweeping sooner would delete the pending row and fileless scan
 # out from under a live upload.
 PENDING_UPLOAD_TTL_HOURS = env.float("PENDING_UPLOAD_TTL_HOURS", default=9.0)
+
+# Whether Generate Files adds a Tesseract text layer to the per-page PDFs in
+# ``llm/``. Off by default: the pipeline no longer embeds one anywhere (see
+# scanning #145), and the model that reads these pages reads the page image
+# itself. Turn it on to restore the text crops ``ai.user_prompt`` layers on
+# top of the roadmap (caption first lines, column-top continuations,
+# footnote snippets), at the cost of an OCR pass over every page of the
+# volume. It runs after redaction, so it never OCRs content that a rect is
+# about to cover.
+LLM_PAGE_TEXT_LAYER = env.bool("LLM_PAGE_TEXT_LAYER", default=False)

--- a/scanning/static/scanning/viewer_step2.js
+++ b/scanning/static/scanning/viewer_step2.js
@@ -40,6 +40,62 @@ document.addEventListener('DOMContentLoaded', function () {
         return container.querySelector('.lazy-page[data-pdf-index="' + pdfIndex + '"]');
     }
 
+    // Stamp an overlay box with a stable, human-readable identity so a box
+    // that looks wrong can be reported (and found in the DB) without
+    // measuring pixels: hover shows it, devtools shows it, and
+    // `data-box-id` is greppable in a screenshot or a bug report.
+    //
+    // The page number matches the on-screen "PDF p.N" label (1-based);
+    // `data-pdf-index` carries the 0-based index used by
+    // scan.redaction_rects / margin_rects / detections.
+    function _boxSlug(value) {
+        return String(value || 'box').toLowerCase().replace(/[^a-z0-9]+/g, '_');
+    }
+
+    function _tagOverlayBox(el, kind, type, pdfIndex, seq, rect, units) {
+        var pdfPage = pdfIndex + 1;
+        var slug = _boxSlug(type);
+        var boxId = kind + (slug ? '-' + slug : '') + '-p' + pdfPage + '-' + seq;
+        el.dataset.boxId = boxId;
+        el.dataset.kind = kind;
+        el.dataset.type = type || '';
+        el.dataset.pdfPage = pdfPage;
+        el.dataset.pdfIndex = pdfIndex;
+        el.dataset.seq = seq;
+        var coords = '';
+        if (rect) {
+            coords = [rect.x0, rect.y0, rect.x1, rect.y1]
+                .map(function (v) { return Math.round(v); })
+                .join(',');
+            el.dataset.rect = coords;
+            // Redaction and detection rects are stored in image pixels,
+            // margin rects in PDF points; say which so a reported number
+            // can be matched against the JSON without guessing.
+            el.dataset.units = units || 'px';
+        }
+        return boxId + (coords ? '  [' + coords + ' ' + (units || 'px') + ']' : '');
+    }
+
+    // Console helper for the review loop: given a box id read off a
+    // tooltip, scroll to that box and outline it. Pages render lazily, so a
+    // box only exists once its page has been in view and its overlay is on.
+    window.findBox = function (boxId) {
+        var el = container.querySelector('[data-box-id="' + boxId + '"]');
+        if (!el) {
+            console.warn(
+                'No box "' + boxId + '" is rendered. Scroll its page into ' +
+                'view with the overlay enabled, then try again.'
+            );
+            return null;
+        }
+        if (window.scrollPageIntoView) window.scrollPageIntoView(el);
+        var previous = el.style.outline;
+        el.style.outline = '3px solid #f59e0b';
+        setTimeout(function () { el.style.outline = previous; }, 4000);
+        console.log(boxId, Object.assign({}, el.dataset));
+        return el;
+    };
+
     var viewerPanel = container.closest('.viewer-panel') || container.parentElement;
     var viewerHeight = viewerPanel ? viewerPanel.clientHeight : (window.innerHeight - 200);
     // Scale so one full page (792pt letter height) fits within the viewer, never bigger
@@ -886,6 +942,7 @@ document.addEventListener('DOMContentLoaded', function () {
         var sx = canvasW / imgW;
         var sy = canvasH / imgH;
 
+        var detSeq = {};
         pageDets.forEach(function (d) {
             var box = document.createElement('div');
             box.className = 'detection-box';
@@ -899,7 +956,12 @@ document.addEventListener('DOMContentLoaded', function () {
             box.dataset.imgWidth = imgW;
             box.dataset.imgHeight = imgH;
             box.style.borderColor = color;
-            box.title = d.label + ' (' + d.confidence + ')';
+            detSeq[d.label] = (detSeq[d.label] || 0) + 1;
+            var detTag = _tagOverlayBox(
+                box, 'detection', d.label, pdfIndex, detSeq[d.label],
+                {x0: d.bbox[0], y0: d.bbox[1], x1: d.bbox[2], y1: d.bbox[3]}
+            );
+            box.title = d.label + ' (' + d.confidence + ')\n' + detTag;
 
             if (d.manual) box.classList.add('manual');
 
@@ -1466,6 +1528,79 @@ document.addEventListener('DOMContentLoaded', function () {
         return _marginIndex[pageIndex] || null;
     }
 
+    // Image-pixel dimensions for a page, read off its detections, with a
+    // document-wide fallback cache. Redaction rects are stored in those
+    // pixels, so this is what scales them onto the canvas.
+    function _imgDimsForPage(pdfIndex) {
+        var imgW = cachedImgW || 1, imgH = cachedImgH || 1;
+        if (allDetections) {
+            for (var di = 0; di < allDetections.length; di++) {
+                if (allDetections[di].page_index === pdfIndex) {
+                    imgW = allDetections[di].img_width || imgW;
+                    imgH = allDetections[di].img_height || imgH;
+                    break;
+                }
+            }
+            if (imgW <= 1 && allDetections.length > 0) {
+                imgW = allDetections[0].img_width || 1;
+                imgH = allDetections[0].img_height || 1;
+            }
+            if (imgW > 1) { cachedImgW = imgW; cachedImgH = imgH; }
+        }
+        return [imgW, imgH];
+    }
+
+    // Build one redaction / whiteout overlay box.
+    //
+    // Both draw paths go through here -- the whole document on toggle and a
+    // single page on lazy render -- because they were near-duplicates that
+    // had already drifted: the lazily drawn boxes carried no tooltip and no
+    // data-fill, so hovering a box showed nothing on the path users
+    // actually hit while scrolling.
+    //
+    // `seqs` accumulates a per-type counter for the page being drawn, which
+    // becomes the box id's ordinal.
+    function _makeRedactionBox(r, pdfIndex, dsx, dsy, seqs) {
+        var div = document.createElement('div');
+        div.className = 'redaction-overlay-box';
+        div.dataset.fill = r.fill || 'black';
+        div.style.position = 'absolute';
+        div.style.left = (r.x0 * dsx) + 'px';
+        div.style.top = (r.y0 * dsy) + 'px';
+        div.style.width = ((r.x1 - r.x0) * dsx) + 'px';
+        div.style.height = ((r.y1 - r.y0) * dsy) + 'px';
+        var solid = (overlayMode === 'solid');
+        if (r.fill === 'black') {
+            div.style.background = solid ? 'rgba(0, 0, 0, 1)' : 'rgba(0, 0, 0, 0.4)';
+            div.style.border = solid ? 'none' : '1px solid rgba(0, 0, 0, 0.7)';
+        } else {
+            div.style.background = solid ? 'rgba(255, 255, 255, 1)' : 'rgba(255, 255, 255, 0.5)';
+            div.style.border = solid ? 'none' : '1px solid rgba(200, 200, 200, 0.8)';
+        }
+        div.style.pointerEvents = 'auto';
+        div.style.cursor = 'pointer';
+        div.style.zIndex = '6';
+
+        var kind = (r.fill === 'white') ? 'whiteout' : 'redaction';
+        seqs[r.type] = (seqs[r.type] || 0) + 1;
+        div.title = (r.type || r.fill) + '\n' + _tagOverlayBox(
+            div, kind, r.type, pdfIndex, seqs[r.type], r
+        );
+
+        // Type label, hidden in solid mode so the preview stays faithful.
+        var label = document.createElement('span');
+        label.style.cssText = 'position:absolute;top:0;left:0;font-size:9px;padding:1px 3px;color:black;background:rgba(255,255,255,0.7);pointer-events:none;';
+        label.textContent = r.type || r.fill;
+        if (solid) label.style.display = 'none';
+        div.appendChild(label);
+
+        div.addEventListener('dblclick', function(e) {
+            e.stopPropagation();
+            _selectRedactionBox(div, pdfIndex, r, dsx, dsy);
+        });
+        return div;
+    }
+
     // Draw the margin boxes for a single page's data. Clears only that page's
     // boxes so it can be called per-render without touching other pages.
     function _drawMarginsForPageData(pageData) {
@@ -1483,9 +1618,15 @@ document.addEventListener('DOMContentLoaded', function () {
         var msx = canvas.offsetWidth / vp.width;
         var msy = canvas.offsetHeight / vp.height;
 
+        var marginSeq = 0;
         pageData.rects.forEach(function(r) {
                 var div = document.createElement('div');
                 div.className = 'margin-overlay-box';
+                marginSeq += 1;
+                div.title = 'margin whiteout\n' + _tagOverlayBox(
+                    div, 'whiteout', 'margin', pageData.page_index,
+                    marginSeq, r, 'pt'
+                );
                 div.style.position = 'absolute';
                 div.style.left = (r.x0 * msx) + 'px';
                 div.style.top = (r.y0 * msy) + 'px';
@@ -1584,55 +1725,15 @@ document.addEventListener('DOMContentLoaded', function () {
             if (!canvas.width || canvas.width < 10) return;
 
             // Rects are in image pixel coords — same scaling as detection overlay
-            var imgW = cachedImgW || 1, imgH = cachedImgH || 1;
-            if (allDetections) {
-                for (var di = 0; di < allDetections.length; di++) {
-                    if (allDetections[di].page_index === pageData.page_index) {
-                        imgW = allDetections[di].img_width || imgW;
-                        imgH = allDetections[di].img_height || imgH;
-                        break;
-                    }
-                }
-                if (imgW <= 1 && allDetections.length > 0) {
-                    imgW = allDetections[0].img_width || 1;
-                    imgH = allDetections[0].img_height || 1;
-                }
-                // Update cache
-                if (imgW > 1) { cachedImgW = imgW; cachedImgH = imgH; }
-            }
-            var dsx = canvas.offsetWidth / imgW;
-            var dsy = canvas.offsetHeight / imgH;
+            var dims = _imgDimsForPage(pageData.page_index);
+            var dsx = canvas.offsetWidth / dims[0];
+            var dsy = canvas.offsetHeight / dims[1];
 
+            var seqs = {};
             pageData.rects.forEach(function(r) {
-                var div = document.createElement('div');
-                div.className = 'redaction-overlay-box';
-                div.dataset.fill = r.fill || 'black';
-                div.style.position = 'absolute';
-                div.style.left = (r.x0 * dsx) + 'px';
-                div.style.top = (r.y0 * dsy) + 'px';
-                div.style.width = ((r.x1 - r.x0) * dsx) + 'px';
-                div.style.height = ((r.y1 - r.y0) * dsy) + 'px';
-                var solid = (overlayMode === 'solid');
-                if (r.fill === 'black') {
-                    div.style.background = solid ? 'rgba(0, 0, 0, 1)' : 'rgba(0, 0, 0, 0.4)';
-                    div.style.border = solid ? 'none' : '1px solid rgba(0, 0, 0, 0.7)';
-                } else {
-                    div.style.background = solid ? 'rgba(255, 255, 255, 1)' : 'rgba(255, 255, 255, 0.5)';
-                    div.style.border = solid ? 'none' : '1px solid rgba(200, 200, 200, 0.8)';
-                }
-                div.style.pointerEvents = 'auto';
-                div.style.cursor = 'pointer';
-                div.style.zIndex = '6';
-                // Show label only on hover
-                div.title = r.type || r.fill;
-
-                // Double-click to select for editing
-                div.addEventListener('dblclick', function(e) {
-                    e.stopPropagation();
-                    _selectRedactionBox(div, pageData.page_index, r, dsx, dsy);
-                });
-
-                wrapper.appendChild(div);
+                wrapper.appendChild(
+                    _makeRedactionBox(r, pageData.page_index, dsx, dsy, seqs)
+                );
             });
         });
     }
@@ -1861,53 +1962,15 @@ document.addEventListener('DOMContentLoaded', function () {
         // Remove existing boxes for this page
         wrapper.querySelectorAll('.redaction-overlay-box').forEach(function(el) { el.remove(); });
 
-        var imgW = cachedImgW || 1, imgH = cachedImgH || 1;
-        if (allDetections) {
-            for (var di = 0; di < allDetections.length; di++) {
-                if (allDetections[di].page_index === pdfIndex) {
-                    imgW = allDetections[di].img_width || imgW;
-                    imgH = allDetections[di].img_height || imgH;
-                    break;
-                }
-            }
-            if (imgW <= 1 && allDetections.length > 0) {
-                imgW = allDetections[0].img_width || 1;
-                imgH = allDetections[0].img_height || 1;
-            }
-            if (imgW > 1) { cachedImgW = imgW; cachedImgH = imgH; }
-        }
-        var dsx = canvas.offsetWidth / imgW;
-        var dsy = canvas.offsetHeight / imgH;
+        var dims = _imgDimsForPage(pdfIndex);
+        var dsx = canvas.offsetWidth / dims[0];
+        var dsy = canvas.offsetHeight / dims[1];
 
+        var seqs = {};
         pageData.rects.forEach(function(r) {
-            var div = document.createElement('div');
-            div.className = 'redaction-overlay-box';
-            div.style.position = 'absolute';
-            div.style.left = (r.x0 * dsx) + 'px';
-            div.style.top = (r.y0 * dsy) + 'px';
-            div.style.width = ((r.x1 - r.x0) * dsx) + 'px';
-            div.style.height = ((r.y1 - r.y0) * dsy) + 'px';
-            var solid = (overlayMode === 'solid');
-            if (r.fill === 'black') {
-                div.style.background = solid ? 'rgba(0, 0, 0, 1)' : 'rgba(0, 0, 0, 0.4)';
-                div.style.border = solid ? 'none' : '1px solid rgba(0, 0, 0, 0.7)';
-            } else {
-                div.style.background = solid ? 'rgba(255, 255, 255, 1)' : 'rgba(255, 255, 255, 0.5)';
-                div.style.border = solid ? 'none' : '1px solid rgba(200, 200, 200, 0.8)';
-            }
-            div.style.pointerEvents = 'auto';
-            div.style.cursor = 'pointer';
-            div.style.zIndex = '6';
-            var label = document.createElement('span');
-            label.style.cssText = 'position:absolute;top:0;left:0;font-size:9px;padding:1px 3px;color:black;background:rgba(255,255,255,0.7);pointer-events:none;';
-            label.textContent = r.type || r.fill;
-            if (solid) label.style.display = 'none';
-            div.appendChild(label);
-            div.addEventListener('dblclick', function(e) {
-                e.stopPropagation();
-                _selectRedactionBox(div, pdfIndex, r, dsx, dsy);
-            });
-            wrapper.appendChild(div);
+            wrapper.appendChild(
+                _makeRedactionBox(r, pdfIndex, dsx, dsy, seqs)
+            );
         });
     }
 

--- a/scanning/tests/pdf_fixtures.py
+++ b/scanning/tests/pdf_fixtures.py
@@ -1,0 +1,219 @@
+"""Builders for small synthetic PDFs used by the geometry tests.
+
+The pipeline's PDFs come in two flavors and the geometry code has to work
+with both: a page with a real text layer, and a ``bitonal.pdf``-style page
+that is a single 1-bit image with no text at all. These helpers produce
+both, plus the scanner artifacts (a solid band along a page edge) that the
+ink measurements have to ignore.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import fitz
+from PIL import Image
+
+PAGE_W, PAGE_H = 612.0, 792.0
+
+# Box the synthetic body text is laid out in, in PDF points.
+CONTENT = fitz.Rect(72, 100, 540, 700)
+
+BODY_SENTENCE = (
+    "The judgment of the district court is affirmed in part and reversed "
+    "in part, and the cause is remanded for further proceedings. "
+)
+
+# Body text is drawn line by line rather than with ``insert_textbox``,
+# which inserts nothing at all when the text overflows its rect. Lines are
+# laid out on this leading so they fill CONTENT top to bottom, and each is
+# cut to CONTENT's width, so a clip over any part of the box lands on text.
+LINE_LEADING = 12.0
+FONT_SIZE = 9.0
+
+# A single line of text above the body block, like a running head. The gap
+# between it and the body is blank but sits *inside* the page's content
+# box, which is where empty redaction rects used to come from.
+HEADER_LINE_Y = 58.0
+HEADER_TEXT = "FRATERNAL ORDER OF POLICE v. BOARD OF GOVERNORS"
+
+# A solid black band along the top edge, like a platen shadow.
+TOP_BAR = fitz.Rect(0, 4, PAGE_W, 12)
+
+# A small blob at the top-right corner, like a page number bleeding through
+# from the facing page. Close enough to the header that ink alone treats it
+# as content, which is what suppressed the top margin strip.
+BLEED_MARK = fitz.Rect(470, 2, 530, 14)
+
+# A speck in the left margin, close enough to the text that the ink content
+# box takes it in (further out and ``ink.content_box`` discards it as its
+# own low-mass run), which is how a real gutter smudge widens the box and
+# shrinks the strip on that side.
+STRAY_MARK = fitz.Rect(45, 400, 52, 407)
+
+# A page number printed in the outer corner, outside the text columns --
+# real content that a tightened side strip must not reach.
+CORNER_NUMBER_X = 40.0
+
+# ...and along the bottom edge, where it sits well below the last line of
+# text (the case that stretched ink measurements to the page edge).
+BOTTOM_BAR = fitz.Rect(120, PAGE_H - 10, 500, PAGE_H - 4)
+
+
+def _line_for_width(width: float) -> str:
+    """Return a body-text line that just fits ``width`` at FONT_SIZE.
+
+    :param width: Target line width in PDF points.
+    :return: The line text.
+    """
+    text = BODY_SENTENCE
+    while fitz.get_text_length(text, fontsize=FONT_SIZE) < width:
+        text += BODY_SENTENCE
+    while fitz.get_text_length(text, fontsize=FONT_SIZE) > width:
+        text = text[:-1]
+    return text
+
+
+def write_text_page(
+    path: Path,
+    top_bar: bool = False,
+    bottom_bar: bool = False,
+    header_line: bool = False,
+    bleed_mark: bool = False,
+    stray_mark: bool = False,
+    corner_number: bool = False,
+) -> None:
+    """Write a one-page PDF with real text filling :data:`CONTENT`.
+
+    :param path: Where to write the PDF.
+    :param top_bar: Paint :data:`TOP_BAR`.
+    :param bottom_bar: Paint :data:`BOTTOM_BAR`.
+    :param header_line: Also draw :data:`HEADER_TEXT` above the body, so
+        the page has a blank gap inside its content box.
+    :param bleed_mark: Paint :data:`BLEED_MARK`.
+    :param stray_mark: Paint :data:`STRAY_MARK`.
+    :param corner_number: Print a page number at :data:`CORNER_NUMBER_X`,
+        outside the text columns.
+    """
+    line = _line_for_width(CONTENT.width)
+    with fitz.open() as doc:
+        page = doc.new_page(width=PAGE_W, height=PAGE_H)
+        if header_line:
+            page.insert_text(
+                (CONTENT.x0, HEADER_LINE_Y), HEADER_TEXT, fontsize=FONT_SIZE
+            )
+        if corner_number:
+            page.insert_text(
+                (CORNER_NUMBER_X, HEADER_LINE_Y), "12", fontsize=FONT_SIZE
+            )
+        y = CONTENT.y0 + FONT_SIZE
+        while y <= CONTENT.y1:
+            page.insert_text((CONTENT.x0, y), line, fontsize=FONT_SIZE)
+            y += LINE_LEADING
+        for draw, rect in (
+            (top_bar, TOP_BAR),
+            (bottom_bar, BOTTOM_BAR),
+            (bleed_mark, BLEED_MARK),
+            (stray_mark, STRAY_MARK),
+        ):
+            if draw:
+                page.draw_rect(rect, fill=(0, 0, 0), width=0)
+        doc.save(str(path))
+
+
+def rasterize(src: Path, dst: Path) -> None:
+    """Rebuild a PDF as one 1-bit image per page, like ``bitonal.pdf``.
+
+    The result has no text layer, so anything measuring the page has to
+    read its pixels.
+
+    :param src: Source PDF to rasterize.
+    :param dst: Where to write the rasterized PDF.
+    """
+    with fitz.open(str(src)) as doc, fitz.open() as out:
+        for page_idx in range(len(doc)):
+            src_page = doc[page_idx]
+            pix = src_page.get_pixmap(dpi=200, colorspace=fitz.csGRAY)
+            img = Image.frombytes(
+                "L", (pix.width, pix.height), pix.samples
+            ).convert("1")
+            buf = io.BytesIO()
+            img.save(buf, format="TIFF", compression="group4")
+            page = out.new_page(
+                width=src_page.rect.width, height=src_page.rect.height
+            )
+            page.insert_image(page.rect, stream=buf.getvalue())
+        out.save(str(dst))
+
+
+def write_bitonal_page(
+    path: Path,
+    top_bar: bool = False,
+    bottom_bar: bool = False,
+    header_line: bool = False,
+    bleed_mark: bool = False,
+    stray_mark: bool = False,
+    corner_number: bool = False,
+    tmp_dir: Path | None = None,
+) -> None:
+    """Write a text-less, 1-bit version of :func:`write_text_page`.
+
+    :param path: Where to write the PDF.
+    :param top_bar: Paint :data:`TOP_BAR` before rasterizing.
+    :param bottom_bar: Paint :data:`BOTTOM_BAR` before rasterizing.
+    :param header_line: Draw :data:`HEADER_TEXT` above the body.
+    :param bleed_mark: Paint :data:`BLEED_MARK` before rasterizing.
+    :param stray_mark: Paint :data:`STRAY_MARK` before rasterizing.
+    :param corner_number: Print a page number outside the text columns.
+    :param tmp_dir: Directory for the intermediate text PDF. Defaults to
+        ``path``'s parent.
+    """
+    tmp_dir = tmp_dir or path.parent
+    src = tmp_dir / f"{path.stem}.text.pdf"
+    write_text_page(
+        src,
+        top_bar=top_bar,
+        bottom_bar=bottom_bar,
+        header_line=header_line,
+        bleed_mark=bleed_mark,
+        stray_mark=stray_mark,
+        corner_number=corner_number,
+    )
+    rasterize(src, path)
+
+
+# Two text bands with a hairline gutter between them, like a tightly set
+# reporter page. A gutter this narrow is what let an ink measurement walk
+# straight across it into the neighbouring column.
+COLUMN_GAP = 1.5
+COLUMN_LEFT = fitz.Rect(72, 100, 300, 700)
+COLUMN_RIGHT = fitz.Rect(COLUMN_LEFT.x1 + COLUMN_GAP, 100, 540, 700)
+
+
+def write_two_column_page(path: Path, tmp_dir: Path | None = None) -> None:
+    """Write a text-less, 1-bit page holding two columns of text lines.
+
+    Lines are drawn as thin filled rects rather than glyphs so the bands
+    have exact, predictable edges.
+
+    :param path: Where to write the PDF.
+    :param tmp_dir: Directory for the intermediate PDF. Defaults to
+        ``path``'s parent.
+    """
+    tmp_dir = tmp_dir or path.parent
+    src = tmp_dir / f"{path.stem}.text.pdf"
+    with fitz.open() as doc:
+        page = doc.new_page(width=PAGE_W, height=PAGE_H)
+        for band in (COLUMN_LEFT, COLUMN_RIGHT):
+            y = band.y0
+            while y < band.y1:
+                page.draw_rect(
+                    fitz.Rect(band.x0, y, band.x1, y + 4),
+                    color=None,
+                    fill=(0, 0, 0),
+                    width=0,
+                )
+                y += LINE_LEADING
+        doc.save(str(src))
+    rasterize(src, path)

--- a/scanning/tests/test_s3_sync.py
+++ b/scanning/tests/test_s3_sync.py
@@ -15,6 +15,25 @@ from scanning.models import Status
 MEDIA_ROOT = tempfile.mkdtemp()
 
 
+def _fake_download(bucket, key, dest):
+    """Stand in for ``boto3``'s ``download_file``, including its temp file.
+
+    s3transfer writes to ``<dest>.<random>`` in the destination's own
+    directory and renames it into place, so downloading into a directory
+    that does not exist yet fails on that temp name. Creating the parent
+    here instead would make every caller look correct.
+
+    :param bucket: Unused; matches the signature being faked.
+    :param key: Unused; matches the signature being faked.
+    :param dest: Local path to write to.
+    """
+    del bucket, key
+    dest = pathlib.Path(dest)
+    tmp = dest.with_suffix(dest.suffix + ".abc12345")
+    tmp.write_bytes(b"12345")
+    tmp.replace(dest)
+
+
 def _reporter_scan(**kwargs):
     """Build a scan with a reporter for predictable S3 prefixes.
 
@@ -207,9 +226,6 @@ class TestSyncHelpersWithCredentials(TestCase):
         ]
         mock_s3.get_paginator.return_value = mock_paginator
 
-        def _fake_download(bucket, key, dest):
-            pathlib.Path(dest).write_bytes(b"12345")
-
         mock_s3.download_file.side_effect = _fake_download
 
         with patch("scanning.s3_sync.boto3") as mock_boto3:
@@ -223,6 +239,52 @@ class TestSyncHelpersWithCredentials(TestCase):
             mock_s3.download_file.call_args.args[1],
             f"{prefix}bitonal.pdf",
         )
+
+    def test_download_processing_file_pulls_only_that_key(self):
+        """Serving one generated file must not drag the whole prefix.
+
+        A full volume's prefix runs to gigabytes (the original, every
+        opinion, every LLM page), and under ASGI one long sync pull stalls
+        every other request in the process.
+        """
+        scan = _reporter_scan()
+        scan.status = Status.PENDING_REVIEW
+        scan.save(update_fields=["status"])
+
+        prefix = s3_sync.s3_processing_prefix(scan)
+        wanted = "redacted/a.164.0001-0027.pdf"
+        mock_s3 = MagicMock()
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [
+            {
+                "Contents": [
+                    {"Key": f"{prefix}{wanted}", "Size": 5},
+                    {
+                        "Key": f"{prefix}redacted/a.164.0028-0031.pdf",
+                        "Size": 5,
+                    },
+                    {"Key": f"{prefix}a.164.1.31.original.pdf", "Size": 9999},
+                    {"Key": f"{prefix}llm/page_0001.pdf", "Size": 5},
+                ]
+            }
+        ]
+        mock_s3.get_paginator.return_value = mock_paginator
+
+        mock_s3.download_file.side_effect = _fake_download
+
+        with patch("scanning.s3_sync.boto3") as mock_boto3:
+            mock_boto3.client.return_value = mock_s3
+            result = s3_sync.download_processing_file(scan, wanted)
+
+        self.assertEqual(mock_s3.download_file.call_count, 1)
+        self.assertEqual(
+            mock_s3.download_file.call_args.args[1], f"{prefix}{wanted}"
+        )
+        # The deliverables live in subdirectories, and nothing has created
+        # them on a machine that only ever served this one file, so the
+        # pull has to. Without it the download fails on its own temp file
+        # and the request 404s with the object sitting in S3.
+        self.assertTrue((pathlib.Path(result) / wanted).is_file())
 
     def test_download_preview_pdf_skips_original_and_images(self):
         """Only the bitonal/OCR preview is pulled, not original or images."""
@@ -247,10 +309,6 @@ class TestSyncHelpersWithCredentials(TestCase):
             }
         ]
         mock_s3.get_paginator.return_value = mock_paginator
-
-        def _fake_download(bucket, key, dest):
-            pathlib.Path(dest).parent.mkdir(parents=True, exist_ok=True)
-            pathlib.Path(dest).write_bytes(b"12345")
 
         mock_s3.download_file.side_effect = _fake_download
 

--- a/scanning/tests/test_services.py
+++ b/scanning/tests/test_services.py
@@ -1595,7 +1595,7 @@ class TestBuildCombinedRedactionsStaleRects(TestCase):
             with self.assertRaises(RuntimeError) as caught:
                 services._build_combined_redactions(scan.pk)
             self.assertIn(
-                "Recompute the redaction rects", str(caught.exception)
+                "Re-add a detection on that page", str(caught.exception)
             )
 
 

--- a/scanning/tests/test_services.py
+++ b/scanning/tests/test_services.py
@@ -9,8 +9,9 @@ import shutil
 import tempfile
 from unittest.mock import patch
 
+import fitz
 from django.db.models import F
-from django.test import TestCase, override_settings
+from django.test import SimpleTestCase, TestCase, override_settings
 
 from scanning import s3_sync
 from scanning.factories import (
@@ -26,6 +27,17 @@ from scanning.models import (
     Status,
 )
 from scanning.services import refresh_volume_queue_status
+from scanning.tests.pdf_fixtures import (
+    BOTTOM_BAR,
+    COLUMN_LEFT,
+    COLUMN_RIGHT,
+    CONTENT,
+    PAGE_H,
+    PAGE_W,
+    write_bitonal_page,
+    write_text_page,
+    write_two_column_page,
+)
 
 FIXTURE_DIR = pathlib.Path(__file__).parent / "fixtures"
 PDF_PATH = FIXTURE_DIR / "a3d.332.1.1.pdf"
@@ -69,9 +81,23 @@ def _make_scan_with_output(tmpdir=None, **kwargs):
 
     # If a tmpdir was provided, copy fixture files there too
     if tmpdir:
-        shutil.copy2(PDF_PATH, pathlib.Path(tmpdir) / "bitonal.pdf")
-        shutil.copy2(PDF_PATH, output / "bitonal.pdf")
+        _write_bitonal_copy(pathlib.Path(tmpdir) / "bitonal.pdf")
+        _write_bitonal_copy(output / "bitonal.pdf")
     return scan
+
+
+def _write_bitonal_copy(dest):
+    """Copy the fixture as ``bitonal.pdf``, distinguishable from the original.
+
+    The processing PDF and the original are the same fixture, so a step that
+    reads the multi-GB original where it should read the small processing
+    copy produces byte-identical output and no test can tell. A trailing
+    comment (ignored by every PDF reader, since it sits after ``%%EOF``)
+    makes "which PDF did this read" assertable.
+    """
+    shutil.copy2(PDF_PATH, dest)
+    with open(dest, "ab") as fh:
+        fh.write(b"\n% bitonal\n")
 
 
 def _run_detect_on_fixture(tmpdir):
@@ -266,6 +292,32 @@ class TestComputeAndSaveRedactionRects(TestCase):
             scan.refresh_from_db()
             self.assertTrue(scan.redaction_rects)
 
+    def test_corrects_the_column_boxes_before_measuring(self):
+        """The rects and the margins must read the same column boxes.
+
+        Margin strips are computed from ink-corrected columns. A reviewer
+        who hand-draws a missed ``TEXT_COLUMN`` puts it in the DB exactly as
+        drawn, so without this the headnote rects on that page would snap to
+        the raw box while the margins used the corrected one.
+        """
+        from scanning import services
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scan = _make_scan_with_output(
+                tmpdir,
+                reporter=ReporterFactory(short_name="a3d"),
+            )
+            _run_detect_on_fixture(tmpdir)
+            services._import_detections_from_json(scan.pk, tmpdir)
+
+            with patch.object(services, "snap_document_columns") as snap:
+                services._compute_and_save_redaction_rects(
+                    scan.pk, str(PDF_PATH)
+                )
+            snap.assert_called_once()
+            document = snap.call_args.args[0]
+            self.assertTrue(document.pages, "snapped an empty document")
+
 
 @override_settings(MEDIA_ROOT=MEDIA_ROOT)
 class TestComputeAndSaveMarginRects(TestCase):
@@ -273,6 +325,23 @@ class TestComputeAndSaveMarginRects(TestCase):
 
     def setUp(self):
         _require_fixture(self)
+
+    @staticmethod
+    def _with_column(scan):
+        """Give a scan the one detection the margin bounds need."""
+        Detection.objects.create(
+            scan=scan,
+            page_index=0,
+            label="TEXT_COLUMN",
+            label_id=16,
+            confidence=0.95,
+            x0=100,
+            y0=200,
+            x1=1600,
+            y1=2000,
+            img_width=1700,
+            img_height=2200,
+        )
 
     def test_writes_margin_rects_to_model(self):
         from scanning.services import _compute_and_save_margin_rects
@@ -282,6 +351,7 @@ class TestComputeAndSaveMarginRects(TestCase):
                 tmpdir,
                 reporter=ReporterFactory(short_name="a3d"),
             )
+            self._with_column(scan)
             rects = _compute_and_save_margin_rects(
                 scan.pk, str(PDF_PATH), tmpdir
             )
@@ -298,6 +368,7 @@ class TestComputeAndSaveMarginRects(TestCase):
                 tmpdir,
                 reporter=ReporterFactory(short_name="a3d"),
             )
+            self._with_column(scan)
             first = _compute_and_save_margin_rects(
                 scan.pk, str(PDF_PATH), tmpdir
             )
@@ -305,6 +376,75 @@ class TestComputeAndSaveMarginRects(TestCase):
                 scan.pk, str(PDF_PATH), tmpdir
             )
             self.assertEqual(first, second)
+
+    def test_does_not_cache_a_result_computed_without_detections(self):
+        """Margins measured from marks alone lose a page's top strip.
+
+        detections.json belongs to whichever process ran the pipeline, and
+        ``/tmp`` is per-container in dev and per-pod in production, so a
+        viewer request can arrive before this machine has it. Caching that
+        answer means it is never recomputed once the detections land.
+        """
+        from scanning.services import _compute_and_save_margin_rects
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scan = _make_scan_with_output(
+                tmpdir,
+                reporter=ReporterFactory(short_name="a3d"),
+            )
+            rects = _compute_and_save_margin_rects(
+                scan.pk, str(PDF_PATH), tmpdir
+            )
+            self.assertIsNotNone(rects)
+
+            scan.refresh_from_db()
+            self.assertFalse(scan.margin_rects, "cached a detection-less run")
+
+            # ...and once the detections exist, the next call caches.
+            self._with_column(scan)
+            _compute_and_save_margin_rects(scan.pk, str(PDF_PATH), tmpdir)
+            scan.refresh_from_db()
+            self.assertTrue(scan.margin_rects)
+
+    def test_reads_detections_from_the_db_not_the_file(self):
+        """The DB is the source of truth, and is always reachable."""
+        from scanning.services import _detections_for_geometry
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scan = _make_scan_with_output(
+                tmpdir,
+                reporter=ReporterFactory(short_name="a3d"),
+            )
+            self._with_column(scan)
+            # No detections.json anywhere near this scan.
+            self.assertFalse(
+                (pathlib.Path(scan.output_dir) / "detections.json").exists()
+            )
+            dets = _detections_for_geometry(scan.pk, scan.output_dir)
+            self.assertEqual([d["label"] for d in dets], ["TEXT_COLUMN"])
+            self.assertEqual(dets[0]["bbox"], [100, 200, 1600, 2000])
+
+    def test_does_not_measure_anything_without_detections(self):
+        """Refuse before rendering, not after.
+
+        The viewer asks for these on a sync request and does not cache the
+        reply, so measuring a result that is then thrown away un-cached
+        renders the whole volume at 100 dpi on every poll, in the executor
+        every other sync view shares.
+        """
+        from scanning import services
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scan = _make_scan_with_output(
+                tmpdir,
+                reporter=ReporterFactory(short_name="a3d"),
+            )
+            with patch.object(services, "compute_margin_rects") as measure:
+                rects = services._compute_and_save_margin_rects(
+                    scan.pk, str(PDF_PATH), tmpdir
+                )
+            measure.assert_not_called()
+            self.assertEqual(rects, [])
 
 
 @override_settings(MEDIA_ROOT=MEDIA_ROOT)
@@ -1129,28 +1269,751 @@ class TestImmediateS3PushOnGeneration(TestCase):
         bitonal.assert_not_called()
         push.assert_not_called()
 
-    def test_run_ocr_pushes_generated_pdf(self):
-        """The OCR PDF is uploaded immediately after it's produced."""
+
+@override_settings(MEDIA_ROOT=MEDIA_ROOT)
+class TestGenerateFilesWithoutOcrPdf(TestCase):
+    """``run_generate_files`` works from ``bitonal.pdf`` alone.
+
+    The pipeline no longer produces an OCR'd PDF, so generation has to
+    build on the processing PDF instead of refusing to run.
+    """
+
+    def setUp(self):
+        _require_fixture(self)
+
+    def test_generates_from_bitonal(self):
         from scanning import services
 
-        scan = ScanFactory(start_page=1, end_page=2)
+        scan = _make_scan_with_output(
+            reporter=ReporterFactory(short_name="a3d"),
+        )
         output = pathlib.Path(scan.output_dir)
-        output.mkdir(parents=True, exist_ok=True)
-        ocr_pdf = output / "rep.1.1.2.pdf"
+        bitonal = output / "bitonal.pdf"
+        _write_bitonal_copy(bitonal)
+        scan.opinions_json = [
+            {
+                "caption_page": 0,
+                "key_page": 0,
+                "end_page": 0,
+                "page_count": 1,
+                "first_page_number": 1,
+                "last_page_number": 1,
+            }
+        ]
+        scan.save(update_fields=["opinions_json"])
 
         with (
-            patch.object(services, "_ocr", return_value=ocr_pdf),
-            patch.object(services, "_push_generated_file_to_s3") as push,
-            patch.object(services.fitz, "open") as fitz_open,
+            # close_all() resets connections for daemon-process forking;
+            # in tests it kills the test transaction -- patch it out.
+            patch("django.db.connections.close_all"),
+            patch("blackletter.api.generate") as generate,
+            patch.object(services, "_push_processing_files_to_s3"),
+            patch.object(services, "_pull_processing_files_from_s3"),
         ):
-            fitz_open.return_value.__enter__.return_value.page_count = 2
-            services._run_ocr(
-                scan.pk,
-                "in.pdf",
-                str(output),
-                reporter="rep",
-                volume="1",
-                first_page=1,
+            generate.return_value = {
+                "opinion_count": 1,
+                "full_redacted": "",
+                "redacted_dir": str(output / "redacted"),
+            }
+            services.run_generate_files(scan.pk)
+
+        generate.assert_called_once()
+        gen_pdf = pathlib.Path(generate.call_args.kwargs["pdf_path"])
+        # Generation runs on a stamped *copy* of the bitonal, never on
+        # the bitonal itself.
+        self.assertEqual(gen_pdf.name, "stamped.pdf")
+        self.assertEqual(gen_pdf.read_bytes(), bitonal.read_bytes())
+
+        scan.refresh_from_db()
+        self.assertEqual(scan.stage, Stage.APPROVED)
+        self.assertEqual(scan.status, Status.PENDING_REVIEW)
+
+    def test_computes_margins_when_absent(self):
+        """Whiteouts must not depend on the viewer having asked for them.
+
+        Margin rects are computed on demand elsewhere, so a scan taken
+        straight from review to Generate used to ship with no whiteouts at
+        all -- platen bands, fold shadows and corner bleed left in the
+        deliverable.
+        """
+        from scanning import services
+
+        scan = _make_scan_with_output(
+            reporter=ReporterFactory(short_name="a3d"),
+        )
+        output = pathlib.Path(scan.output_dir)
+        shutil.copy2(PDF_PATH, output / "bitonal.pdf")
+        self.assertFalse(scan.margin_rects)
+        # A scan reaching Generate has been detected, and the margin bounds
+        # are only cached once detections back them up.
+        Detection.objects.create(
+            scan=scan,
+            page_index=0,
+            label="TEXT_COLUMN",
+            label_id=16,
+            confidence=0.95,
+            x0=100,
+            y0=200,
+            x1=1600,
+            y1=2000,
+            img_width=1700,
+            img_height=2200,
+        )
+
+        with (
+            patch("django.db.connections.close_all"),
+            patch("blackletter.api.generate") as generate,
+            patch.object(services, "_push_processing_files_to_s3"),
+            patch.object(services, "_pull_processing_files_from_s3"),
+        ):
+            generate.return_value = {
+                "opinion_count": 0,
+                "full_redacted": "",
+                "redacted_dir": str(output / "redacted"),
+            }
+            services.run_generate_files(scan.pk)
+
+        scan.refresh_from_db()
+        self.assertTrue(scan.margin_rects, "no margin rects computed")
+        self.assertTrue(
+            any(e["rects"] for e in scan.margin_rects),
+            "margin rects are all empty",
+        )
+
+    def test_raises_without_any_processing_pdf(self):
+        """An empty output dir is still an error, just a clearer one."""
+        from scanning import services
+
+        scan = _make_scan_with_output(
+            reporter=ReporterFactory(short_name="a3d"),
+        )
+        with (
+            patch("django.db.connections.close_all"),
+            patch.object(services, "_pull_processing_files_from_s3"),
+            patch.object(services, "_handle_pipeline_exception") as handler,
+        ):
+            services.run_generate_files(scan.pk)
+
+        handler.assert_called_once()
+        self.assertIn("bitonal.pdf", str(handler.call_args.args[1]))
+
+
+class TestRedactionGeometryFromInk(SimpleTestCase):
+    """The library contract this app now depends on for headnote rects.
+
+    The app used to patch ``blackletter.process``'s text-bound helpers from
+    here, because ``_text_bottom`` returned ``clip.y0`` on a page with no
+    words, which collapsed every headnote rect and dropped it: a text-less
+    ``bitonal.pdf`` produced *no* headnote rects while every other rect type
+    came out unchanged. blackletter measures ink itself now (#68), keyed off
+    ``Document.ocr_applied``, which ``_build_document_from_detections``
+    always sets. These tests pin that contract, so a library release that
+    regressed it would fail here rather than silently ship empty redactions.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmp = pathlib.Path(self._tmp.name)
+
+    def test_bottom_comes_from_the_ink_without_a_text_layer(self):
+        from blackletter.scanner import _text_bottom
+
+        pdf = self.tmp / "bitonal.pdf"
+        write_bitonal_page(pdf)
+        clip = fitz.Rect(CONTENT.x0, CONTENT.y0, CONTENT.x1, PAGE_H)
+        with fitz.open(str(pdf)) as doc:
+            bottom = _text_bottom(doc[0], clip)
+        self.assertGreater(bottom, clip.y0, "headnote rects would collapse")
+        self.assertAlmostEqual(bottom, CONTENT.y1, delta=8.0)
+
+    def test_ocr_applied_prefers_ink_over_our_own_word_boxes(self):
+        """Documents are built with ``ocr_applied=True``, which selects ink."""
+        from blackletter.scanner import _tighten_to_text
+
+        pdf = self.tmp / "text.pdf"
+        write_text_page(pdf, bottom_bar=True)
+        rect = fitz.Rect(0, 0, PAGE_W, PAGE_H)
+        with fitz.open(str(pdf)) as doc:
+            tight = _tighten_to_text(doc[0], rect, ocr_applied=True)
+        self.assertIsNotNone(tight)
+        # The platen band at the page foot is outside the content box, so
+        # ink measurement stops at the last line of text instead.
+        self.assertLess(tight.y1, BOTTOM_BAR.y0)
+
+    def test_side_bounds_are_not_narrowed_from_ink(self):
+        """Shrinking a headnote rect horizontally is the unsafe direction."""
+        from blackletter.scanner import _text_x_bounds
+
+        pdf = self.tmp / "bitonal.pdf"
+        write_bitonal_page(pdf)
+        clip = fitz.Rect(CONTENT.x0 - 20, 200, CONTENT.x1 + 20, 400)
+        with fitz.open(str(pdf)) as doc:
+            left, right = _text_x_bounds(doc[0], clip)
+        self.assertEqual((left, right), (clip.x0, clip.x1))
+
+
+class TestSnapTextColumnsToInk(TestCase):
+    """``_snap_text_columns_to_ink`` corrects the column boxes at the source.
+
+    YOLO's ``TEXT_COLUMN`` boxes land slightly inside the printed text, and
+    three consumers depend on them: headnote rects snap their x-bounds to
+    these boxes, margin strips take them as the text band, and the
+    outside-opinion masks white out whole columns with them. Widening the
+    boxes once means none of those has to compensate.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.pdf = pathlib.Path(self._tmp.name) / "two_col.pdf"
+        write_two_column_page(self.pdf)
+        self.scan = ScanFactory(reporter=ReporterFactory(short_name="a3d"))
+
+    def _column(self, x0, x1, y0=100.0, y1=700.0):
+        """A TEXT_COLUMN detection, in image pixels == PDF points."""
+        return Detection.objects.create(
+            scan=self.scan,
+            page_index=0,
+            label="TEXT_COLUMN",
+            label_id=16,
+            confidence=0.97,
+            x0=x0,
+            y0=y0,
+            x1=x1,
+            y1=y1,
+            img_width=PAGE_W,
+            img_height=PAGE_H,
+        )
+
+    def test_widens_a_narrow_box_to_the_text(self):
+        from scanning.services import _snap_text_columns_to_ink
+
+        det = self._column(COLUMN_LEFT.x0 + 6, COLUMN_LEFT.x1 - 6)
+        changed = _snap_text_columns_to_ink(self.scan.pk, str(self.pdf))
+        det.refresh_from_db()
+        self.assertEqual(changed, 1)
+        self.assertAlmostEqual(det.x0, COLUMN_LEFT.x0, delta=2.0)
+        self.assertAlmostEqual(det.x1, COLUMN_LEFT.x1, delta=2.0)
+
+    def test_leaves_the_vertical_bounds_alone(self):
+        """Only x is consumed; y feeds nothing and must not move."""
+        from scanning.services import _snap_text_columns_to_ink
+
+        det = self._column(COLUMN_LEFT.x0 + 6, COLUMN_LEFT.x1 - 6, 150, 650)
+        _snap_text_columns_to_ink(self.scan.pk, str(self.pdf))
+        det.refresh_from_db()
+        self.assertEqual((det.y0, det.y1), (150, 650))
+
+    def test_does_not_cross_the_gutter(self):
+        """A box may not grow into its neighbour's column."""
+        from scanning.services import _snap_text_columns_to_ink
+
+        left = self._column(COLUMN_LEFT.x0, COLUMN_LEFT.x1)
+        right = self._column(COLUMN_RIGHT.x0, COLUMN_RIGHT.x1)
+        _snap_text_columns_to_ink(self.scan.pk, str(self.pdf))
+        left.refresh_from_db()
+        right.refresh_from_db()
+        self.assertLessEqual(
+            left.x1, right.x0, f"columns overlap: {left.x1} > {right.x0}"
+        )
+
+    def test_is_idempotent(self):
+        from scanning.services import _snap_text_columns_to_ink
+
+        self._column(COLUMN_LEFT.x0 + 6, COLUMN_LEFT.x1 - 6)
+        self._column(COLUMN_RIGHT.x0 + 6, COLUMN_RIGHT.x1 - 6)
+        first = _snap_text_columns_to_ink(self.scan.pk, str(self.pdf))
+        second = _snap_text_columns_to_ink(self.scan.pk, str(self.pdf))
+        self.assertEqual(first, 2)
+        self.assertEqual(second, 0, "snapping moved the boxes twice")
+
+    def test_leaves_an_inconclusive_edge_alone(self):
+        """An edge that never finds the end of the ink is not moved.
+
+        A one-column detection over a full-width table would otherwise
+        slide out by the growth limit on every run, never settling.
+        """
+        from scanning.services import _snap_text_columns_to_ink
+
+        # Inset far enough on both sides that growth runs to its limit.
+        det = self._column(COLUMN_RIGHT.x0 + 40, COLUMN_RIGHT.x1 - 40)
+        before = (det.x0, det.x1)
+        changed = _snap_text_columns_to_ink(self.scan.pk, str(self.pdf))
+        det.refresh_from_db()
+        self.assertEqual(changed, 0)
+        self.assertEqual((det.x0, det.x1), before)
+
+    def test_no_columns_is_a_no_op(self):
+        from scanning.services import _snap_text_columns_to_ink
+
+        self.assertEqual(
+            _snap_text_columns_to_ink(self.scan.pk, str(self.pdf)), 0
+        )
+
+
+@override_settings(MEDIA_ROOT=MEDIA_ROOT)
+class TestBuildCombinedRedactionsStaleRects(TestCase):
+    """Saved rects and live detections can disagree about which pages exist.
+
+    ``redaction_rects`` is a snapshot on the Scan; the pages come from the
+    detections as they stand now. Deactivating the last detection on a page
+    that a multi-page headnote block still has rects for leaves a page whose
+    pixel coordinates cannot be scaled to points.
+    """
+
+    def setUp(self):
+        _require_fixture(self)
+
+    def test_says_what_to_do_about_it(self):
+        from scanning import services
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scan = _make_scan_with_output(
+                tmpdir,
+                reporter=ReporterFactory(short_name="a3d"),
+            )
+            shutil.copy2(PDF_PATH, pathlib.Path(tmpdir) / "bitonal.pdf")
+            # Rects for page 0, and no detection anywhere to scale them by.
+            scan.redaction_rects = [
+                {
+                    "page_index": 0,
+                    "rects": [
+                        {
+                            "x0": 100,
+                            "y0": 200,
+                            "x1": 800,
+                            "y1": 400,
+                            "fill": "black",
+                            "type": "headnote",
+                        }
+                    ],
+                }
+            ]
+            scan.save(update_fields=["redaction_rects"])
+
+            with self.assertRaises(RuntimeError) as caught:
+                services._build_combined_redactions(scan.pk)
+            self.assertIn(
+                "Recompute the redaction rects", str(caught.exception)
             )
 
-        push.assert_called_once_with(scan.pk, "rep.1.1.2.pdf")
+
+@override_settings(MEDIA_ROOT=MEDIA_ROOT)
+class TestLlmPageTextLayer(TestCase):
+    """The post-redaction text layer is opt-in and never implicit.
+
+    Dropping the Tesseract pre-pass is the point of scanning #145, so
+    Generate Files must not quietly reintroduce an OCR run over every page.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.llm = pathlib.Path(self._tmp.name) / "llm"
+        self.llm.mkdir()
+        (self.llm / "page_0001.pdf").write_bytes(b"%PDF-1.4\n")
+        self.scan = ScanFactory(reporter=ReporterFactory(short_name="a3d"))
+
+    def test_off_by_default(self):
+        from scanning.services import _add_llm_page_text_layer
+
+        with patch("blackletter.api.add_text_layer") as ocr:
+            added = _add_llm_page_text_layer(self.scan.pk, self.llm)
+        ocr.assert_not_called()
+        self.assertEqual(added, 0)
+
+    @override_settings(LLM_PAGE_TEXT_LAYER=True)
+    def test_runs_over_the_llm_pages_when_switched_on(self):
+        from scanning.services import _add_llm_page_text_layer
+
+        with patch("blackletter.api.add_text_layer") as ocr:
+            ocr.return_value = [self.llm / "page_0001.pdf"]
+            added = _add_llm_page_text_layer(self.scan.pk, self.llm)
+        ocr.assert_called_once_with(self.llm)
+        self.assertEqual(added, 1)
+
+    @override_settings(LLM_PAGE_TEXT_LAYER=True)
+    def test_skips_a_scan_with_no_llm_directory(self):
+        from scanning.services import _add_llm_page_text_layer
+
+        with patch("blackletter.api.add_text_layer") as ocr:
+            added = _add_llm_page_text_layer(
+                self.scan.pk, self.llm / "missing"
+            )
+        ocr.assert_not_called()
+        self.assertEqual(added, 0)
+
+
+@override_settings(MEDIA_ROOT=MEDIA_ROOT)
+class TestBuildCombinedRedactionsPayload(TestCase):
+    """The payload ``generate`` reads mixes two coordinate spaces.
+
+    Redaction rects are stored in image pixels and margin rects in PDF
+    points, and both come out of this step in points. Getting that backwards
+    puts every blackout in the wrong place, and nothing downstream notices.
+    """
+
+    def setUp(self):
+        _require_fixture(self)
+
+    def test_pixel_rects_are_scaled_and_point_rects_are_not(self):
+        from scanning import services
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scan = _make_scan_with_output(
+                tmpdir,
+                reporter=ReporterFactory(short_name="a3d"),
+            )
+            output = pathlib.Path(scan.output_dir)
+            with fitz.open(str(output / "bitonal.pdf")) as doc:
+                page_w = doc[0].rect.width
+            # An image twice the page's width in points, so the scale is 1:2
+            # and a mistake cannot hide behind a factor of one.
+            Detection.objects.create(
+                scan=scan,
+                page_index=0,
+                label="TEXT_COLUMN",
+                label_id=16,
+                confidence=0.95,
+                x0=100,
+                y0=200,
+                x1=800,
+                y1=400,
+                img_width=int(page_w * 2),
+                img_height=2200,
+            )
+            scan.redaction_rects = [
+                {
+                    "page_index": 0,
+                    "rects": [
+                        {
+                            "x0": 100,
+                            "y0": 200,
+                            "x1": 800,
+                            "y1": 400,
+                            "fill": "black",
+                            "type": "headnote",
+                        }
+                    ],
+                }
+            ]
+            scan.margin_rects = [
+                {
+                    "page_index": 0,
+                    "rects": [{"x0": 0.0, "y0": 0.0, "x1": 20.0, "y1": 50.0}],
+                }
+            ]
+            scan.save(update_fields=["redaction_rects", "margin_rects"])
+
+            payload = json.loads(
+                services._build_combined_redactions(scan.pk).read_text()
+            )
+            page_rects = payload["pages"]["0"]
+
+            headnote = next(r for r in page_rects if r["type"] == "headnote")
+            self.assertAlmostEqual(headnote["x0"], 50.0, delta=0.2)
+            self.assertAlmostEqual(headnote["x1"], 400.0, delta=0.2)
+
+            margin = next(r for r in page_rects if r["type"] == "margin")
+            self.assertEqual(
+                margin["x1"], 20.0, "margin rects are already points"
+            )
+            self.assertEqual(margin["fill"], "white")
+
+
+@override_settings(MEDIA_ROOT=MEDIA_ROOT)
+class TestServeMarginRectsView(TestCase):
+    """The endpoint the margin work exists for.
+
+    It must go through the service helper rather than measuring on its own:
+    computing here with a separate detection lookup is how the viewer once
+    cached margins with no top strips, permanently.
+    """
+
+    def setUp(self):
+        _require_fixture(self)
+        self.user = UserFactory()
+        self.client.force_login(self.user)
+
+    def test_computes_through_the_service_helper(self):
+        from scanning import services
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scan = _make_scan_with_output(
+                tmpdir,
+                uploaded_by=self.user,
+                reporter=ReporterFactory(short_name="a3d"),
+            )
+            output = pathlib.Path(scan.output_dir)
+            with patch.object(
+                services, "_compute_and_save_margin_rects", return_value=[]
+            ) as compute:
+                response = self.client.get(f"/scans/{scan.pk}/margin-rects/")
+            self.assertEqual(response.status_code, 200)
+            compute.assert_called_once_with(
+                scan.pk, str(output / "bitonal.pdf"), str(output)
+            )
+
+    def test_a_detection_less_scan_is_not_cached(self):
+        """It must stay recomputable once the detections land."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scan = _make_scan_with_output(
+                tmpdir,
+                uploaded_by=self.user,
+                reporter=ReporterFactory(short_name="a3d"),
+            )
+            response = self.client.get(f"/scans/{scan.pk}/margin-rects/")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json(), [])
+            scan.refresh_from_db()
+            self.assertFalse(scan.margin_rects)
+
+    def test_returns_empty_without_a_processing_pdf(self):
+        scan = ScanFactory(uploaded_by=self.user)
+        response = self.client.get(f"/scans/{scan.pk}/margin-rects/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+
+
+@override_settings(MEDIA_ROOT=MEDIA_ROOT)
+class TestMarginRectsUseTheDetections(TestCase):
+    """The detected pages must reach the measurement.
+
+    They are what intersects the ink content box with the text band and the
+    header row: without them one bleed-through blob in a corner drags the
+    box out to the page edge and that page's top strip collapses.
+    blackletter owns that behaviour and tests it; what this app has to get
+    right is handing the pages over, corrected, rather than measuring bare.
+    """
+
+    def setUp(self):
+        _require_fixture(self)
+
+    def test_passes_the_detected_pages_to_the_measurement(self):
+        from blackletter.models import Label
+
+        from scanning import services
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scan = _make_scan_with_output(
+                tmpdir,
+                reporter=ReporterFactory(short_name="a3d"),
+            )
+            Detection.objects.create(
+                scan=scan,
+                page_index=0,
+                label="TEXT_COLUMN",
+                label_id=16,
+                confidence=0.95,
+                x0=100,
+                y0=200,
+                x1=1600,
+                y1=2000,
+                img_width=1700,
+                img_height=2200,
+            )
+            with patch.object(
+                services, "compute_margin_rects", return_value=[]
+            ) as measure:
+                services._compute_and_save_margin_rects(
+                    scan.pk, str(PDF_PATH), tmpdir
+                )
+            pages = measure.call_args.kwargs["pages"]
+            self.assertTrue(pages, "measured with no detected pages")
+            self.assertIn(
+                Label.TEXT_COLUMN,
+                [d.label for d in pages[0].detections],
+            )
+
+
+@override_settings(MEDIA_ROOT=MEDIA_ROOT)
+class TestPagesForGeometry(TestCase):
+    """The correction is applied in memory and never written back here.
+
+    ``_snap_text_columns_to_ink`` owns persistence. This helper exists for
+    boxes that reached the DB uncorrected, which is what a reviewer's
+    hand-drawn column is, and it must leave the row alone.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmp = pathlib.Path(self._tmp.name)
+        self.scan = ScanFactory(reporter=ReporterFactory(short_name="a3d"))
+        output = pathlib.Path(self.scan.output_dir)
+        output.mkdir(parents=True, exist_ok=True)
+        self.pdf = output / "bitonal.pdf"
+        write_two_column_page(self.pdf, tmp_dir=self.tmp)
+        self.det = Detection.objects.create(
+            scan=self.scan,
+            page_index=0,
+            label="TEXT_COLUMN",
+            label_id=16,
+            confidence=0.95,
+            x0=COLUMN_LEFT.x0 + 6,
+            y0=COLUMN_LEFT.y0,
+            x1=COLUMN_LEFT.x1 - 6,
+            y1=COLUMN_LEFT.y1,
+            img_width=PAGE_W,
+            img_height=PAGE_H,
+        )
+
+    def test_widens_an_uncorrected_box_without_persisting_it(self):
+        from scanning.services import _pages_for_geometry
+
+        pages = _pages_for_geometry(
+            self.scan, str(self.pdf), self.scan.output_dir
+        )
+        box = pages[0].detections[0].bbox
+        self.assertAlmostEqual(box.x1, COLUMN_LEFT.x0, delta=2.0)
+        self.assertAlmostEqual(box.x2, COLUMN_LEFT.x1, delta=2.0)
+
+        self.det.refresh_from_db()
+        self.assertEqual(self.det.x0, COLUMN_LEFT.x0 + 6, "persisted the snap")
+
+    def test_snap_false_leaves_the_box_as_stored(self):
+        """The steps that never read a column box must not pay to fix one."""
+        from scanning.services import _pages_for_geometry
+
+        pages = _pages_for_geometry(
+            self.scan, str(self.pdf), self.scan.output_dir, snap=False
+        )
+        self.assertEqual(pages[0].detections[0].bbox.x1, COLUMN_LEFT.x0 + 6)
+
+
+@override_settings(MEDIA_ROOT=MEDIA_ROOT)
+class TestPipelineCorrectsColumnsAfterDetecting(TestCase):
+    """Every path that imports detections must correct the column boxes.
+
+    The correction is persisted once, right after import, and everything
+    downstream reads the corrected rows. A path that imports without it
+    leaves boxes a few points inside the printed text, and the first or last
+    character of every masked line survives in the deliverable.
+    """
+
+    def setUp(self):
+        _require_fixture(self)
+
+    def test_run_detect_snaps_after_importing(self):
+        from scanning import services
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scan = _make_scan_with_output(
+                tmpdir,
+                reporter=ReporterFactory(short_name="a3d"),
+            )
+            output = pathlib.Path(scan.output_dir)
+            _run_detect_on_fixture(str(output))
+
+            with (
+                patch("django.db.connections.close_all"),
+                patch.object(services, "_run_yolo"),
+                patch.object(services, "_re_pair_opinions"),
+                patch.object(services, "_pull_processing_files_from_s3"),
+                patch.object(services, "_push_processing_files_to_s3"),
+                patch.object(
+                    services, "_snap_text_columns_to_ink", return_value=0
+                ) as snap,
+            ):
+                services.run_detect(scan.pk)
+
+            snap.assert_called_once()
+            self.assertEqual(
+                snap.call_args.args[1], str(output / "bitonal.pdf")
+            )
+
+
+@override_settings(MEDIA_ROOT=MEDIA_ROOT)
+class TestSnapIgnoresDetectionsPastTheEnd(TestCase):
+    """A detection can outlive the page it was found on.
+
+    Deleting a page shifts the rows after it down, and a stale row can end
+    up pointing past the end of the PDF. Indexing that page raises, and it
+    would take the whole pipeline step down with it.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmp = pathlib.Path(self._tmp.name)
+        self.pdf = self.tmp / "two_col.pdf"
+        write_two_column_page(self.pdf, tmp_dir=self.tmp)
+        self.scan = ScanFactory(reporter=ReporterFactory(short_name="a3d"))
+
+    def _column(self, page_index, x0, x1):
+        return Detection.objects.create(
+            scan=self.scan,
+            page_index=page_index,
+            label="TEXT_COLUMN",
+            label_id=16,
+            confidence=0.97,
+            x0=x0,
+            y0=100.0,
+            x1=x1,
+            y1=700.0,
+            img_width=PAGE_W,
+            img_height=PAGE_H,
+        )
+
+    def test_a_detection_past_the_last_page_is_skipped(self):
+        from scanning.services import _snap_text_columns_to_ink
+
+        self._column(0, COLUMN_LEFT.x0 + 6, COLUMN_LEFT.x1 - 6)
+        ghost = self._column(5, COLUMN_LEFT.x0 + 6, COLUMN_LEFT.x1 - 6)
+
+        self.assertEqual(
+            _snap_text_columns_to_ink(self.scan.pk, str(self.pdf)), 1
+        )
+        ghost.refresh_from_db()
+        self.assertEqual(ghost.x0, COLUMN_LEFT.x0 + 6, "moved a ghost box")
+
+
+@override_settings(MEDIA_ROOT=MEDIA_ROOT)
+class TestRebuildIssuesUsesTheCorrectedSplit(TestCase):
+    """Auto-correction decides which pages are out of range.
+
+    ``_auto_correct`` can pull a misread page number back into range, so the
+    in/out split computed after it is the one that applies. Letting
+    ``build_analysis`` recompute the split from scratch would be reading the
+    same results a second time and reaching a different answer.
+    """
+
+    def test_the_split_is_handed_over_not_recomputed(self):
+        from scanning import services
+
+        scan = ScanFactory(start_page=100, end_page=110, page_count=3)
+        results = [
+            {"pdf_page": 1, "detected": "100", "type": "single"},
+            {"pdf_page": 2, "detected": "101", "type": "single"},
+            {"pdf_page": 3, "detected": "102", "type": "single"},
+        ]
+        with patch.object(
+            services, "build_analysis", wraps=services.build_analysis
+        ) as analyse:
+            services._rebuild_issues_from_results(scan.pk, results)
+
+        self.assertIn("out_of_range", analyse.call_args.kwargs)
+        self.assertEqual(
+            analyse.call_args.kwargs["out_of_range"],
+            [],
+            "every reading is in range, so nothing should be flagged",
+        )
+
+    def test_a_scan_without_an_end_page_still_reports_gaps(self):
+        """The old hand-built analysis returned no missing pages at all."""
+        from scanning import services
+        from scanning.models import Issue
+
+        scan = ScanFactory(start_page=10, end_page=None, page_count=4)
+        results = [
+            {"pdf_page": 1, "detected": "10", "type": "single"},
+            {"pdf_page": 2, "detected": "11", "type": "single"},
+            {"pdf_page": 3, "detected": "15", "type": "single"},
+            {"pdf_page": 4, "detected": "16", "type": "single"},
+        ]
+        services._rebuild_issues_from_results(scan.pk, results)
+
+        scan.refresh_from_db()
+        self.assertEqual(scan.missing_pages, [12, 13, 14])
+        self.assertTrue(Issue.objects.filter(scan=scan).exists())

--- a/scanning/tests/test_services.py
+++ b/scanning/tests/test_services.py
@@ -1380,6 +1380,118 @@ class TestGenerateFilesWithoutOcrPdf(TestCase):
             "margin rects are all empty",
         )
 
+    def test_computes_redaction_rects_when_absent(self):
+        """Generate is self-sufficient now that the upload path skips rects.
+
+        ``run_full_pipeline`` no longer computes them, and the step 2
+        overlay only asks for them if a reviewer opens it, so Generate
+        cannot assume they exist.
+        """
+        from scanning import services
+
+        scan = _make_scan_with_output(
+            reporter=ReporterFactory(short_name="a3d"),
+        )
+        output = pathlib.Path(scan.output_dir)
+        _write_bitonal_copy(output / "bitonal.pdf")
+        self.assertFalse(scan.redaction_rects)
+
+        with (
+            patch("django.db.connections.close_all"),
+            patch("blackletter.api.generate") as generate,
+            patch.object(services, "_push_processing_files_to_s3"),
+            patch.object(services, "_pull_processing_files_from_s3"),
+            patch.object(
+                services, "_snap_text_columns_to_ink", return_value=0
+            ) as snap,
+            patch.object(
+                services, "_compute_and_save_redaction_rects", return_value=[]
+            ) as rects,
+        ):
+            generate.return_value = {
+                "opinion_count": 0,
+                "full_redacted": "",
+                "redacted_dir": str(output / "redacted"),
+            }
+            services.run_generate_files(scan.pk)
+
+        rects.assert_called_once()
+        self.assertEqual(rects.call_args.args[1], str(output / "bitonal.pdf"))
+        # The columns are corrected first: the rects and the margin strips
+        # are both measured against them.
+        snap.assert_called_once()
+        self.assertEqual(snap.call_args.args[1], str(output / "bitonal.pdf"))
+
+    def test_keeps_redaction_rects_a_reviewer_edited(self):
+        """Stored rects win, because a reviewer may have moved them.
+
+        ``save_redaction_rect`` writes straight into ``redaction_rects``,
+        so recomputing here would throw away every drag, delete and
+        hand-added box from step 3.
+        """
+        from scanning import services
+
+        scan = _make_scan_with_output(
+            reporter=ReporterFactory(short_name="a3d"),
+        )
+        output = pathlib.Path(scan.output_dir)
+        _write_bitonal_copy(output / "bitonal.pdf")
+        edited = [
+            {
+                "page_index": 0,
+                "rects": [
+                    {
+                        "x0": 10,
+                        "y0": 20,
+                        "x1": 30,
+                        "y1": 40,
+                        "fill": "black",
+                        "type": "headnote",
+                    }
+                ],
+            }
+        ]
+        scan.redaction_rects = edited
+        scan.save(update_fields=["redaction_rects"])
+        # The rects are stored in image pixels, so the page they name has to
+        # still have a detection to scale them by.
+        Detection.objects.create(
+            scan=scan,
+            page_index=0,
+            label="TEXT_COLUMN",
+            label_id=16,
+            confidence=0.95,
+            x0=100,
+            y0=200,
+            x1=1600,
+            y1=2000,
+            img_width=1700,
+            img_height=2200,
+        )
+
+        with (
+            patch("django.db.connections.close_all"),
+            patch("blackletter.api.generate") as generate,
+            patch.object(services, "_push_processing_files_to_s3"),
+            patch.object(services, "_pull_processing_files_from_s3"),
+            patch.object(
+                services, "_snap_text_columns_to_ink", return_value=0
+            ),
+            patch.object(
+                services, "_compute_and_save_redaction_rects"
+            ) as rects,
+        ):
+            generate.return_value = {
+                "opinion_count": 0,
+                "full_redacted": "",
+                "redacted_dir": str(output / "redacted"),
+            }
+            services.run_generate_files(scan.pk)
+
+        rects.assert_not_called()
+        scan.refresh_from_db()
+        self.assertEqual(scan.redaction_rects, edited)
+
     def test_raises_without_any_processing_pdf(self):
         """An empty output dir is still an error, just a clearer one."""
         from scanning import services
@@ -1884,12 +1996,14 @@ class TestPagesForGeometry(TestCase):
 
 @override_settings(MEDIA_ROOT=MEDIA_ROOT)
 class TestPipelineCorrectsColumnsAfterDetecting(TestCase):
-    """Every path that imports detections must correct the column boxes.
+    """``run_detect`` corrects the column boxes it just imported.
 
-    The correction is persisted once, right after import, and everything
-    downstream reads the corrected rows. A path that imports without it
-    leaves boxes a few points inside the printed text, and the first or last
-    character of every masked line survives in the deliverable.
+    Re-detect is an explicit request for new geometry, and the reviewer is
+    watching one scan rather than waiting on an upload, so it persists the
+    correction rather than deferring it the way ``run_full_pipeline`` does.
+    Boxes left uncorrected sit a few points inside the printed text, and the
+    first or last character of every masked line survives in the
+    deliverable.
     """
 
     def setUp(self):
@@ -1922,6 +2036,58 @@ class TestPipelineCorrectsColumnsAfterDetecting(TestCase):
             self.assertEqual(
                 snap.call_args.args[1], str(output / "bitonal.pdf")
             )
+
+
+@override_settings(MEDIA_ROOT=MEDIA_ROOT)
+class TestUploadPathSkipsRedactionGeometry(TestCase):
+    """The upload path stops at "is this volume complete?".
+
+    Review 1 asks nothing about redaction: no detection overlay, no rects.
+    Measuring either here cost three full-volume renders at 100 dpi that a
+    scanner sat through before the scan even reached PENDING_REVIEW, which
+    is most of what dropping the Tesseract pass was meant to give back.
+    """
+
+    def setUp(self):
+        _require_fixture(self)
+
+    def test_run_full_pipeline_defers_both(self):
+        from scanning import services
+
+        scan = _make_scan_with_output(
+            reporter=ReporterFactory(short_name="a3d"),
+        )
+        output = pathlib.Path(scan.output_dir)
+        bitonal = output / "bitonal.pdf"
+        _write_bitonal_copy(bitonal)
+
+        with (
+            patch("django.db.connections.close_all"),
+            patch.object(services, "_pull_processing_files_from_s3"),
+            patch.object(services, "_push_processing_files_to_s3"),
+            patch.object(services, "_ensure_bitonal", return_value=bitonal),
+            patch.object(services, "_run_yolo"),
+            patch.object(
+                services, "_import_detections_from_json", return_value=[]
+            ),
+            patch.object(services, "run_paddleocr_validation"),
+            patch.object(services, "_re_pair_opinions", return_value=[]),
+            patch.object(services, "_snap_text_columns_to_ink") as snap,
+            patch.object(
+                services, "_compute_and_save_redaction_rects"
+            ) as rects,
+            patch.object(
+                services, "_compute_and_save_margin_rects"
+            ) as margins,
+        ):
+            services.run_full_pipeline(scan.pk)
+
+        snap.assert_not_called()
+        rects.assert_not_called()
+        margins.assert_not_called()
+
+        scan.refresh_from_db()
+        self.assertEqual(scan.status, Status.PENDING_REVIEW)
 
 
 @override_settings(MEDIA_ROOT=MEDIA_ROOT)

--- a/scanning/tests/test_sync_pages.py
+++ b/scanning/tests/test_sync_pages.py
@@ -1,19 +1,30 @@
 """Unit tests for the per-page sync helpers in ``scanning.services``.
 
 Focus is the sandwich-rule blank-page detector
-(``_is_blank_via_sandwich``) and its boundary text-extraction
-fallback. The helper is a pure function over data structures plus
+(``_is_blank_via_sandwich``) and its boundary rect-coverage
+confirmation. The helper is a pure function over data structures plus
 an optional PDF path; we exercise it directly without touching the
 DB.
 """
 
 from __future__ import annotations
 
+import tempfile
+from pathlib import Path
 from unittest.mock import patch
 
+import fitz
 from django.test import SimpleTestCase
 
-from scanning.services import _is_blank_via_sandwich
+from scanning.services import _is_blank_via_sandwich, _page_body_covered
+
+PAGE_W, PAGE_H = 612.0, 792.0
+HEADER_PTS = 60.0
+
+
+def _rect(x0, y0, x1, y1, rtype="headnote"):
+    """Build a redaction rect dict in PDF points."""
+    return {"x0": x0, "y0": y0, "x1": x1, "y1": y1, "type": rtype}
 
 
 def _hn(page_index: int) -> dict:
@@ -66,19 +77,18 @@ class IsBlankViaSandwichTests(SimpleTestCase):
             )
         )
 
-    def test_last_page_of_block_fires_when_pdf_body_is_textless(self):
+    def test_last_page_of_block_fires_when_body_is_covered(self):
         """Boundary case — only the previous neighbor has headnotes
-        (this is the trailing edge of a headnote block) AND the
-        rendered PDF's body extracts to nothing → blank.
+        (this is the trailing edge of a headnote block) AND the page's
+        rects cover the whole body → blank.
 
-        The per-page PDFs are post-redaction, so an actually-empty
-        body extracts to no text. We mock the PDF check so the test
-        doesn't need a real file on disk.
+        We mock the coverage check so the test doesn't need a real file
+        on disk.
         """
         pages = {"4": [_hn(4)], "5": [_hn(5)]}  # no 6 — block ends here
         with patch(
-            "scanning.services._page_body_textless", return_value=True
-        ) as mock_textless:
+            "scanning.services._page_body_covered", return_value=True
+        ) as mock_covered:
             result = _is_blank_via_sandwich(
                 page_index=5,
                 opinions=[self.OPINION],
@@ -87,17 +97,15 @@ class IsBlankViaSandwichTests(SimpleTestCase):
                 pdf_path="/fake/page_0006.pdf",
             )
         self.assertTrue(result)
-        mock_textless.assert_called_once()
+        mock_covered.assert_called_once()
 
-    def test_last_page_of_block_does_not_fire_when_body_has_text(self):
+    def test_last_page_of_block_does_not_fire_when_body_uncovered(self):
         """Boundary case — only the previous neighbor has headnotes,
-        but the rendered PDF still has body text (headnote block ended
+        but part of the body is left unredacted (the headnote block ended
         partway down the page and body picks up below) → not blank.
         """
         pages = {"4": [_hn(4)], "5": [_hn(5)]}
-        with patch(
-            "scanning.services._page_body_textless", return_value=False
-        ):
+        with patch("scanning.services._page_body_covered", return_value=False):
             result = _is_blank_via_sandwich(
                 page_index=5,
                 opinions=[self.OPINION],
@@ -107,13 +115,13 @@ class IsBlankViaSandwichTests(SimpleTestCase):
             )
         self.assertFalse(result)
 
-    def test_first_page_of_block_fires_when_pdf_body_is_textless(self):
+    def test_first_page_of_block_fires_when_body_is_covered(self):
         """Boundary case — only the NEXT neighbor has headnotes (this
         is the leading edge of a block, just after the caption page).
-        Same text-extraction confirmation as the trailing-edge case.
+        Same coverage confirmation as the trailing-edge case.
         """
         pages = {"5": [_hn(5)], "6": [_hn(6)]}  # no 4 — block starts here
-        with patch("scanning.services._page_body_textless", return_value=True):
+        with patch("scanning.services._page_body_covered", return_value=True):
             result = _is_blank_via_sandwich(
                 page_index=5,
                 opinions=[self.OPINION],
@@ -185,3 +193,57 @@ class IsBlankViaSandwichTests(SimpleTestCase):
                 page_detections=[],
             )
         )
+
+
+class PageBodyCoveredTests(SimpleTestCase):
+    """Tests for ``_page_body_covered``.
+
+    Replaces the old text-extraction probe: the generated per-page PDFs
+    no longer carry a text layer, so body emptiness is measured from the
+    redaction geometry instead.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.pdf_path = Path(self._tmp.name) / "page_0006.pdf"
+        with fitz.open() as doc:
+            doc.new_page(width=PAGE_W, height=PAGE_H)
+            doc.save(str(self.pdf_path))
+
+    def test_fully_covered_body_is_blank(self):
+        pages = {"5": [_rect(0, HEADER_PTS, PAGE_W, PAGE_H)]}
+        self.assertTrue(_page_body_covered(pages, 5, self.pdf_path))
+
+    def test_header_band_does_not_need_covering(self):
+        """The printed page number lives above the body and is kept."""
+        pages = {"5": [_rect(0, HEADER_PTS, PAGE_W, PAGE_H)]}
+        self.assertTrue(_page_body_covered(pages, 5, self.pdf_path))
+        # A rect that starts below the header leaves body uncovered.
+        pages = {"5": [_rect(0, 400, PAGE_W, PAGE_H)]}
+        self.assertFalse(_page_body_covered(pages, 5, self.pdf_path))
+
+    def test_margins_plus_headnotes_count_together(self):
+        """Headnote rects never reach the page edges; margins do."""
+        pages = {
+            "5": [
+                _rect(0, 0, 72, PAGE_H, "margin"),
+                _rect(540, 0, PAGE_W, PAGE_H, "margin"),
+                _rect(72, HEADER_PTS, 540, PAGE_H),
+            ]
+        }
+        self.assertTrue(_page_body_covered(pages, 5, self.pdf_path))
+
+    def test_partly_covered_body_is_not_blank(self):
+        """A headnote block ending mid-page leaves live text below."""
+        pages = {"5": [_rect(72, HEADER_PTS, 540, 400)]}
+        self.assertFalse(_page_body_covered(pages, 5, self.pdf_path))
+
+    def test_no_rects_is_not_blank(self):
+        self.assertFalse(_page_body_covered({}, 5, self.pdf_path))
+
+    def test_unreadable_pdf_is_not_blank(self):
+        """Never flag a page blank when the check itself failed."""
+        pages = {"5": [_rect(0, HEADER_PTS, PAGE_W, PAGE_H)]}
+        missing = Path(self._tmp.name) / "does_not_exist.pdf"
+        self.assertFalse(_page_body_covered(pages, 5, missing))

--- a/scanning/tests/test_utils.py
+++ b/scanning/tests/test_utils.py
@@ -1,8 +1,17 @@
 """Tests for scanning.utils helpers."""
 
-from django.test import TestCase
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
 
-from scanning.utils import compute_coverage_gaps
+from django.test import SimpleTestCase, TestCase
+
+from scanning.utils import (
+    compute_coverage_gaps,
+    find_ocr_pdf,
+    find_processing_pdf,
+    processing_pdf_path,
+)
 
 
 def _op(caption_page, key_page, **extra):
@@ -71,3 +80,70 @@ class TestComputeCoverageGaps(TestCase):
         self.assertEqual(compute_coverage_gaps([], 1, 10), [])
         self.assertEqual(compute_coverage_gaps([_op(0, 3)], None, 10), [])
         self.assertEqual(compute_coverage_gaps([_op(0, 3)], 1, None), [])
+
+
+class TestFindProcessingPdf(SimpleTestCase):
+    """Tests for ``find_processing_pdf``."""
+
+    def test_returns_bitonal_when_no_ocr_pdf(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            bitonal = Path(tmp) / "bitonal.pdf"
+            bitonal.write_bytes(b"%PDF-1.4")
+            self.assertEqual(find_processing_pdf(tmp), bitonal)
+
+    def test_prefers_legacy_ocr_pdf_over_bitonal(self):
+        """Scans processed before the text layer was dropped keep it."""
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "bitonal.pdf").write_bytes(b"%PDF-1.4")
+            ocr = Path(tmp) / "a3d.164.1.10.pdf"
+            ocr.write_bytes(b"%PDF-1.4")
+            self.assertEqual(find_ocr_pdf(tmp), ocr)
+            self.assertEqual(find_processing_pdf(tmp), ocr)
+
+    def test_ignores_originals_and_derived_pdfs(self):
+        """The multi-GB original and generated output are not candidates."""
+        with tempfile.TemporaryDirectory() as tmp:
+            for name in (
+                "a3d.164.1.10.original.pdf",
+                "a3d.164.1.10.redacted.pdf",
+                "stamped.pdf",
+            ):
+                (Path(tmp) / name).write_bytes(b"%PDF-1.4")
+            self.assertIsNone(find_processing_pdf(tmp))
+
+    def test_returns_none_for_empty_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(find_processing_pdf(tmp))
+
+
+class TestProcessingPdfPath(SimpleTestCase):
+    """Tests for ``processing_pdf_path``."""
+
+    class _FakeScan:
+        """Stand-in exposing only what the resolver reads."""
+
+        def __init__(self, output_dir, pdf_path="/orig/scan.original.pdf"):
+            self.output_dir = output_dir
+            self.pdf_path = pdf_path
+
+    def test_prefers_processing_pdf_over_original(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            bitonal = Path(tmp) / "bitonal.pdf"
+            bitonal.write_bytes(b"%PDF-1.4")
+            scan = self._FakeScan(tmp)
+            self.assertEqual(processing_pdf_path(scan), str(bitonal))
+
+    def test_falls_back_to_original(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            scan = self._FakeScan(tmp)
+            self.assertEqual(
+                processing_pdf_path(scan), "/orig/scan.original.pdf"
+            )
+
+    def test_falls_back_to_original_without_output_dir(self):
+        scan = self._FakeScan("")
+        with patch("scanning.utils.find_processing_pdf") as find:
+            self.assertEqual(
+                processing_pdf_path(scan), "/orig/scan.original.pdf"
+            )
+        find.assert_not_called()

--- a/scanning/tests/test_views.py
+++ b/scanning/tests/test_views.py
@@ -2526,3 +2526,70 @@ class TestLazyPullsFetchOneFile(ScanningTestCase):
         self.assertEqual(response.status_code, 200)
         one.assert_called_once_with(scan, "tp.8.redacted.pdf")
         everything.assert_not_called()
+
+
+class TestDeleteDetectionPrunesStaleRects(ScanningTestCase):
+    """Deleting a page's last detection must not strand its saved rects.
+
+    ``redaction_rects`` is a snapshot in image pixels, and the scale that
+    places it comes from that page's detections. Leaving rects behind for a
+    page that has none makes Generate Files fail on every retry, with no
+    reachable way for a reviewer to clear it.
+    """
+
+    def setUp(self):
+        self.user = self.make_user()
+        self.client.force_login(self.user)
+        self.scan = ScanFactory(reporter=ReporterFactory(short_name="tp"))
+        self.scan.redaction_rects = [
+            {"page_index": 0, "rects": [{"x0": 1, "y0": 2, "x1": 3, "y1": 4}]},
+            {"page_index": 1, "rects": [{"x0": 5, "y0": 6, "x1": 7, "y1": 8}]},
+        ]
+        self.scan.save(update_fields=["redaction_rects"])
+
+    def _detection(self, page_index):
+        return Detection.objects.create(
+            scan=self.scan,
+            page_index=page_index,
+            label="HEADNOTE",
+            label_id=3,
+            confidence=0.9,
+            x0=10,
+            y0=20,
+            x1=30,
+            y1=40,
+            img_width=1700,
+            img_height=2200,
+        )
+
+    def _delete(self, detection):
+        return self.client.post(
+            reverse("delete_detection", kwargs={"pk": self.scan.pk}),
+            data=json.dumps({"detection_id": detection.pk}),
+            content_type="application/json",
+        )
+
+    def test_the_last_detection_on_a_page_takes_its_rects_with_it(self):
+        only_one = self._detection(0)
+        self._detection(1)
+
+        response = self._delete(only_one)
+
+        self.assertEqual(response.status_code, 200)
+        self.scan.refresh_from_db()
+        self.assertEqual(
+            [e["page_index"] for e in self.scan.redaction_rects],
+            [1],
+            "page 0's rects should have gone with its last detection",
+        )
+
+    def test_rects_survive_while_the_page_still_has_a_detection(self):
+        one_of_two = self._detection(0)
+        self._detection(0)
+
+        self._delete(one_of_two)
+
+        self.scan.refresh_from_db()
+        self.assertEqual(
+            [e["page_index"] for e in self.scan.redaction_rects], [0, 1]
+        )

--- a/scanning/tests/test_views.py
+++ b/scanning/tests/test_views.py
@@ -1643,9 +1643,9 @@ class TestServeOpinionPdfLazyPull(ScanningTestCase):
         opinion.redacted_pdf.name = "redacted/op.pdf"
         opinion.save(update_fields=["redacted_pdf"])
 
-        def _fake_download(scan_arg):
+        def _fake_download(scan_arg, rel_key):
             # Simulate the pull writing the file to the scan's output dir.
-            target = pathlib.Path(scan_arg.output_dir) / "redacted" / "op.pdf"
+            target = pathlib.Path(scan_arg.output_dir) / rel_key
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_bytes(b"%PDF-1.4 pulled")
 
@@ -1656,9 +1656,10 @@ class TestServeOpinionPdfLazyPull(ScanningTestCase):
                 PROCESSING_TMP_DIR=tmp_root,
             ),
             patch(
-                "scanning.s3_sync.download_processing_files",
+                "scanning.s3_sync.download_processing_file",
                 side_effect=_fake_download,
             ) as mock_pull,
+            patch("scanning.s3_sync.download_processing_files") as mock_all,
         ):
             response = self.client.get(
                 reverse(
@@ -1668,7 +1669,11 @@ class TestServeOpinionPdfLazyPull(ScanningTestCase):
             )
 
         self.assertEqual(response.status_code, 200)
-        mock_pull.assert_called_once()
+        # Only the requested file is pulled. Pulling the whole prefix here
+        # meant gigabytes for one opinion, and because sync views share a
+        # single executor under ASGI it stalled every other request.
+        mock_pull.assert_called_once_with(scan, "redacted/op.pdf")
+        mock_all.assert_not_called()
 
 
 class TestServeOpinionPdfCaching(ScanningTestCase):
@@ -2438,3 +2443,86 @@ class TestSidebarDuplicateMarkers(ScanningTestCase):
             ],
             [2],
         )
+
+
+class TestLazyPullsFetchOneFile(ScanningTestCase):
+    """A stale /tmp/ must cost one object, not the whole prefix.
+
+    Both of these views used to call ``download_processing_files``, which
+    pulls every object under the scan's processing prefix: gigabytes for one
+    page on a full volume, and because the sync views share a single
+    executor under ASGI, it stalled every other request while it ran.
+    """
+
+    def setUp(self):
+        self.user = self.make_user()
+        self.client.force_login(self.user)
+        self.tmp_root = tempfile.mkdtemp()
+
+    @staticmethod
+    def _writes_the_file(rel_key_of):
+        """A download_processing_file stub that materialises the file."""
+
+        def _fake(scan_arg, rel_key):
+            target = pathlib.Path(scan_arg.output_dir) / rel_key_of(rel_key)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(b"%PDF-1.4 pulled")
+
+        return _fake
+
+    def test_serve_page_pdf_pulls_only_that_page(self):
+        from scanning.models import Page
+
+        scan = ScanFactory(reporter=ReporterFactory(short_name="tp"), volume=7)
+        page = Page.objects.create(
+            scan=scan, page_index=0, pdf_path="llm/page_0001.pdf"
+        )
+
+        with (
+            override_settings(
+                DEVELOPMENT=False,
+                TESTING=False,
+                PROCESSING_TMP_DIR=self.tmp_root,
+            ),
+            patch(
+                "scanning.s3_sync.download_processing_file",
+                side_effect=self._writes_the_file(lambda key: key),
+            ) as one,
+            patch("scanning.s3_sync.download_processing_files") as everything,
+        ):
+            response = self.client.get(
+                reverse("serve_page_pdf", kwargs={"pk": page.pk})
+            )
+
+        self.assertEqual(response.status_code, 200)
+        one.assert_called_once_with(scan, "llm/page_0001.pdf")
+        everything.assert_not_called()
+
+    def test_serve_redacted_pdf_pulls_only_the_redacted_file(self):
+        scan = ScanFactory(reporter=ReporterFactory(short_name="tp"), volume=8)
+
+        with (
+            override_settings(
+                DEVELOPMENT=False,
+                TESTING=False,
+                PROCESSING_TMP_DIR=self.tmp_root,
+            ),
+            patch(
+                "scanning.s3_sync.download_processing_file",
+                side_effect=self._writes_the_file(lambda key: key),
+            ) as one,
+            patch("scanning.s3_sync.download_processing_files") as everything,
+        ):
+            # output_dir is derived from PROCESSING_TMP_DIR, so this has to
+            # be set under the override, not before it.
+            scan.redacted_pdf_path = str(
+                pathlib.Path(scan.output_dir) / "tp.8.redacted.pdf"
+            )
+            scan.save(update_fields=["redacted_pdf_path"])
+            response = self.client.get(
+                reverse("serve_redacted_pdf", kwargs={"pk": scan.pk})
+            )
+
+        self.assertEqual(response.status_code, 200)
+        one.assert_called_once_with(scan, "tp.8.redacted.pdf")
+        everything.assert_not_called()

--- a/scanning/utils.py
+++ b/scanning/utils.py
@@ -45,6 +45,11 @@ def find_json_file(output_base: Path, filename: str) -> Path | None:
 def find_ocr_pdf(output_dir: str | Path) -> Path | None:
     """Find the OCR PDF in output_dir (excludes bitonal, redacted, original).
 
+    The pipeline no longer produces one: the ocrmypdf/Tesseract text-layer
+    pass was dropped from ``run_full_pipeline``. Only scans processed
+    before that change still have this file, so callers that just want a
+    workable PDF should use :func:`find_processing_pdf` instead.
+
     :param output_dir: The directory to search for the OCR PDF.
     :return: The Path if found, or None.
     """
@@ -58,6 +63,49 @@ def find_ocr_pdf(output_dir: str | Path) -> Path | None:
         ):
             return f
     return None
+
+
+def find_processing_pdf(output_dir: str | Path) -> Path | None:
+    """Find the small PDF the pipeline works on.
+
+    ``bitonal.pdf`` is the canonical one: it has the exact page geometry
+    of the original (``_render_bitonal_page`` creates each page from the
+    source page's rect) at a fraction of the size, so anything that only
+    needs page dimensions, detection coordinates, or a preview can use it.
+
+    Scans processed before the Tesseract text-layer pass was dropped from
+    the pipeline also carry an OCR'd PDF in the same directory. It is
+    preferred when present: same geometry, plus a text layer that still
+    gives tighter margin bounds.
+
+    :param output_dir: The scan's output directory.
+    :return: The OCR'd PDF, else ``bitonal.pdf``, else None.
+    """
+    ocr_pdf = find_ocr_pdf(output_dir)
+    if ocr_pdf:
+        return ocr_pdf
+    bitonal = Path(output_dir) / "bitonal.pdf"
+    return bitonal if bitonal.exists() else None
+
+
+def processing_pdf_path(scan: Scan) -> str:
+    """Resolve the PDF path pipeline steps should read for a scan.
+
+    Prefers the small processing PDF (see :func:`find_processing_pdf`) and
+    falls back to the multi-GB original only when no processing PDF exists
+    locally, which in production means an S3 pull, so callers should treat
+    that as the slow path rather than the normal one.
+
+    :param scan: The scan to resolve a PDF for.
+    :return: Filesystem path to the best available PDF.
+    :raises FileNotFoundError: If neither a processing PDF nor a local
+        copy of the original exists (raised by ``Scan.pdf_path``).
+    """
+    if scan.output_dir:
+        found = find_processing_pdf(scan.output_dir)
+        if found:
+            return str(found)
+    return scan.pdf_path
 
 
 def has_s3_credentials() -> bool:

--- a/scanning/views_api.py
+++ b/scanning/views_api.py
@@ -41,7 +41,8 @@ from scanning.models import (
 from scanning.utils import (
     compute_coverage_gaps,
     find_json_file,
-    find_ocr_pdf,
+    find_processing_pdf,
+    processing_pdf_path,
 )
 
 logger = logging.getLogger(__name__)
@@ -131,16 +132,18 @@ def serve_margin_rects(request: HttpRequest, pk: int) -> JsonResponse:
     if scan.margin_rects:
         return JsonResponse(scan.margin_rects, safe=False)
     output_base = Path(scan.output_dir)
-    ocr_pdf = find_ocr_pdf(output_base) if output_base.is_dir() else None
-    if not ocr_pdf:
+    base_pdf = (
+        find_processing_pdf(output_base) if output_base.is_dir() else None
+    )
+    if not base_pdf:
         return JsonResponse([], safe=False)
-    from blackletter.margins import compute_margin_rects
+    # Shared with the pipeline rather than reimplemented: computing these
+    # here with its own detection lookup is how a viewer request that
+    # arrived before this machine had detections.json cached margins with
+    # no top strips, permanently.
+    from scanning.services import _compute_and_save_margin_rects
 
-    from scanning.services import _adjust_margins_for_detections
-
-    rects = compute_margin_rects(ocr_pdf)
-    rects = _adjust_margins_for_detections(rects, output_base)
-    Scan.objects.filter(pk=pk).update(margin_rects=rects)
+    rects = _compute_and_save_margin_rects(pk, str(base_pdf), str(output_base))
     return JsonResponse(rects, safe=False)
 
 
@@ -350,7 +353,7 @@ def compute_redactions_api(request: HttpRequest, pk: int) -> JsonResponse:
     if not scan.opinions_json:
         return JsonResponse({"error": "No opinions paired yet"}, status=400)
     output_dir = scan.output_dir
-    pdf_path = find_ocr_pdf(output_dir) or scan.pdf_path
+    pdf_path = processing_pdf_path(scan)
     try:
         rects = _compute_and_save_redaction_rects(pk, pdf_path)
         _compute_and_save_margin_rects(pk, pdf_path, output_dir)
@@ -452,7 +455,9 @@ def _resolve_opinion_pdf(
             try:
                 from scanning import s3_sync
 
-                s3_sync.download_processing_files(opinion.scan)
+                # Just this file: see s3_sync.download_processing_file for
+                # why pulling the whole prefix here hangs the process.
+                s3_sync.download_processing_file(opinion.scan, field.name)
             except Exception:
                 logger.exception(
                     "Lazy S3 pull failed for opinion %s", opinion.pk
@@ -542,7 +547,8 @@ def serve_page_pdf(request: HttpRequest, pk: int) -> FileResponse:
     try:
         from scanning import s3_sync
 
-        s3_sync.download_processing_files(page.scan)
+        # Just this page's file, not the scan's whole prefix.
+        s3_sync.download_processing_file(page.scan, page.pdf_path)
     except Exception:
         logger.exception("Lazy S3 pull failed for page %s", page.pk)
     if candidate.is_file():
@@ -631,7 +637,7 @@ def serve_redacted_pdf(
 ) -> FileResponse | HttpResponse:
     """Serve the redacted PDF for a scan.
 
-    Falls back to the OCR PDF if the redacted version hasn't been
+    Falls back to the processing PDF if the redacted version hasn't been
     generated yet, so the viewer has something to display.
 
     :param request: The HTTP request.
@@ -647,19 +653,28 @@ def serve_redacted_pdf(
             content_type="application/pdf",
         )
 
-    # 2. Fall back to the OCR PDF (for preview before generation)
+    # 2. Fall back to the processing PDF (for preview before generation)
     output = Path(scan.output_dir)
     if output.is_dir():
-        ocr = find_ocr_pdf(output)
-        if ocr:
-            return FileResponse(ocr.open("rb"), content_type="application/pdf")
+        base_pdf = find_processing_pdf(output)
+        if base_pdf:
+            return FileResponse(
+                base_pdf.open("rb"), content_type="application/pdf"
+            )
 
     # 3. Lazy S3 pull + retry: handles the case where the daemon just
-    # finished Generate Files and the web container's /tmp/ is stale.
+    # finished Generate Files and this container's /tmp/ is stale. Pull only
+    # the file being served -- the whole prefix runs to gigabytes on a full
+    # volume, and every sync view shares one executor under ASGI.
     try:
         from scanning import s3_sync
 
-        s3_sync.download_processing_files(scan)
+        if scan.redacted_pdf_path:
+            s3_sync.download_processing_file(
+                scan, os.path.basename(scan.redacted_pdf_path)
+            )
+        else:
+            s3_sync.download_preview_pdf(scan)
     except Exception:
         logger.exception("Lazy S3 pull failed for scan %s", scan.pk)
     if scan.redacted_pdf_path and os.path.isfile(scan.redacted_pdf_path):
@@ -668,9 +683,11 @@ def serve_redacted_pdf(
             content_type="application/pdf",
         )
     if output.is_dir():
-        ocr = find_ocr_pdf(output)
-        if ocr:
-            return FileResponse(ocr.open("rb"), content_type="application/pdf")
+        base_pdf = find_processing_pdf(output)
+        if base_pdf:
+            return FileResponse(
+                base_pdf.open("rb"), content_type="application/pdf"
+            )
 
     return HttpResponse("No PDF available", status=404)
 

--- a/scanning/views_api.py
+++ b/scanning/views_api.py
@@ -787,6 +787,11 @@ def delete_detection(request: HttpRequest, pk: int) -> JsonResponse:
     if isinstance(data, JsonResponse):
         return data
     detection_id = data["detection_id"]
+    page_index = (
+        Detection.objects.filter(pk=detection_id, scan=scan)
+        .values_list("page_index", flat=True)
+        .first()
+    )
     count = Detection.objects.filter(pk=detection_id, scan=scan).update(
         active=False
     )
@@ -794,10 +799,48 @@ def delete_detection(request: HttpRequest, pk: int) -> JsonResponse:
         return JsonResponse(
             {"status": "error", "message": "Detection not found"}, status=404
         )
+    _drop_orphaned_redaction_rects(scan, page_index)
     output_dir = Path(scan.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
     _sync_detections_to_disk(scan.pk)
     return JsonResponse({"status": "ok", "deleted": count})
+
+
+def _drop_orphaned_redaction_rects(scan: Scan, page_index: int | None) -> None:
+    """Forget a page's saved rects once its last detection is gone.
+
+    ``redaction_rects`` is a snapshot in image pixels, and the scale that
+    converts it to points comes from the page's own detections. Deleting the
+    last one on a page leaves rects that cannot be placed, which stops
+    Generate Files outright, and nothing in the review UI recomputes them.
+
+    Dropping them loses nothing: a page with no detections left has nothing
+    on it to redact, and the reviewer saying so is what deleting the last
+    detection means. Rects on every other page, including any the reviewer
+    adjusted by hand, are untouched.
+
+    :param scan: The scan whose rects to prune.
+    :param page_index: Page the deleted detection was on, if known.
+    """
+    if page_index is None or not scan.redaction_rects:
+        return
+    if Detection.objects.filter(
+        scan=scan, page_index=page_index, active=True
+    ).exists():
+        return
+    remaining = [
+        entry
+        for entry in scan.redaction_rects
+        if entry.get("page_index") != page_index
+    ]
+    if len(remaining) != len(scan.redaction_rects):
+        logger.info(
+            "Dropped saved redaction rects for scan %s page %s: "
+            "no active detections left on it",
+            scan.pk,
+            page_index,
+        )
+        Scan.objects.filter(pk=scan.pk).update(redaction_rects=remaining)
 
 
 @login_required

--- a/scanning/views_process.py
+++ b/scanning/views_process.py
@@ -31,7 +31,7 @@ from scanning.models import (
     Stage,
     Status,
 )
-from scanning.utils import compute_coverage_gaps, find_ocr_pdf
+from scanning.utils import compute_coverage_gaps, find_processing_pdf
 
 logger = logging.getLogger(__name__)
 
@@ -451,7 +451,7 @@ def progress_api(request: HttpRequest, pk: int) -> JsonResponse:
 
 @login_required
 def serve_scan_pdf(request: HttpRequest, pk: int) -> HttpResponse:
-    """Serve the small processed PDF (OCR text layer, else bitonal).
+    """Serve the small processed PDF (``bitonal.pdf``).
 
     The viewer only ever gets the small, browser-viewable preview. The
     multi-GB original is never streamed here: it blows past the gunicorn
@@ -462,7 +462,7 @@ def serve_scan_pdf(request: HttpRequest, pk: int) -> HttpResponse:
 
     Resolution:
 
-    1. Serve the processed PDF (OCR > bitonal) if it is already local.
+    1. Serve the processed PDF if it is already local.
     2. Otherwise pull *only* the preview PDF(s) from S3 and look again.
        This covers prod, where the daemon and web run in separate
        containers with separate ephemeral ``/tmp/`` volumes. The targeted
@@ -483,17 +483,14 @@ def serve_scan_pdf(request: HttpRequest, pk: int) -> HttpResponse:
     logger.info("serve_scan_pdf: resolving pdf for scan=%s", scan.pk)
 
     def _processed_local() -> FileResponse | None:
-        """Return the OCR pdf, else ``bitonal.pdf``, from ``output_dir``."""
+        """Return ``bitonal.pdf`` (or a legacy OCR pdf) from ``output_dir``."""
         output = Path(scan.output_dir)
         if not output.is_dir():
             return None
-        ocr = find_ocr_pdf(scan.output_dir)
-        if ocr:
-            return FileResponse(ocr.open("rb"), content_type="application/pdf")
-        bitonal = output / "bitonal.pdf"
-        if bitonal.exists():
+        base_pdf = find_processing_pdf(scan.output_dir)
+        if base_pdf:
             return FileResponse(
-                bitonal.open("rb"), content_type="application/pdf"
+                base_pdf.open("rb"), content_type="application/pdf"
             )
         return None
 

--- a/uv.lock
+++ b/uv.lock
@@ -142,7 +142,7 @@ wheels = [
 [[package]]
 name = "blackletter"
 version = "0.1.1"
-source = { git = "https://github.com/freelawproject/blackletter?branch=68-make-the-tesseract-text-layer-pass-optional-and-usable-after-redaction#8ab02a2871deaa2321ad75ce8e30c52467959a4f" }
+source = { git = "https://github.com/freelawproject/blackletter?branch=68-make-the-tesseract-text-layer-pass-optional-and-usable-after-redaction#00daa3267c34222a39886061817306bb4de5feaf" }
 dependencies = [
     { name = "numpy" },
     { name = "ocrmypdf" },

--- a/uv.lock
+++ b/uv.lock
@@ -141,14 +141,18 @@ wheels = [
 
 [[package]]
 name = "blackletter"
-version = "0.1.1"
-source = { git = "https://github.com/freelawproject/blackletter?branch=68-make-the-tesseract-text-layer-pass-optional-and-usable-after-redaction#00daa3267c34222a39886061817306bb4de5feaf" }
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "ocrmypdf" },
     { name = "opencv-python" },
     { name = "pillow" },
     { name = "pymupdf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/8a/a744ed3dbe5b00716a91f9b8b9933b125d7aa0b54710ebf4428621bcbf5e/blackletter-0.2.0.tar.gz", hash = "sha256:85a0d08edda53567f92b39bb1d2bc8378ed5a979882cb1a44a7fb1a0b01c01be", size = 170941, upload-time = "2026-08-05T01:36:06.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/61/db2868191379fadb08cea86cc8a6f3b2b897a045cb35a00b27147ad63ed9/blackletter-0.2.0-py3-none-any.whl", hash = "sha256:e909a0f2b96807de7287470874e75dbf1500ae7a7081196c3938c52d1b4f90b5", size = 130766, upload-time = "2026-08-05T01:36:05.595Z" },
 ]
 
 [package.optional-dependencies]
@@ -2355,8 +2359,8 @@ local-ml = [
 
 [package.metadata]
 requires-dist = [
-    { name = "blackletter", git = "https://github.com/freelawproject/blackletter?branch=68-make-the-tesseract-text-layer-pass-optional-and-usable-after-redaction" },
-    { name = "blackletter", extras = ["detect", "analyze"], marker = "extra == 'local-ml'", git = "https://github.com/freelawproject/blackletter?branch=68-make-the-tesseract-text-layer-pass-optional-and-usable-after-redaction" },
+    { name = "blackletter", specifier = ">=0.2.0" },
+    { name = "blackletter", extras = ["detect", "analyze"], marker = "extra == 'local-ml'", specifier = ">=0.2.0" },
     { name = "boto3" },
     { name = "daphne" },
     { name = "django", specifier = ">=6.0,<6.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -142,16 +142,13 @@ wheels = [
 [[package]]
 name = "blackletter"
 version = "0.1.1"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/freelawproject/blackletter?branch=68-make-the-tesseract-text-layer-pass-optional-and-usable-after-redaction#8ab02a2871deaa2321ad75ce8e30c52467959a4f" }
 dependencies = [
+    { name = "numpy" },
     { name = "ocrmypdf" },
     { name = "opencv-python" },
     { name = "pillow" },
     { name = "pymupdf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/f5/0ffcffef51356c9bc6bf43ab933b3aab7badaf769a8a96a007fadf4a2cfa/blackletter-0.1.1.tar.gz", hash = "sha256:a7357cc1fdfd1622659ff6fecf0c4afd87b912bbf74f40529ce726e1ef03236b", size = 114927, upload-time = "2026-07-15T19:21:22.769Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/2a/1792865ca059a20bffac9cb51f21cf6fc8ce309c610b6963bbd044a7dbd8/blackletter-0.1.1-py3-none-any.whl", hash = "sha256:8fe7857ceb5af4f7fc74e2e33583b692c288c3e9b35a5129ffac1b10486e335c", size = 102622, upload-time = "2026-07-15T19:21:21.393Z" },
 ]
 
 [package.optional-dependencies]
@@ -1577,29 +1574,29 @@ wheels = [
 
 [[package]]
 name = "pdfminer-six"
-version = "20251230"
+version = "20260107"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "charset-normalizer" },
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/9a/d79d8fa6d47a0338846bb558b39b9963b8eb2dfedec61867c138c1b17eeb/pdfminer_six-20251230.tar.gz", hash = "sha256:e8f68a14c57e00c2d7276d26519ea64be1b48f91db1cdc776faa80528ca06c1e", size = 8511285, upload-time = "2025-12-30T15:49:13.104Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/a4/5cec1112009f0439a5ca6afa8ace321f0ab2f48da3255b7a1c8953014670/pdfminer_six-20260107.tar.gz", hash = "sha256:96bfd431e3577a55a0efd25676968ca4ce8fd5b53f14565f85716ff363889602", size = 8512094, upload-time = "2026-01-07T13:29:12.937Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/d7/b288ea32deb752a09aab73c75e1e7572ab2a2b56c3124a5d1eb24c62ceb3/pdfminer_six-20251230-py3-none-any.whl", hash = "sha256:9ff2e3466a7dfc6de6fd779478850b6b7c2d9e9405aa2a5869376a822771f485", size = 6591909, upload-time = "2025-12-30T15:49:10.76Z" },
+    { url = "https://files.pythonhosted.org/packages/20/8b/28c4eaec9d6b036a52cb44720408f26b1a143ca9bce76cc19e8f5de00ab4/pdfminer_six-20260107-py3-none-any.whl", hash = "sha256:366585ba97e80dffa8f00cebe303d2f381884d8637af4ce422f1df3ef38111a9", size = 6592252, upload-time = "2026-01-07T13:29:10.742Z" },
 ]
 
 [[package]]
 name = "pdfplumber"
-version = "0.11.9"
+version = "0.11.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pdfminer-six" },
     { name = "pillow" },
     { name = "pypdfium2" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/37/9ca3519e92a8434eb93be570b131476cc0a4e840bb39c62ddb7813a39d53/pdfplumber-0.11.9.tar.gz", hash = "sha256:481224b678b2bbdbf376e2c39bf914144eef7c3d301b4a28eebf0f7f6109d6dc", size = 102768, upload-time = "2026-01-05T08:10:29.072Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/56/6f450312ba05a27d7713b73857c1a25100dbda04fbc1331b13fb227a607d/pdfplumber-0.11.10.tar.gz", hash = "sha256:b95b2d28c66efb0a794a83b88c6c6aea5987532a445d20a1cbcfa657022e6e57", size = 102892, upload-time = "2026-06-15T03:31:31.035Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/c8/cdbc975f5b634e249cfa6597e37c50f3078412474f21c015e508bfbfe3c3/pdfplumber-0.11.9-py3-none-any.whl", hash = "sha256:33ec5580959ba524e9100138746e090879504c42955df1b8a997604dd326c443", size = 60045, upload-time = "2026-01-05T08:10:27.512Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9a/07d658e1e7fad860f1c541ab941348125dbdab773be3a0afaf32361866c7/pdfplumber-0.11.10-py3-none-any.whl", hash = "sha256:7741ea81bf165b474b153e6789d10d18e06b6ddcf3ec84289c3ef2fed6802580", size = 60047, upload-time = "2026-06-15T03:31:29.702Z" },
 ]
 
 [[package]]
@@ -2073,31 +2070,31 @@ wheels = [
 
 [[package]]
 name = "pypdfium2"
-version = "5.6.0"
+version = "5.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3b/01/be763b9081c7eb823196e7d13d9c145bf75ac43f3c1466de81c21c24b381/pypdfium2-5.6.0.tar.gz", hash = "sha256:bcb9368acfe3547054698abbdae68ba0cbd2d3bda8e8ee437e061deef061976d", size = 270714, upload-time = "2026-03-08T01:05:06.5Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/42/0b51bdf50ccf13f3deb3209ca996179a49761dc191748469cf0de55b0055/pypdfium2-5.12.1.tar.gz", hash = "sha256:d0e0648fb2e28f50efcd1ec0a5a18ced9f4d66b2c227fae9b603f0a883b2d13f", size = 274428, upload-time = "2026-07-17T10:01:22.713Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/b1/129ed0177521a93a892f8a6a215dd3260093e30e77ef7035004bb8af7b6c/pypdfium2-5.6.0-py3-none-android_23_arm64_v8a.whl", hash = "sha256:fb7858c9707708555b4a719b5548a6e7f5d26bc82aef55ae4eb085d7a2190b11", size = 3346059, upload-time = "2026-03-08T01:04:21.37Z" },
-    { url = "https://files.pythonhosted.org/packages/86/34/cbdece6886012180a7f2c7b2c360c415cf5e1f83f1973d2c9201dae3506a/pypdfium2-5.6.0-py3-none-android_23_armeabi_v7a.whl", hash = "sha256:6a7e1f4597317786f994bfb947eef480e53933f804a990193ab89eef8243f805", size = 2804418, upload-time = "2026-03-08T01:04:23.384Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/f6/9f9e190fe0e5a6b86b82f83bd8b5d3490348766062381140ca5cad8e00b1/pypdfium2-5.6.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e468c38997573f0e86f03273c2c1fbdea999de52ba43fee96acaa2f6b2ad35f7", size = 3412541, upload-time = "2026-03-08T01:04:25.45Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/8d/e57492cb2228ba56ed57de1ff044c8ac114b46905f8b1445c33299ba0488/pypdfium2-5.6.0-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:ad3abddc5805424f962e383253ccad6a0d1d2ebd86afa9a9e1b9ca659773cd0d", size = 3592320, upload-time = "2026-03-08T01:04:27.509Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/8a/8ab82e33e9c551494cbe1526ea250ca8cc4e9e98d6a4fc6b6f8d959aa1d1/pypdfium2-5.6.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f6b5eb9eae5c45076395454522ca26add72ba8bd1fe473e1e4721aa58521470c", size = 3596450, upload-time = "2026-03-08T01:04:29.183Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/b5/602a792282312ccb158cc63849528079d94b0a11efdc61f2a359edfb41e9/pypdfium2-5.6.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:258624da8ef45cdc426e11b33e9d83f9fb723c1c201c6e0f4ab5a85966c6b876", size = 3325442, upload-time = "2026-03-08T01:04:30.886Z" },
-    { url = "https://files.pythonhosted.org/packages/81/1f/9e48ec05ed8d19d736c2d1f23c1bd0f20673f02ef846a2576c69e237f15d/pypdfium2-5.6.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e9367451c8a00931d6612db0822525a18c06f649d562cd323a719e46ac19c9bb", size = 3727434, upload-time = "2026-03-08T01:04:33.619Z" },
-    { url = "https://files.pythonhosted.org/packages/33/90/0efd020928b4edbd65f4f3c2af0c84e20b43a3ada8fa6d04f999a97afe7a/pypdfium2-5.6.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a757869f891eac1cc1372e38a4aa01adac8abc8fe2a8a4e2ebf50595e3bf5937", size = 4139029, upload-time = "2026-03-08T01:04:36.08Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/49/a640b288a48dab1752281dd9b72c0679fccea107874e80a65a606b00efa9/pypdfium2-5.6.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:515be355222cc57ae9e62cd5c7c350b8e0c863efc539f80c7d75e2811ba45cb6", size = 3646387, upload-time = "2026-03-08T01:04:38.151Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/3b/a344c19c01021eeb5d830c102e4fc9b1602f19c04aa7d11abbe2d188fd8e/pypdfium2-5.6.0-py3-none-manylinux_2_27_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d1c4753c7caf7d004211d7f57a21f10d127f5e0e5510a14d24bc073e7220a3ea", size = 3097212, upload-time = "2026-03-08T01:04:40.776Z" },
-    { url = "https://files.pythonhosted.org/packages/50/96/e48e13789ace22aeb9b7510904a1b1493ec588196e11bbacc122da330b3d/pypdfium2-5.6.0-py3-none-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c49729090281fdd85775fb8912c10bd19e99178efaa98f145ab06e7ce68554d2", size = 2965026, upload-time = "2026-03-08T01:04:42.857Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/06/3100e44d4935f73af8f5d633d3bd40f0d36d606027085a0ef1f0566a6320/pypdfium2-5.6.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a4a1749a8d4afd62924a8d95cfa4f2e26fc32957ce34ac3b674be6f127ed252e", size = 4131431, upload-time = "2026-03-08T01:04:44.982Z" },
-    { url = "https://files.pythonhosted.org/packages/64/ef/d8df63569ce9a66c8496057782eb8af78e0d28667922d62ec958434e3d4b/pypdfium2-5.6.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:36469ebd0fdffb7130ce45ed9c44f8232d91571c89eb851bd1633c64b6f6114f", size = 3747469, upload-time = "2026-03-08T01:04:46.702Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/47/fd2c6a67a49fade1acd719fbd11f7c375e7219912923ef2de0ea0ac1544e/pypdfium2-5.6.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9da900df09be3cf546b637a127a7b6428fb22d705951d731269e25fd3adef457", size = 4337578, upload-time = "2026-03-08T01:04:49.007Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/f5/836c83e54b01e09478c4d6bf4912651d6053c932250fcee953f5c72d8e4a/pypdfium2-5.6.0-py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:45fccd5622233c5ec91a885770ae7dd4004d4320ac05a4ad8fa03a66dea40244", size = 4376104, upload-time = "2026-03-08T01:04:51.04Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/7f/b940b6a1664daf8f9bad87c6c99b84effa3611615b8708d10392dc33036c/pypdfium2-5.6.0-py3-none-musllinux_1_2_riscv64.whl", hash = "sha256:282dc030e767cd61bd0299f9d581052b91188e2b87561489057a8e7963e7e0cb", size = 3929824, upload-time = "2026-03-08T01:04:53.544Z" },
-    { url = "https://files.pythonhosted.org/packages/88/79/00267d92a6a58c229e364d474f5698efe446e0c7f4f152f58d0138715e99/pypdfium2-5.6.0-py3-none-musllinux_1_2_s390x.whl", hash = "sha256:a1c1dfe950382c76a7bba1ba160ec5e40df8dd26b04a1124ae268fda55bc4cbe", size = 4270201, upload-time = "2026-03-08T01:04:55.81Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/ab/b127f38aba41746bdf9ace15ba08411d7ef6ecba1326d529ba414eb1ed50/pypdfium2-5.6.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:43b0341ca6feb6c92e4b7a9eb4813e5466f5f5e8b6baeb14df0a94d5f312c00b", size = 4180793, upload-time = "2026-03-08T01:04:57.961Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/8c/a01c8e4302448b614d25a85c08298b0d3e9dfbdac5bd1b2f32c9b02e83d9/pypdfium2-5.6.0-py3-none-win32.whl", hash = "sha256:9dfcd4ff49a2b9260d00e38539ab28190d59e785e83030b30ffaf7a29c42155d", size = 3596753, upload-time = "2026-03-08T01:05:00.566Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/5f/2d871adf46761bb002a62686545da6348afe838d19af03df65d1ece786a2/pypdfium2-5.6.0-py3-none-win_amd64.whl", hash = "sha256:c6bc8dd63d0568f4b592f3e03de756afafc0e44aa1fe8878cc4aba1b11ae7374", size = 3716526, upload-time = "2026-03-08T01:05:02.433Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/80/0d9b162098597fbe3ac2b269b1682c0c3e8db9ba87679603fdd9b19afaa6/pypdfium2-5.6.0-py3-none-win_arm64.whl", hash = "sha256:5538417b199bdcb3207370c88df61f2ba3dac7a3253f82e1aa2708e6376b6f90", size = 3515049, upload-time = "2026-03-08T01:05:04.587Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7e/bd8df53b1131c582f6646372047b49162032bd01628d49b9a60cd94d2181/pypdfium2-5.12.1-py3-none-android_23_arm64_v8a.whl", hash = "sha256:05bab9b1ba2de7fc299ae2af25cb9c8a0543bc8bb893e879fe8c9ba8310e9ce4", size = 3392276, upload-time = "2026-07-17T10:00:47.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/13/a2b71e17b0439d2af78c817a381e3557371c6c56098581da8485aef65ea6/pypdfium2-5.12.1-py3-none-android_23_armeabi_v7a.whl", hash = "sha256:d4ee061e566a6422b660cdddaaa799a2d1cbf2f016921bcaf24d61426d01d942", size = 2848776, upload-time = "2026-07-17T10:00:49.09Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a8/d7a61700db3022792b28bce5264be90a7d2e7104998362af6b93766f50b2/pypdfium2-5.12.1-py3-none-macosx_13_0_arm64.whl", hash = "sha256:66a9ed40d70a5d728cd42148fecb9d7a0917c6161d6bb67c844093a4ed1df089", size = 3480243, upload-time = "2026-07-17T10:00:50.674Z" },
+    { url = "https://files.pythonhosted.org/packages/01/2c/d7a38fad74b6da0947cf8763aee0f8e6c9d3c12fc8e137aa615f7f8ae76c/pypdfium2-5.12.1-py3-none-macosx_13_0_x86_64.whl", hash = "sha256:847378a5ab41332998b2621b21bab2e96dc8c3eff36a08bce26695b964163983", size = 3643490, upload-time = "2026-07-17T10:00:52.236Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/29/aca739676323558595fcf8cdc8d7939d2b25aaaa6f538e829f1fee938cdd/pypdfium2-5.12.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6eabf028ad8e7bc7811c9acf3a72718c180569b624b844d2c6cc974609784275", size = 3649734, upload-time = "2026-07-17T10:00:53.776Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/e0/e4ecc05f4f1a11d11c8d684a24b2fc8be8207f341be985dac301caa4f6aa/pypdfium2-5.12.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7857cfa6642ec5a09db12ff8f5cf6b6494585b5e3a605399fddc4fb862837b63", size = 3380828, upload-time = "2026-07-17T10:00:55.377Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1b/c94c9d486791276e736350917a11fe2cf3acba2c6c7f03f9ac0d51f8952a/pypdfium2-5.12.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:05bfa20a08a96584253bbe38b60e13f81a037eac31c5579e607ec1480ad25dbf", size = 3777202, upload-time = "2026-07-17T10:00:57.212Z" },
+    { url = "https://files.pythonhosted.org/packages/14/aa/7f81f0c035fc32850dfab9daf78530814f215be226dad7491e3caa0a3e8c/pypdfium2-5.12.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9f059f7bdbdf4352eb83691071096940d769d6ae5930b8734237fdb1bd78fbc2", size = 4186083, upload-time = "2026-07-17T10:00:59.022Z" },
+    { url = "https://files.pythonhosted.org/packages/23/16/21420a6f2bc5f981299c336817dd5d72709dad5fda30ac38cbd5f0f7b372/pypdfium2-5.12.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e10cbf41b21233ec5e20adfc170cf60edd77abead86a97dc708fff55a8a886c7", size = 3701734, upload-time = "2026-07-17T10:01:00.952Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a1/bb89f49e2b3ea3e945b67859d2ec6e73e722a83c006099c675692641e51d/pypdfium2-5.12.1-py3-none-manylinux_2_27_s390x.manylinux_2_28_s390x.whl", hash = "sha256:07eeebb2784f4cd38d386b924235df43217a397442796673296bb6efbdaad1d0", size = 4030403, upload-time = "2026-07-17T10:01:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/80/a7/cea5eb0c39e9c6fdf9853a3008bf021d08f962228073af90354b60c5ccdc/pypdfium2-5.12.1-py3-none-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5c3e6cbe43581af79526184643920ab03a9401a0c79f2226bea9d4d1e3d34008", size = 3994411, upload-time = "2026-07-17T10:01:04.25Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/43/5e470213b27c13b0d94d03d97fc3740507edadea1d1e2ce2049bfbec4aa0/pypdfium2-5.12.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4648f0905441bcb141687ca2263bbf38a1aa056b943eef06019f91cff3e1da4a", size = 4993687, upload-time = "2026-07-17T10:01:05.811Z" },
+    { url = "https://files.pythonhosted.org/packages/db/da/af7972ca72f24ed720db6501333fd67bc66aa6aa5a5ec698551bd30ae62e/pypdfium2-5.12.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:bdff622181fab64f32328591c9c8287cdc745c9a1f2afc26ca3feba39e3e6645", size = 4534560, upload-time = "2026-07-17T10:01:07.291Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/63/06a7f2cd691f7e336cbc53fd65453fee516042c8ddb016bc50d1cd2bed45/pypdfium2-5.12.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:236dbdc88aa54f14b27937ccb2ebe3dcf08c10dbb8652f432ea982dc9af39732", size = 5237681, upload-time = "2026-07-17T10:01:08.997Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f5/937b080671758ab0b3d3d69b2657006682e4c6a0134b36774be4ed1afcfb/pypdfium2-5.12.1-py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:9c8856ce7dd77a7827476c7d75afe1197d6cd505f5cb4167b6aacf661f3f8ea5", size = 5143027, upload-time = "2026-07-17T10:01:10.69Z" },
+    { url = "https://files.pythonhosted.org/packages/32/02/094632700c24728fa443dc89d9d1c6e4fc05bb00778b22e8482fdb133da0/pypdfium2-5.12.1-py3-none-musllinux_1_2_riscv64.whl", hash = "sha256:5f257bb40fa44ce9ba18d2c919777dbd3f16bf22548b1d68fd56c7c92f1de530", size = 4647048, upload-time = "2026-07-17T10:01:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d0/12d84bf55a4fcf2c0ed242afc94168933194f672067e1d162aa60a8e4426/pypdfium2-5.12.1-py3-none-musllinux_1_2_s390x.whl", hash = "sha256:974082344172da76a5c3c0782eaedfe6069dbe88db77d8c671ef36b61e9b14e2", size = 5088747, upload-time = "2026-07-17T10:01:14.42Z" },
+    { url = "https://files.pythonhosted.org/packages/92/9c/92a460bac1f6cfd6f96251802b3098a804fb251dfe0b5eb004ede958ae0e/pypdfium2-5.12.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:715ae16b34ea1d64884d58800155179ba700e9ea65a2f583b020666acd2bfb12", size = 5049695, upload-time = "2026-07-17T10:01:15.961Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/67/53c61d366222550220b42a9212131407f49d3dbcf050178c620bf80fa899/pypdfium2-5.12.1-py3-none-win32.whl", hash = "sha256:e5358d2ce4ebc5c899aab1df9ca5d215357244e9168aa443225d3c1e649c7eac", size = 3725466, upload-time = "2026-07-17T10:01:17.773Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c3/08b62718faf2f6b6aa49207626e3113ff3ec1b3cd076c0ef8fd852f0e57c/pypdfium2-5.12.1-py3-none-win_amd64.whl", hash = "sha256:9609be73a6701a68f29dffe0335f7a2e4b3ba581542ed65d35d49f761a4600ca", size = 3859845, upload-time = "2026-07-17T10:01:19.417Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d5/ad551e55790134c8bc87ea16e0866a3721def0620fbfa19112c8ad4a25a6/pypdfium2-5.12.1-py3-none-win_arm64.whl", hash = "sha256:afc0b7e0c975a429abc75875209ce17b66d749f6ac5cbe8ba72470e83901e304", size = 3674605, upload-time = "2026-07-17T10:01:21.008Z" },
 ]
 
 [[package]]
@@ -2358,8 +2355,8 @@ local-ml = [
 
 [package.metadata]
 requires-dist = [
-    { name = "blackletter", specifier = ">=0.1.1" },
-    { name = "blackletter", extras = ["detect", "analyze"], marker = "extra == 'local-ml'", specifier = ">=0.1.1" },
+    { name = "blackletter", git = "https://github.com/freelawproject/blackletter?branch=68-make-the-tesseract-text-layer-pass-optional-and-usable-after-redaction" },
+    { name = "blackletter", extras = ["detect", "analyze"], marker = "extra == 'local-ml'", git = "https://github.com/freelawproject/blackletter?branch=68-make-the-tesseract-text-layer-pass-optional-and-usable-after-redaction" },
     { name = "boto3" },
     { name = "daphne" },
     { name = "django", specifier = ">=6.0,<6.1" },


### PR DESCRIPTION
Fixes #145. Depends on freelawproject/blackletter#69.

## Why

`run_full_pipeline` ran ocrmypdf/Tesseract over every page as step 3, before detection and page-number analysis. On an 8-core server a full volume spent something like half an hour with every core saturated, in the daemon process, before the reviewer saw anything.

Nothing in the review UI read the text it produced. What the layer was actually buying us was word bounding boxes, and only for geometry: tightening headnote rects, deriving the margin whiteouts, protecting printed page numbers, and deciding whether a generated page was blank. A scanned page is black marks on white, so all four can be measured from the pixels instead. That work is now in blackletter (#68), and this branch takes the pass out and consumes the library.

## What changed

**The pass is gone.** `_run_ocr`, `_ocr`, `_ocr_single_page` and the OCR'd PDF are deleted. `bitonal.pdf` is the processing PDF end to end, resolved through the new `utils.processing_pdf_path`, with the original as a fallback that in production means an S3 pull and is treated as the slow path. Scans processed before this still have their OCR'd PDF and still use it.

**Geometry comes from blackletter, not from here.** `scanning/ink.py` and `scanning/margins.py` are deleted, along with the passes this app used to run over `compute_redaction_rects`' output: column snapping, splitting at headnote detections, growth onto adjoining ink, and pulling margin strips back off real detections. They run inside the library now, so every caller gets the same rects. `_build_combined_redactions` delegates to `api.build_redactions`, the blank-body check to `process.page_body_covered`, and the page-sequence analysis to `validate.build_analysis`. About 1,300 lines of app code removed.

**Searchable LLM pages are opt-in.** `ai.user_prompt` crops three text snippets off each generated page, and with no text layer they come back empty. Rather than reinstate the pass for the whole pipeline, `LLM_PAGE_TEXT_LAYER` runs blackletter's `add_text_layer` over `llm/` at the end of Generate Files, after redaction and masking. Off by default: the model reads the page image anyway.

**One-file S3 pulls.** Three views pulled the scan's entire processing prefix to serve a single file, which is gigabytes on a full volume, and the sync views share one executor under ASGI.

## Behaviour changes worth knowing

Re-checking a scan without applying edits now agrees with the other two recalculation paths, where it used to differ in three ways: a page printed as a range accounts for every number it covers, out-of-range readings reach the issue builder, and a scan with no end page gets missing-page findings across the span it detected.

## Verification

404 tests, up from 374. Checked against a real 1,292-page volume by recomputing its geometry and diffing against what the pre-migration code had stored:

- Ink left uncovered around headnote rects, over 200 pages: **415 px → 198 px**
- Content ink erased by margin strips: **1 px, unchanged**
- Column ink no longer covered that sits inside a HEADNOTE detection: **4 px** across three pages, one to two pixels each
- Column ink no longer covered that sits outside one: 10,083 px, the court's own text the old rects were blacking out

## Before merging

`pyproject.toml` pins blackletter to the #68 branch and `uv.lock` resolves it to a commit, because the ink geometry is unreleased. Once blackletter #69 is merged and tagged, the last commit here has to raise the floor to `blackletter>=0.2.0` and delete the `[tool.uv.sources]` entry. The branch this pin names stops existing when #69 merges.
