### PR TITLE
fix: make Recheck and the original-PDF views work without a local PDF

### DIFF
--- a/scanning/services.py
+++ b/scanning/services.py
@@ -1531,6 +1531,19 @@ def _expected_range(scan: "Scan") -> tuple[int | None, int | None]:
     return scan.start_page or 1, scan.end_page
 
 
+def _is_manual_read(result: dict) -> bool:
+    """Return whether a per-page page number was entered by hand.
+
+    ``assign_page`` stamps ``zone`` and ``ocr`` with ``"manual"`` when a
+    curator types a page number in step 1.
+
+    :param result: One per-page entry from ``Scan.ocr_results``.
+    :returns: ``True`` when the number came from a person, not a model.
+    :rtype: bool
+    """
+    return "manual" in (result.get("ocr"), result.get("zone"))
+
+
 def _split_detected(
     ocr_results: list, exp_start: int | None, exp_end: int | None
 ) -> tuple[list, dict]:
@@ -1675,6 +1688,11 @@ def recalculate_issues(scan: "Scan") -> None:
         in_range_sorted = sorted(in_range_by_page.items())
         offsets = {}
         for r in out_of_range:
+            if _is_manual_read(r):
+                # A curator typed this number, so it outranks the
+                # offset heuristic. It is still reported as an
+                # out-of-range reading below, just not overwritten.
+                continue
             p, detected = r["pdf_page"], int(r["detected"])
             before = [(pp, n) for pp, n in in_range_sorted if pp < p]
             after = [(pp, n) for pp, n in in_range_sorted if pp > p]
@@ -1753,7 +1771,10 @@ def recalculate_issues(scan: "Scan") -> None:
     scan.progress_message = "Done"
     scan.save()
 
-    scan.issues.all().delete()
+    # Suppression flags are curator decisions stored as Issue rows, not
+    # derived from the page numbers, so a recheck keeps them (same
+    # exclusion the daemon rebuild uses).
+    scan.issues.exclude(check_name=CheckName.SUPPRESS_DETECTION).delete()
     Issue.objects.bulk_create(
         [Issue(scan=scan, **i) for i in result["issues"]]
     )

--- a/scanning/services.py
+++ b/scanning/services.py
@@ -1911,8 +1911,13 @@ def _rebuild_issues_from_results(scan_pk: int, all_results: list) -> None:
     out_of_range, seen_nums = _split_in_out_of_range(
         all_results, exp_start, exp_end
     )
+    # Hand-entered numbers outrank the offset heuristic, and blackletter's
+    # _auto_correct does not know about them, so withhold them here. This
+    # keeps a rebuild from clobbering what a recheck preserves.
     all_results, corrections = _auto_correct(
-        all_results, out_of_range, seen_nums
+        all_results,
+        [r for r in out_of_range if not _is_manual_read(r)],
+        seen_nums,
     )
     if corrections:
         out_of_range, seen_nums = _split_in_out_of_range(

--- a/scanning/services.py
+++ b/scanning/services.py
@@ -42,7 +42,6 @@ from blackletter.scanner import _pair_opinions
 from blackletter.validate import (
     _auto_correct,
     _build_issues,
-    _parse_expected_range,
     _split_in_out_of_range,
 )
 from django.conf import settings
@@ -1509,6 +1508,29 @@ def run_incremental_validation(scan_pk: int, pdf_path: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _expected_range(scan: "Scan") -> tuple[int | None, int | None]:
+    """Return the expected first/last printed page numbers for a scan.
+
+    Uses the scanner-entered ``start_page``/``end_page`` fields, the same
+    source the validate stage uses, so a recheck sees the same range the
+    original run did. Deriving it from the uploaded filename instead is
+    both unreliable (the ``.original.pdf`` suffix defeats the
+    reporter.volume.first.last parser) and needs a local copy of the PDF,
+    which production does not keep around between requests.
+
+    Both values are returned together or not at all: every downstream
+    range check needs the pair.
+
+    :param scan: The Scan to read the range from.
+    :returns: ``(exp_start, exp_end)``, or ``(None, None)`` when the scan
+        has no end page recorded.
+    :rtype: tuple[int | None, int | None]
+    """
+    if not scan.end_page:
+        return None, None
+    return scan.start_page or 1, scan.end_page
+
+
 def _split_detected(
     ocr_results: list, exp_start: int | None, exp_end: int | None
 ) -> tuple[list, dict]:
@@ -1536,8 +1558,10 @@ def _split_detected(
             continue
         if num < 1:
             out_of_range.append(r)
-        elif exp_start is not None and (
-            num < exp_start - 5 or num > exp_end + 5
+        elif (
+            exp_start is not None
+            and exp_end is not None
+            and (num < exp_start - 5 or num > exp_end + 5)
         ):
             out_of_range.append(r)
         else:
@@ -1574,7 +1598,7 @@ def _build_analysis(
             for pg in range(int(m.group(1)), int(m.group(2)) + 1):
                 range_pages.add(pg)
 
-    if exp_start is not None and all_nums:
+    if exp_start is not None and exp_end is not None and all_nums:
         missing_pages = sorted(
             (set(range(exp_start, exp_end + 1)) - set(all_nums))
             - range_pages
@@ -1616,10 +1640,7 @@ def rebuild_page_map(scan: "Scan") -> None:
     ocr_results = scan.ocr_results
     if not ocr_results:
         return
-    try:
-        exp_start, exp_end = _parse_expected_range(scan.pdf_path)
-    except FileNotFoundError:
-        exp_start, exp_end = _parse_expected_range(scan.original_pdf.name)
+    exp_start, exp_end = _expected_range(scan)
     analysis = _build_analysis(ocr_results, exp_start, exp_end)
     result = _build_issues(
         analysis, scan.page_count, exp_start=exp_start, exp_end=exp_end
@@ -1632,6 +1653,9 @@ def rebuild_page_map(scan: "Scan") -> None:
 def recalculate_issues(scan: "Scan") -> None:
     """Rebuild issues from scan.ocr_results without re-running OCR.
 
+    Runs off stored data only, so it works on a web pod that never
+    downloaded the scan's processing files from S3.
+
     :param scan: The Scan instance to recalculate issues for.
     """
 
@@ -1639,7 +1663,7 @@ def recalculate_issues(scan: "Scan") -> None:
     if not ocr_results:
         return
 
-    exp_start, exp_end = _parse_expected_range(scan.pdf_path)
+    exp_start, exp_end = _expected_range(scan)
 
     out_of_range, seen_nums = _split_detected(ocr_results, exp_start, exp_end)
 
@@ -1710,8 +1734,16 @@ def recalculate_issues(scan: "Scan") -> None:
             }
         )
 
-    with fitz.open(scan.pdf_path) as pdf_fitz:
-        scan.page_count = len(pdf_fitz)
+    # Refresh page_count opportunistically: the PDF has not changed since
+    # validation, and in production the local copy is usually absent
+    # because rechecks run on a web pod that never pulled it from S3.
+    try:
+        pdf_path = scan.pdf_path
+    except FileNotFoundError:
+        pdf_path = None
+    if pdf_path:
+        with fitz.open(pdf_path) as pdf_fitz:
+            scan.page_count = len(pdf_fitz)
 
     scan.page_map = result["page_map"]
     scan.missing_pages = result["missing_pages"]

--- a/scanning/tests/test_services.py
+++ b/scanning/tests/test_services.py
@@ -1283,6 +1283,103 @@ class TestRecalculateIssues(TestCase):
         scan.refresh_from_db()
         self.assertEqual(scan.page_count, 1)
 
+    def test_auto_corrects_stray_ocr_reading(self):
+        """A stray OCR reading that sits at a consistent offset from its
+        neighbours is corrected to the number the sequence implies."""
+        from scanning import services
+
+        scan = self._make_scan(
+            start_page=1,
+            end_page=4,
+            page_count=4,
+            ocr_results=[
+                {"pdf_page": 1, "detected": "1", "type": "single"},
+                {"pdf_page": 2, "detected": "2", "type": "single"},
+                {"pdf_page": 3, "detected": "3", "type": "single"},
+                {"pdf_page": 4, "detected": "999", "type": "single"},
+            ],
+        )
+
+        services.recalculate_issues(scan)
+
+        scan.refresh_from_db()
+        self.assertEqual(scan.ocr_results[3]["detected"], "4")
+        self.assertTrue(
+            scan.issues.filter(check_name="auto_corrected").exists()
+        )
+
+    def test_manual_page_number_not_auto_corrected(self):
+        """A page number a curator typed is left alone even when it falls
+        outside the volume's range: it is flagged, not overwritten."""
+        from scanning import services
+
+        scan = self._make_scan(
+            start_page=1,
+            end_page=4,
+            page_count=4,
+            ocr_results=[
+                {"pdf_page": 1, "detected": "1", "type": "single"},
+                {"pdf_page": 2, "detected": "2", "type": "single"},
+                {"pdf_page": 3, "detected": "3", "type": "single"},
+                {
+                    "pdf_page": 4,
+                    "detected": "999",
+                    "type": "single",
+                    "zone": "manual",
+                    "ocr": "manual",
+                },
+            ],
+        )
+
+        services.recalculate_issues(scan)
+
+        scan.refresh_from_db()
+        self.assertEqual(scan.ocr_results[3]["detected"], "999")
+        self.assertFalse(
+            scan.issues.filter(check_name="auto_corrected").exists()
+        )
+        self.assertTrue(
+            scan.issues.filter(check_name="suspicious_reading").exists()
+        )
+
+    def test_keeps_suppressed_detection_issues(self):
+        """Recheck rebuilds page-number issues but leaves detection
+        suppressions, which are curator decisions, in place."""
+        from scanning import services
+        from scanning.models import CheckName, Issue
+
+        scan = self._make_scan(
+            start_page=1,
+            end_page=2,
+            page_count=2,
+            ocr_results=[
+                {"pdf_page": 1, "detected": "1", "type": "single"},
+                {"pdf_page": 2, "detected": None, "type": None},
+            ],
+        )
+        Issue.objects.create(
+            scan=scan,
+            check_name=CheckName.SUPPRESS_DETECTION,
+            severity="info",
+            message="detection 42 suppressed",
+        )
+        stale = Issue.objects.create(
+            scan=scan,
+            check_name=CheckName.NO_PAGE_NUMBER,
+            page_number=1,
+            severity="info",
+            message="stale",
+        )
+
+        services.recalculate_issues(scan)
+
+        self.assertTrue(
+            scan.issues.filter(
+                check_name=CheckName.SUPPRESS_DETECTION
+            ).exists()
+        )
+        self.assertFalse(Issue.objects.filter(pk=stale.pk).exists())
+
     def test_rebuild_page_map_without_local_pdf(self):
         """rebuild_page_map (manual page edits) also runs off stored data
         and applies the scan's page range."""

--- a/scanning/tests/test_services.py
+++ b/scanning/tests/test_services.py
@@ -1157,6 +1157,48 @@ class TestImmediateS3PushOnGeneration(TestCase):
 
 
 @override_settings(MEDIA_ROOT=MEDIA_ROOT)
+class TestRebuildIssuesFromResults(TestCase):
+    """The daemon rebuild behind 'Rebuild & Validate' auto-corrects stray
+    OCR readings but leaves hand-entered page numbers alone, matching
+    Recheck. run_reprocess never re-OCRs existing pages, so a manual entry
+    reaches this path with its ``manual`` markers intact.
+    """
+
+    def _results(self, last, **extra):
+        """Three good pages plus a fourth reading, optionally manual."""
+        return [
+            {"pdf_page": 1, "detected": "1", "type": "single"},
+            {"pdf_page": 2, "detected": "2", "type": "single"},
+            {"pdf_page": 3, "detected": "3", "type": "single"},
+            {"pdf_page": 4, "detected": last, "type": "single", **extra},
+        ]
+
+    def test_auto_corrects_stray_ocr_reading(self):
+        """An out-of-range OCR reading is interpolated from its neighbours."""
+        from scanning import services
+
+        scan = ScanFactory(start_page=1, end_page=4, page_count=4)
+        results = self._results("999")
+
+        services._rebuild_issues_from_results(scan.pk, results)
+
+        scan.refresh_from_db()
+        self.assertEqual(scan.ocr_results[3]["detected"], "4")
+
+    def test_manual_page_number_preserved(self):
+        """A curator's typed number survives the rebuild untouched."""
+        from scanning import services
+
+        scan = ScanFactory(start_page=1, end_page=4, page_count=4)
+        results = self._results("999", zone="manual", ocr="manual")
+
+        services._rebuild_issues_from_results(scan.pk, results)
+
+        scan.refresh_from_db()
+        self.assertEqual(scan.ocr_results[3]["detected"], "999")
+
+
+@override_settings(MEDIA_ROOT=MEDIA_ROOT)
 class TestRecalculateIssues(TestCase):
     """Recheck rebuilds issues from stored data.
 

--- a/scanning/tests/test_services.py
+++ b/scanning/tests/test_services.py
@@ -1154,3 +1154,152 @@ class TestImmediateS3PushOnGeneration(TestCase):
             )
 
         push.assert_called_once_with(scan.pk, "rep.1.1.2.pdf")
+
+
+@override_settings(MEDIA_ROOT=MEDIA_ROOT)
+class TestRecalculateIssues(TestCase):
+    """Recheck rebuilds issues from stored data.
+
+    It must not need a local copy of the PDF (production web pods never
+    download one, SCANNING-1S), and the expected page range comes from
+    the scan's start_page/end_page, the same source the validate stage
+    uses, rather than from the uploaded filename.
+    """
+
+    def _make_scan(self, **kwargs):
+        """Create a scan whose original PDF is absent locally, as in prod."""
+        scan = ScanFactory(status=Status.PENDING_REVIEW, **kwargs)
+        pathlib.Path(scan.original_pdf.path).unlink()
+        return scan
+
+    def test_no_local_pdf(self):
+        """Rechecking a scan with no local PDF rebuilds issues instead of
+        raising FileNotFoundError."""
+        from scanning import services
+
+        scan = self._make_scan(
+            start_page=1,
+            end_page=3,
+            page_count=3,
+            ocr_results=[
+                {"pdf_page": 1, "detected": "1", "type": "single"},
+                {"pdf_page": 2, "detected": None, "type": None},
+                {"pdf_page": 3, "detected": "3", "type": "single"},
+            ],
+        )
+        with self.assertRaises(FileNotFoundError):
+            scan.pdf_path
+
+        services.recalculate_issues(scan)
+
+        scan.refresh_from_db()
+        self.assertEqual(scan.status, Status.PENDING_REVIEW)
+        self.assertEqual(scan.page_count, 3)
+        self.assertEqual(
+            [e["pdf_index"] for e in scan.page_map if "pdf_index" in e],
+            [0, 1, 2],
+        )
+        self.assertTrue(
+            scan.issues.filter(check_name="no_page_number").exists()
+        )
+
+    def test_missing_pages_use_scan_page_range(self):
+        """Pages the volume should contain but OCR never saw are reported,
+        even when they fall past the last detected number."""
+        from scanning import services
+
+        scan = self._make_scan(
+            start_page=1,
+            end_page=5,
+            page_count=3,
+            ocr_results=[
+                {"pdf_page": 1, "detected": "1", "type": "single"},
+                {"pdf_page": 2, "detected": "2", "type": "single"},
+                {"pdf_page": 3, "detected": "3", "type": "single"},
+            ],
+        )
+
+        services.recalculate_issues(scan)
+
+        scan.refresh_from_db()
+        self.assertEqual(scan.missing_pages, [4, 5])
+
+    def test_out_of_range_reading_flagged(self):
+        """A number far outside the volume's range is flagged as a stray
+        reading rather than accepted as a real page number."""
+        from scanning import services
+
+        scan = self._make_scan(
+            start_page=1,
+            end_page=5,
+            page_count=1,
+            ocr_results=[
+                {"pdf_page": 1, "detected": "999", "type": "single"},
+            ],
+        )
+
+        services.recalculate_issues(scan)
+
+        scan.refresh_from_db()
+        self.assertTrue(
+            scan.issues.filter(check_name="suspicious_reading").exists()
+        )
+
+    def test_no_end_page_falls_back_to_detected_numbers(self):
+        """Without an end_page there is no expected range, so missing
+        pages are derived from the detected numbers alone."""
+        from scanning import services
+
+        scan = self._make_scan(
+            start_page=1,
+            end_page=None,
+            number_of_pages=None,
+            page_count=2,
+            ocr_results=[
+                {"pdf_page": 1, "detected": "4", "type": "single"},
+                {"pdf_page": 2, "detected": "6", "type": "single"},
+            ],
+        )
+
+        services.recalculate_issues(scan)
+
+        scan.refresh_from_db()
+        self.assertEqual(scan.missing_pages, [5])
+
+    def test_page_count_refreshed_when_pdf_available(self):
+        """When the PDF is on disk, page_count is re-read from it."""
+        from scanning import services
+
+        _require_fixture(self)
+        scan = _make_scan_with_output(
+            status=Status.PENDING_REVIEW,
+            ocr_results=[{"pdf_page": 1, "detected": "1", "type": "single"}],
+        )
+        scan.page_count = 99
+        scan.save(update_fields=["page_count"])
+
+        services.recalculate_issues(scan)
+
+        scan.refresh_from_db()
+        self.assertEqual(scan.page_count, 1)
+
+    def test_rebuild_page_map_without_local_pdf(self):
+        """rebuild_page_map (manual page edits) also runs off stored data
+        and applies the scan's page range."""
+        from scanning import services
+
+        scan = self._make_scan(
+            start_page=1,
+            end_page=4,
+            page_count=2,
+            ocr_results=[
+                {"pdf_page": 1, "detected": "1", "type": "single"},
+                {"pdf_page": 2, "detected": "2", "type": "single"},
+            ],
+        )
+
+        services.rebuild_page_map(scan)
+
+        scan.refresh_from_db()
+        self.assertEqual(scan.missing_pages, [3, 4])
+        self.assertFalse(scan.issues.exists())

--- a/scanning/tests/test_utils.py
+++ b/scanning/tests/test_utils.py
@@ -1,8 +1,15 @@
 """Tests for scanning.utils helpers."""
 
-from django.test import TestCase
+import pathlib
+import tempfile
+from unittest.mock import patch
 
-from scanning.utils import compute_coverage_gaps
+from django.test import TestCase, override_settings
+
+from scanning.factories import ScanFactory
+from scanning.utils import compute_coverage_gaps, local_original_pdf
+
+MEDIA_ROOT = tempfile.mkdtemp()
 
 
 def _op(caption_page, key_page, **extra):
@@ -71,3 +78,61 @@ class TestComputeCoverageGaps(TestCase):
         self.assertEqual(compute_coverage_gaps([], 1, 10), [])
         self.assertEqual(compute_coverage_gaps([_op(0, 3)], None, 10), [])
         self.assertEqual(compute_coverage_gaps([_op(0, 3)], 1, None), [])
+
+
+@override_settings(MEDIA_ROOT=MEDIA_ROOT)
+class TestLocalOriginalPdf(TestCase):
+    """Resolving the original PDF falls back to a targeted S3 pull.
+
+    Production keeps the (multi-GB) original in S3 only, so request
+    handlers that need it must tolerate a pod that never downloaded it
+    rather than raising FileNotFoundError (SCANNING-1S).
+    """
+
+    def _make_scan(self):
+        """Create a scan whose original PDF is absent locally, as in prod."""
+        scan = ScanFactory()
+        pathlib.Path(scan.original_pdf.path).unlink()
+        return scan
+
+    def test_returns_path_when_present(self):
+        """With a local copy the path is returned without touching S3."""
+        scan = ScanFactory()
+        with patch("scanning.s3_sync.download_original_pdf") as download:
+            self.assertEqual(local_original_pdf(scan), scan.original_pdf.path)
+        download.assert_not_called()
+
+    def test_pulls_from_s3_when_missing(self):
+        """A missing original triggers a pull and the retried path wins."""
+        scan = self._make_scan()
+        landed = (
+            pathlib.Path(scan.output_dir)
+            / pathlib.Path(scan.original_pdf.name).name
+        )
+
+        def _land(_scan):
+            landed.parent.mkdir(parents=True, exist_ok=True)
+            landed.write_bytes(b"%PDF-1.4 pulled")
+
+        with patch(
+            "scanning.s3_sync.download_original_pdf", side_effect=_land
+        ) as download:
+            self.assertEqual(local_original_pdf(scan), str(landed))
+        download.assert_called_once_with(scan)
+
+    def test_returns_none_when_pull_finds_nothing(self):
+        """A pull that lands no file yields None, not an exception."""
+        scan = self._make_scan()
+        with patch(
+            "scanning.s3_sync.download_original_pdf", return_value=None
+        ):
+            self.assertIsNone(local_original_pdf(scan))
+
+    def test_returns_none_when_pull_raises(self):
+        """An S3 error is logged and reported as None, not propagated."""
+        scan = self._make_scan()
+        with patch(
+            "scanning.s3_sync.download_original_pdf",
+            side_effect=OSError("s3 down"),
+        ):
+            self.assertIsNone(local_original_pdf(scan))

--- a/scanning/tests/test_views.py
+++ b/scanning/tests/test_views.py
@@ -2201,6 +2201,53 @@ class TestPendingChangesGuard(ScanningTestCase):
 
 
 @override_settings(MEDIA_ROOT=MEDIA_ROOT)
+class TestRecalculateView(ScanningTestCase):
+    """Recheck works on a web pod that never pulled the scan's files from
+    S3, so clicking it in step 1 does not 500 (SCANNING-1S)."""
+
+    def setUp(self):
+        self.user = self.make_user()
+        self.client.force_login(self.user)
+        self.scan = ScanFactory(
+            uploaded_by=self.user,
+            status=Status.PENDING_REVIEW,
+            start_page=1,
+            end_page=2,
+            page_count=2,
+            ocr_results=[
+                {"pdf_page": 1, "detected": "1", "type": "single"},
+                {"pdf_page": 2, "detected": "2", "type": "single"},
+            ],
+        )
+        # Production keeps the PDF in S3 only; the request thread has no
+        # local copy.
+        pathlib.Path(self.scan.original_pdf.path).unlink()
+
+    def test_recheck_without_local_pdf(self):
+        """The Recheck POST redirects back to the viewer and rebuilds the
+        page_map from stored OCR results."""
+        response = self.client.post(
+            reverse("recalculate", kwargs={"pk": self.scan.pk})
+        )
+        self.assertEqual(response.status_code, 302)
+        self.scan.refresh_from_db()
+        self.assertEqual(self.scan.page_count, 2)
+        self.assertTrue(self.scan.page_map)
+
+    def test_recheck_without_ocr_results_is_a_noop(self):
+        """With nothing to recompute the view redirects without touching
+        the scan."""
+        self.scan.ocr_results = []
+        self.scan.save(update_fields=["ocr_results"])
+        response = self.client.post(
+            reverse("recalculate", kwargs={"pk": self.scan.pk})
+        )
+        self.assertEqual(response.status_code, 302)
+        self.scan.refresh_from_db()
+        self.assertEqual(self.scan.page_map, [])
+
+
+@override_settings(MEDIA_ROOT=MEDIA_ROOT)
 class TestProcessActionsFragment(ScanningTestCase):
     """The process_actions endpoint renders the step action bar so the
     viewer can refresh it in place after a deletion/undo."""

--- a/scanning/tests/test_views.py
+++ b/scanning/tests/test_views.py
@@ -2201,6 +2201,68 @@ class TestPendingChangesGuard(ScanningTestCase):
 
 
 @override_settings(MEDIA_ROOT=MEDIA_ROOT)
+class TestViewsWithoutLocalOriginal(ScanningTestCase):
+    """Endpoints that need the original PDF degrade gracefully when it is
+    S3-only and cannot be pulled, instead of raising FileNotFoundError
+    from Scan.pdf_path (SCANNING-1S). The crop endpoint's own lazy pull
+    is covered by TestServeOriginalCrop."""
+
+    def setUp(self):
+        self.user = self.make_user()
+        self.client.force_login(self.user)
+        self.scan = ScanFactory(
+            uploaded_by=self.user,
+            status=Status.PENDING_REVIEW,
+            page_count=1,
+            opinions_json=[{"dummy": True}],
+        )
+        pathlib.Path(self.scan.original_pdf.path).unlink()
+        # An output dir with no bitonal/OCR PDF in it: the API views get
+        # past their "no output directory" guard and fall through to the
+        # original.
+        pathlib.Path(self.scan.output_dir).mkdir(parents=True, exist_ok=True)
+        patcher = patch(
+            "scanning.s3_sync.download_original_pdf", return_value=None
+        )
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def test_export_pdf_returns_404(self):
+        """Export gives a 404 rather than a 500."""
+        response = self.client.get(
+            reverse("export_pdf", kwargs={"pk": self.scan.pk})
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_compute_redactions_returns_json_error(self):
+        """Redaction computation reports a JSON error, not a traceback."""
+        response = self.client.post(
+            reverse("compute_redactions_api", kwargs={"pk": self.scan.pk})
+        )
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.json()["error"], "No PDF available")
+
+    def test_pair_opinions_returns_json_error(self):
+        """Opinion pairing reports a JSON error, not a traceback."""
+        Detection.objects.create(
+            scan=self.scan,
+            page_index=0,
+            label="CAPTION",
+            label_id=1,
+            confidence=0.9,
+            x0=0,
+            y0=0,
+            x1=1,
+            y1=1,
+        )
+        response = self.client.post(
+            reverse("pair_opinions_api", kwargs={"pk": self.scan.pk})
+        )
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.json()["error"], "No PDF available")
+
+
+@override_settings(MEDIA_ROOT=MEDIA_ROOT)
 class TestRecalculateView(ScanningTestCase):
     """Recheck works on a web pod that never pulled the scan's files from
     S3, so clicking it in step 1 does not 500 (SCANNING-1S)."""

--- a/scanning/utils.py
+++ b/scanning/utils.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import itertools
+import logging
 import os
 from pathlib import Path
 
 from django.shortcuts import get_object_or_404
 
 from scanning.models import Scan, Volume
+
+logger = logging.getLogger(__name__)
 
 
 def get_volume(reporter_slug: str, vol: int) -> Volume:
@@ -87,6 +90,38 @@ def ensure_output_dir(scan: Scan) -> Path:
     output_dir = Path(scan.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
     return output_dir
+
+
+def local_original_pdf(scan: Scan) -> str | None:
+    """Return a local path to the scan's original PDF, pulling it if needed.
+
+    In production the original lives only in S3: uploads stream straight
+    there, and the targeted syncs skip it because it can be 3 GB
+    (``download_preview_pdf`` fetches only the bitonal/OCR previews). A
+    request handler that genuinely needs the original therefore cannot
+    rely on ``Scan.pdf_path`` alone, which raises ``FileNotFoundError``
+    on a pod that never pulled the file. This resolves the path, falling
+    back to a one-off S3 pull of just the original.
+
+    :param scan: The scan whose original PDF is needed.
+    :returns: The local filesystem path, or ``None`` when no local copy
+        can be made available.
+    :rtype: str | None
+    """
+    try:
+        return scan.pdf_path
+    except FileNotFoundError:
+        pass
+    try:
+        from scanning import s3_sync
+
+        s3_sync.download_original_pdf(scan)
+    except Exception:
+        logger.exception("Lazy S3 original pull failed for scan %s", scan.pk)
+    try:
+        return scan.pdf_path
+    except FileNotFoundError:
+        return None
 
 
 def compute_coverage_gaps(

--- a/scanning/views_api.py
+++ b/scanning/views_api.py
@@ -42,6 +42,7 @@ from scanning.utils import (
     compute_coverage_gaps,
     find_json_file,
     find_ocr_pdf,
+    local_original_pdf,
 )
 
 logger = logging.getLogger(__name__)
@@ -302,7 +303,9 @@ def pair_opinions_api(request: HttpRequest, pk: int) -> JsonResponse:
     if not det_data:
         return JsonResponse({"error": "No detections found"}, status=400)
     bitonal = output_dir / "bitonal.pdf"
-    pdf_path = str(bitonal) if bitonal.exists() else scan.pdf_path
+    pdf_path = str(bitonal) if bitonal.exists() else local_original_pdf(scan)
+    if not pdf_path:
+        return JsonResponse({"error": "No PDF available"}, status=500)
     try:
         from blackletter.api import pair as bl_pair
 
@@ -350,7 +353,9 @@ def compute_redactions_api(request: HttpRequest, pk: int) -> JsonResponse:
     if not scan.opinions_json:
         return JsonResponse({"error": "No opinions paired yet"}, status=400)
     output_dir = scan.output_dir
-    pdf_path = find_ocr_pdf(output_dir) or scan.pdf_path
+    pdf_path = find_ocr_pdf(output_dir) or local_original_pdf(scan)
+    if not pdf_path:
+        return JsonResponse({"error": "No PDF available"}, status=500)
     try:
         rects = _compute_and_save_redaction_rects(pk, pdf_path)
         _compute_and_save_margin_rects(pk, pdf_path, output_dir)
@@ -949,19 +954,27 @@ def bake_redactions(request: HttpRequest, pk: int) -> JsonResponse:
 
 
 @login_required
-def export_pdf(request: HttpRequest, pk: int) -> StreamingHttpResponse:
+def export_pdf(
+    request: HttpRequest, pk: int
+) -> StreamingHttpResponse | HttpResponse:
     """Export a corrected PDF with deletions and inserts applied.
 
     :param request: The HTTP request.
     :param pk: Scan primary key.
-    :return: PDF file download response.
+    :return: PDF file download response, or a 404 when the original PDF
+        cannot be made available locally.
     """
     scan = get_object_or_404(Scan, pk=pk)
+    # Resolve the source PDF before the temp file exists, so a missing
+    # original is a clean 404 rather than a leaked temp file.
+    original = local_original_pdf(scan)
+    if not original:
+        return HttpResponse(status=404)
     tmp = tempfile.NamedTemporaryFile(suffix=".pdf", delete=False)
     tmp.close()
     tmp_path = tmp.name
     try:
-        with fitz.open(scan.pdf_path) as pdf_doc:
+        with fitz.open(original) as pdf_doc:
             page_map = scan.page_map
             deleted_pages = set(d.pdf_page for d in scan.deletions.all())
             for pdf_page in sorted(deleted_pages, reverse=True):

--- a/scanning/views_process.py
+++ b/scanning/views_process.py
@@ -31,7 +31,11 @@ from scanning.models import (
     Stage,
     Status,
 )
-from scanning.utils import compute_coverage_gaps, find_ocr_pdf
+from scanning.utils import (
+    compute_coverage_gaps,
+    find_ocr_pdf,
+    local_original_pdf,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -576,27 +580,15 @@ def serve_original_crop(request: HttpRequest, pk: int) -> HttpResponse:
         page,
         dpi,
     )
-    try:
-        doc = fitz.open(scan.pdf_path)
-    except FileNotFoundError:
-        # Prod: the original lives only in S3 (direct-to-S3 upload, and the
-        # classic prod path streams straight to S3 too). The process view no
-        # longer eagerly lands it locally, and download_preview_pdf excludes
-        # the original, so pull just the original here and retry.
-        try:
-            from scanning import s3_sync
+    # Prod: the original lives only in S3 (direct-to-S3 upload, and the
+    # classic prod path streams straight to S3 too). The process view no
+    # longer eagerly lands it locally, and download_preview_pdf excludes
+    # the original, so this pulls just the original when it is missing.
+    original = local_original_pdf(scan)
+    if not original:
+        return HttpResponse(status=404)
 
-            s3_sync.download_original_pdf(scan)
-        except Exception:
-            logger.exception(
-                "Lazy S3 original pull failed for scan %s", scan.pk
-            )
-        try:
-            doc = fitz.open(scan.pdf_path)
-        except FileNotFoundError:
-            return HttpResponse(status=404)
-
-    with doc:
+    with fitz.open(original) as doc:
         if page < 0 or page >= doc.page_count:
             return HttpResponse(status=404)
         clip = fitz.Rect(x0, y0, x1, y1)


### PR DESCRIPTION
Fixes SCANNING-1S (https://freelawproject.sentry.io/issues/SCANNING-1S)

Clicking **Recheck** in step 1 raised `FileNotFoundError` from `Scan.pdf_path`. Production web pods have no local copy of the original PDF: S3 is the source of truth, and `PROCESSING_TMP_DIR` is only populated by the daemon or a lazy targeted pull.

## The recheck path never needed the PDF

`recalculate_issues` called `_parse_expected_range(scan.pdf_path)`, but that function only parses the *filename*, so requiring a local file bought nothing. Worse, the parse never worked for portal uploads: `book_upload_path` names files `<reporter>.<volume>.<start>.<end>.original.pdf`, and blackletter's `_infer_from_filename` only strips `.redacted`/`.ocr`/`.compressed`, so `int("original")` fails and it returns `(None, None)`. Verified against every naming path (`book_upload_path`, `_original_pdf_name`, pending-upload recovery, `make_dev_data`) plus Django's collision suffix. None of them parse.

Meanwhile the validate stage (`_dispatch_analyze`, `_rebuild_issues_from_results`) uses `scan.start_page` / `scan.end_page`. So Recheck was silently running with *no* expected range, discarding the missing-page, out-of-range, and mislabeled-document findings the original validation produced. `rebuild_page_map` (manual page-number edits) had the same problem behind a `try/except FileNotFoundError` whose fallback also parsed to `(None, None)`.

New `_expected_range(scan)` helper reads the DB fields, returning both values or neither. Two guards that checked only `exp_start` now require `exp_end` as well, since a scan with a `start_page` but no `end_page` would otherwise hit `None + 5` and `range(1, None)`. The `fitz.open(scan.pdf_path)` page-count refresh is now conditional on the file being present; the PDF has not changed during a recheck, and `page_count` is already stored.

**Behavior change:** rechecks now produce more issues than before on existing scans, because the range checks actually run. That matches the pipeline, so a recheck should now agree with the original validation instead of quietly dropping findings.

## Two consequences of turning the range back on

Giving `recalculate_issues` a real range woke up a ~45-line auto-correction block that had been dead code (with no range, `_split_detected` only ever flagged numbers below 1). It rewrites `ocr_results` and does not know about human input, so a curator who set PDF page 9 to `500` in the step-1 editor would click Recheck and see it silently changed to `9`, with a warning claiming "OCR read '500'". Manual reads (`zone`/`ocr` == `"manual"`, stamped by `assign_page`) are now skipped by the heuristic. They are still reported as out-of-range readings, so the curator gets a warning instead of losing their edit.

Recheck also did `scan.issues.all().delete()`, which took out `suppress_detection` rows. Those are curator decisions, not page-number findings, and the daemon rebuild already excludes them. `recalculate_issues` now does too.

## Same crash class in three other views

`export_pdf` was a guaranteed 500 in production for the same reason: `fitz.open(scan.pdf_path)` with no fallback, and `_is_preview_pdf` deliberately excludes the (up to 3 GB) original from what gets synced to a pod. `pair_opinions_api` and `compute_redactions_api` both evaluated `scan.pdf_path` *outside* their `try`, so a missing `bitonal.pdf` or OCR PDF meant an unhandled exception rather than the JSON error the viewer expects.

`serve_original_crop` already had the right pattern inline (catch, pull just the original, retry, 404). That is now extracted as `utils.local_original_pdf(scan)` and used by all four call sites. The pull stays targeted: `download_original_pdf` fetches only `*.original.pdf`, never the `images/` tree, into `PROCESSING_TMP_DIR`, and remains idempotent, so pods keep the same low-disk profile. Audited the rest: no unguarded `Scan.pdf_path` remains on any request path.

## Testing

`TestRecalculateIssues` and `TestRecalculateView` cover the recheck path (no local PDF, range from the scan, stray-reading flagging, no-`end_page` fallback, manual-edit preservation, suppression preservation). `TestLocalOriginalPdf` covers the helper's four branches, and `TestViewsWithoutLocalOriginal` covers the three endpoints. 351 tests pass.

Verified as real regression tests: 6 of the 8 original recheck tests fail against the parent commit, and the auto-correct pair pins the manual-edit guard from both sides.

## Follow-up, not in this PR

Blackletter's `mislabeled_document` message says "Filename suggests pages X to Y", but the range comes from the DB fields (and did in the pipeline all along). Fix belongs in the blackletter repo.
