### PR TITLE
feat(scanning): return worker outputs via presigned PUT to S3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,10 @@ DB_SSL_MODE=prefer
 # AWS_ACCESS_KEY_ID=
 # AWS_SECRET_ACCESS_KEY=
 # AWS_STORAGE_BUCKET_NAME=
+# Region both buckets live in. Presigned URLs are SigV4, which signs
+# the region into the credential scope, so this must match or S3
+# rejects them. Default us-west-2.
+# AWS_S3_REGION_NAME=us-west-2
 
 # Sentry
 # SENTRY_DSN=
@@ -37,9 +41,10 @@ DB_SSL_MODE=prefer
 # Transport-error retries on /run (network blips, 5xx). Terminal job
 # failures are never retried. Default 2.
 # RUNPOD_MAX_RETRIES=2
-# Lifetime of presigned GET URLs handed to the worker (seconds).
-# Default 86400 (1 day); generous headroom so a URL never expires
-# before the worker fetches it. AWS SigV4 max is 7 days.
+# Lifetime of the presigned URLs handed to the worker (seconds), both
+# the GET for the input PDF and the PUT for the result. Default 86400
+# (1 day); generous headroom so neither expires before the worker gets
+# to it. AWS SigV4 max is 7 days.
 # RUNPOD_PRESIGNED_TTL=86400
 # Max transient RunPod failures (NO_GPU, 404) before a scan escalates
 # to ERROR instead of being re-queued. Default 5.

--- a/scanning/runpod/README.md
+++ b/scanning/runpod/README.md
@@ -21,11 +21,18 @@ in RunPod endpoint env vars, never in the image.
 │                     │  POST  │                      │
 │ runpod_client.py    ├───────▶│ handler.py           │
 │  - upload PDF to S3 │  /run  │  - download PDF via  │
-│  - presign GET URL  │        │    presigned URL     │
+│  - presign GET + PUT│        │    presigned GET     │
 │  - submit job       │        │  - blackletter.api   │
 │  - poll /status     │◀───────│    .detect / analyze │
-│  - return result    │        │  - return JSON       │
-└─────────────────────┘  JSON  └──────────────────────┘
+│  - read result key  │  key   │  - PUT result to S3  │
+│  - fetch from S3    │        │  - return the key    │
+└─────────────────────┘        └──────────────────────┘
+          │                               │
+          │        ┌──────────────┐       │
+          └───────▶│      S3      │◀──────┘
+             GET   │  PDF in,     │  PUT
+                   │  result out  │
+                   └──────────────┘
 ```
 
 Full design rationale, payload-size math, and tradeoffs are in
@@ -433,8 +440,10 @@ pod, the lowest-friction option is #3 — no code changes required.
 ## Result retention
 
 RunPod purges job records after a short window. You **must** poll
-`/status` and persist the output before this window expires, or the
-result is lost.
+`/status` before it expires to learn a job's fate. The *payload*
+survives longer than that when the worker writes it to S3 (see
+[Result delivery](#result-delivery)); only the job record itself is
+subject to the retention below.
 
 | Submission path | Result retention |
 |---|---|
@@ -455,9 +464,23 @@ committed locally, RunPod's retention window no longer matters.
 If the daemon crashes between submission and completion, the in-
 flight job ID is lost. The scan sits in `PROCESSING` until the stale-
 recovery timeout (`DAEMON_PROCESSING_TIMEOUT`, default 3600 s)
-re-queues it. A follow-up improvement would be persisting the job ID
-on the `Scan` so the daemon can resume polling after a crash; not
-implemented yet.
+re-queues it. Persisting the job ID and result key on a job row, so a
+restarted daemon can resume polling or harvest the object instead of
+re-running the work, is issue #150.
+
+Result objects live only in S3, under each scan's
+`processing/{pk}/.../jobs/` prefix. Neither side writes them to disk:
+the worker serialises the envelope in memory and PUTs it, and the
+daemon reads it back into memory and parses it. They're also excluded
+from the processing-file sync in both directions, so nothing lands in
+the `/tmp` tree that `cleanup_processing_tmp` sweeps, and nothing is
+copied into `approved/`.
+
+On S3 the footprint is bounded: one object per scan and action, which
+a re-run overwrites. The consumed data lives in Postgres, so the
+objects left behind by finished scans are dead weight — a lifecycle
+expiry rule on the prefix is the intended cleanup (not yet
+configured).
 
 ## Using this image from the scanning daemon
 
@@ -509,12 +532,13 @@ RUNPOD_API_KEY=<runpod-api-key>
 # reason to change them.
 RUNPOD_REQUEST_TIMEOUT=1800       # wall-clock deadline for submit+poll
 RUNPOD_MAX_RETRIES=2              # transport-error retries on /run
-RUNPOD_PRESIGNED_TTL=86400        # presigned GET URL lifetime, in seconds
+RUNPOD_PRESIGNED_TTL=86400        # presigned URL lifetime, in seconds
 ```
 
 Caveat: remote mode uploads the PDF to S3 under the scan's
 processing prefix and generates a presigned GET URL the worker uses
-to fetch it, so AWS credentials
+to fetch it, plus a presigned PUT the worker writes its result to, so
+AWS credentials
 (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` /
 `AWS_STORAGE_BUCKET_NAME`) must also be set locally. Without those
 you'll get `RunpodError: RUNPOD_ENABLED is true but no AWS
@@ -535,10 +559,23 @@ RUNPOD_API_KEY=<runpod-api-key>          # keep secret; never log
 # Optional tuning (defaults shown)
 RUNPOD_REQUEST_TIMEOUT=1800              # wall-clock cap on submit+poll
 RUNPOD_MAX_RETRIES=2                     # transport-error retries on /run
-RUNPOD_PRESIGNED_TTL=86400               # presigned GET URL lifetime, seconds
+RUNPOD_PRESIGNED_TTL=86400               # presigned URL lifetime, seconds
 ```
 
-Plus the AWS credentials the rest of the app already uses.
+`RUNPOD_PRESIGNED_TTL` has to outlive queue time plus execution,
+because it now signs the **result upload** as well as the input
+download: a job that finishes after its signature dies can't deliver
+what it computed. The default (1 day) leaves the 30-minute
+`RUNPOD_REQUEST_TIMEOUT` deadline well inside it, so we cancel a
+wedged job long before that becomes possible.
+
+Plus the AWS credentials the rest of the app already uses, and
+`AWS_S3_REGION_NAME` if the buckets aren't in the `us-west-2` default.
+That one is newly load-bearing: presigned URLs are now SigV4, which
+signs the region into the credential scope, so a mismatch fails with
+`AuthorizationQueryParametersError` rather than being silently
+redirected. Confirm with
+`aws s3api get-bucket-location --bucket <name>`.
 
 Env vars that belong on the **RunPod endpoint** (not the daemon):
 `SENTRY_DSN_GPU`, `SENTRY_ENV`, `GIT_SHA`, `HANDLER_MAX_PAGES`,
@@ -589,11 +626,32 @@ INFO runpod detect job 63b2d3f6-...-u2 submitted
 
 RunPod purges job records 30 minutes after completion (async path).
 If the daemon misses the retention window (long pause, crash, etc.),
-`GET /status/{id}` returns 404. The client treats this as a
-**transient** error: the scan goes back to `QUEUED` and the next
-daemon tick submits a fresh job with a new presigned URL. The input
-files on S3 are untouched, so no work is lost beyond the one
-discarded GPU run.
+`GET /status/{id}` returns 404. That used to throw the run away. Now
+the result object outlives the job record, and the client holds the
+key in memory for the duration of the poll, so it checks S3 first:
+
+1. `/status` says COMPLETED — read the object at `result_key`.
+2. `/status` returns 404 — `head_object` on `result_key`. An object
+   written after this job was submitted means the worker finished and
+   uploaded before RunPod dropped the record, so harvest it. Nothing
+   there, or something older, means this run produced nothing:
+   re-queue and resubmit as before.
+3. `/status` says FAILED — the existing retry path, unchanged.
+
+Presence is sufficient evidence of completeness because a single PUT
+is atomic: a partial upload never becomes a gettable object. The
+write-time check is what makes step 2 safe on a key that gets reused
+across runs.
+
+The key only lives in the daemon's memory, so this covers a job that
+outlives RunPod's retention, not a daemon that restarts mid-flight.
+That needs the key persisted on a job row (#150), which is also what
+turns the blocking poll into a sweep.
+
+Polling S3 alone would never be enough either: a failed job also
+writes nothing, so absence can't distinguish "still queued" from
+"failed". Job status stays the authority; S3 is only ever consulted
+after it.
 
 ## Development workflow
 
@@ -610,7 +668,79 @@ discarded GPU run.
 
 ## Handler contract
 
-`handler(job)` dispatches on `job["input"]["action"]`:
+`handler(job)` dispatches on `job["input"]["action"]`.
+
+### Result delivery
+
+Every action supports two ways of returning its payload, picked per
+job by whether the daemon put a `result_url` in the input:
+
+| Input field  | Meaning |
+|---|---|
+| `result_url` | Presigned S3 **PUT**, covering exactly one object. Its presence switches the worker to S3 delivery. |
+| `result_key` | The key that URL signs — `processing/{pk}/.../jobs/{action}/result.json`. Echoed back in the response; the worker never derives it. |
+
+The key is per scan and action, not per run, so a re-run overwrites
+its predecessor instead of leaving orphans nobody will read. The
+daemon never reads an object without first checking (via
+`head_object`) that it was written after the reading job was
+submitted, which is what stops a reused key from serving a previous
+attempt's output.
+
+With `result_url` present, the worker writes one JSON object with a
+single PUT and answers with the key plus timings only:
+
+```json
+{
+  "status": "succeed",
+  "action": "detect",
+  "result_key": "processing/123/f2d/12/1/jobs/detect/result.json",
+  "bytes": 4823910,
+  "sha256": "9f2c...",
+  "upload_ms": 1840,
+  "duration_ms": 47300,
+  "model_durations_ms": {"small": 12000, "medium": 15000, "large": 20300},
+  "page_count": 312,
+  "worker_boot_ms": 42150,
+  "worker_uptime_ms": 128,
+  "gpu_available": true
+}
+```
+
+Nothing touches the worker's disk on the way out: the envelope is
+serialised in memory and streamed to S3.
+
+The object itself is a self-describing envelope, so a consumer can
+tell what it read without trusting where it read it from:
+
+```json
+{
+  "schema_version": 1,
+  "action": "detect",
+  "scan_pk": 123,
+  "job_id": "abc-123",
+  "payload": {"detections": [...], "page_count": 312, "duration_ms": 47300}
+}
+```
+
+The daemon checks every one of those fields before using the payload,
+so an object from another run, another action, or a future schema
+fails loudly instead of being consumed as this job's result.
+
+Why bother: an inline response is capped at ~20 MB (the reason we
+can't return per-word bounding boxes) and evaporates with RunPod's
+retention window. An S3 object has neither limit. There is
+deliberately **no inline fallback** when `result_url` is present:
+carrying the payload in the response "just in case" would reinstate
+the cap and create two sources of truth.
+
+Without `result_url` the worker returns the payload inline, exactly
+as the sections below describe. That is what happens in dev / CI
+without AWS credentials, and with daemons predating this contract.
+It's also the rollback: redeploying a worker image from before this
+contract reverts result delivery to inline with no daemon change,
+because the daemon accepts an inline response even when it sent a
+`result_url`.
 
 ### `detect`
 
@@ -676,6 +806,23 @@ on the following conditions:
 | `NO_GPU`        | Worker scheduled without a GPU              | Re-queue the scan (transient) |
 | `BAD_INPUT`     | `action` missing/wrong type                 | Mark scan ERROR    |
 | `UNKNOWN_ACTION`| `action` not in `{"detect", "analyze"}`     | Mark scan ERROR    |
+| `RESULT_UPLOAD_FAILED` | The PUT to S3 failed after retries (5xx, 429, dropped connections) | Re-queue the scan (transient) |
+| `RESULT_URL_EXPIRED`   | The presigned PUT is dead (HTTP 403)  | Re-queue the scan; resubmitting mints a fresh signature, and the dead URL is never reused |
+| `RESULT_UPLOAD_REJECTED` | S3 refused the write for a reason a re-run can't fix: a signature scoped to the wrong region, a bucket policy demanding a header we don't send, a malformed request | Mark scan ERROR |
+
+The result codes only ever fire *after* the GPU work succeeded, so
+they cost a run. `_put_result` retries hard (5 attempts, exponential
+backoff with jitter) on the transient shapes, and skips the retries
+for 403 and other 4xx because neither improves by being asked twice.
+
+`RESULT_UPLOAD_REJECTED` is terminal on purpose. It means the
+deployment is misconfigured, so re-queueing would re-run the GPU work
+— and re-bill it — up to `RUNPOD_MAX_TRANSIENT_RETRIES` times before
+failing with the same message. S3's XML explanation is included in the
+error, which is usually enough to fix it outright.
+
+A job that fails any of these ways never writes its object, so nothing
+stale is left behind for the retry to trip over.
 
 Real exceptions inside the action (network failure during download,
 ValueError from the handler, CUDA OOM) propagate up and turn into
@@ -718,6 +865,20 @@ holds `RUNPOD_API_KEY`, so only the daemon can submit jobs." If that
 ever changes, tighten the handler by validating the URL scheme
 (`https` only), optionally pinning a host allowlist, and rejecting
 suspicious redirects.
+
+### The presigned PUT is a write capability
+
+`result_url` hands a third-party GPU host the ability to write to our
+bucket. It stays deliberately narrow: one key, one method, and a
+bounded TTL (`RUNPOD_PRESIGNED_TTL`). The key is under the scan's own
+`jobs/` subtree, so even a leaked or misused URL can only create one
+object the daemon already expected, at a path nothing else reads.
+
+The alternative -- scoped temporary credentials via STS -- would be
+more flexible but would put an AWS credential in the worker's
+environment, giving up the property this image deliberately has: no
+AWS credentials anywhere in it. Both the GET and the PUT are
+capabilities handed in per job and expiring on their own.
 
 ### Container root user
 

--- a/scanning/runpod/handler.py
+++ b/scanning/runpod/handler.py
@@ -7,8 +7,19 @@ Dispatches on ``job["input"]["action"]`` to run one of:
 - ``analyze``: PaddleOCR + YOLO page-number analysis. Returns the
   per-page results list.
 
-Returns JSON inline in the RunPod HTTP response. Does not write to
-S3, does not need AWS credentials.
+Result delivery has two modes, picked per job by the daemon:
+
+- **S3** (``result_url`` present in the input): the payload is written
+  to S3 with a single PUT against a presigned URL, and the response
+  carries only the key, size, digest and timings. This is the path
+  that lifts the ~20 MB inline response cap and outlives RunPod's
+  result-retention window.
+- **Inline** (``result_url`` absent): the payload comes back in the
+  job response exactly as it always has. Keeps dev / CI and older
+  daemons working.
+
+Either way the worker needs no AWS credentials: a presigned PUT is a
+capability handed in with the job, scoped to one key and one method.
 
 Models are preloaded at module import time so cold start pays the
 load cost once; subsequent warm invocations reuse in-process caches.
@@ -16,7 +27,9 @@ load cost once; subsequent warm invocations reuse in-process caches.
 
 from __future__ import annotations
 
+import hashlib
 import io
+import json
 import logging
 import os
 import random
@@ -85,11 +98,38 @@ DOWNLOAD_BACKOFF_CAP = int(
     os.environ.get("HANDLER_DOWNLOAD_BACKOFF_CAP", "30")
 )
 
+# Result-upload budget. The GPU work is already paid for by the time we
+# PUT, so a network blip must not cost a re-run: retry generously.
+RESULT_UPLOAD_MAX_ATTEMPTS = int(
+    os.environ.get("HANDLER_RESULT_UPLOAD_MAX_ATTEMPTS", "5")
+)
+RESULT_UPLOAD_TIMEOUT = int(
+    os.environ.get("HANDLER_RESULT_UPLOAD_TIMEOUT", "300")
+)
+RESULT_UPLOAD_CONNECT_TIMEOUT = int(
+    os.environ.get("HANDLER_RESULT_UPLOAD_CONNECT_TIMEOUT", "10")
+)
+RESULT_UPLOAD_BACKOFF_CAP = int(
+    os.environ.get("HANDLER_RESULT_UPLOAD_BACKOFF_CAP", "30")
+)
+
+# Version of the JSON envelope written to S3. Bump when the envelope's
+# shape changes incompatibly; the daemon refuses versions it doesn't
+# know rather than consuming a payload it may misread.
+RESULT_SCHEMA_VERSION = 1
+
+# Content type sent on the result PUT. The daemon signs this exact
+# value into the presigned URL (``_presign_result_put``), so the two
+# must stay in lockstep: S3 answers SignatureDoesNotMatch if the header
+# it verifies differs from the one that was signed.
+RESULT_CONTENT_TYPE = "application/json"
+
 # Stream errors that mean "the connection died mid-transfer" — safe to
-# reconnect and resume from the last byte written. Anything else (a 4xx
-# other than the handled 403/416, a 5xx, a malformed URL) is not in here
-# and propagates so the daemon can re-queue or fail the scan.
-_TRANSIENT_DOWNLOAD_ERRORS = (
+# reconnect (resuming from the last byte written on a download, or
+# re-PUTting the whole object on an upload). Anything else (a 4xx other
+# than the handled 403/416, a 5xx, a malformed URL) is not in here and
+# propagates so the daemon can re-queue or fail the scan.
+_TRANSIENT_TRANSFER_ERRORS = (
     requests.exceptions.ChunkedEncodingError,
     requests.exceptions.ConnectionError,
     requests.exceptions.Timeout,
@@ -394,7 +434,7 @@ def _download_pdf(url: str, dest: Path) -> None:
                             offset += len(chunk)
             # Stream drained without raising: this attempt finished.
             break
-        except _TRANSIENT_DOWNLOAD_ERRORS as exc:
+        except _TRANSIENT_TRANSFER_ERRORS as exc:
             # Re-derive the offset from disk: a partial write may have
             # landed bytes the in-memory counter didn't account for.
             offset = dest.stat().st_size if dest.exists() else 0
@@ -507,6 +547,206 @@ def _validate_pdf(pdf_path: Path) -> int:
     if page_count < 1:
         raise ValueError(f"downloaded PDF has no pages: {pdf_path}")
     return page_count
+
+
+# ── Result delivery ─────────────────────────────────────────────────
+class ResultUploadError(RuntimeError):
+    """The result object could not be written to S3.
+
+    Surfaces to the daemon as ``error_code=RESULT_UPLOAD_FAILED``,
+    which it classifies as transient: the job is resubmitted with a
+    fresh presigned URL. The GPU run is lost, which is why
+    :func:`_put_result` retries hard before raising this.
+    """
+
+    error_code = "RESULT_UPLOAD_FAILED"
+
+
+class ResultUploadRejectedError(ResultUploadError):
+    """S3 refused the write for a reason a re-run can't fix.
+
+    Anything that isn't a 403 or a retryable 5xx/429: a wrong region in
+    the signature, a bucket policy that demands a header we don't send,
+    a malformed request. Surfaces as ``RESULT_UPLOAD_REJECTED``, which
+    the daemon treats as **terminal**. That distinction is worth its
+    keep -- these are configuration errors, and classifying them
+    transient means the scan re-runs the GPU work (and pays for it)
+    once per retry before failing with the same message anyway.
+    """
+
+    error_code = "RESULT_UPLOAD_REJECTED"
+
+
+class ResultUrlExpiredError(ResultUploadError):
+    """The presigned PUT URL is no longer valid (HTTP 403).
+
+    Distinct from a generic upload failure because retrying the *same*
+    URL can never succeed: the signature is dead. Mirrors how
+    :func:`_download_pdf` treats a 403 on the input URL. Still
+    transient daemon-side, since resubmitting mints a new signature.
+    """
+
+    error_code = "RESULT_URL_EXPIRED"
+
+
+def _put_result(url: str, body: bytes) -> None:
+    """Upload ``body`` to a presigned PUT URL, retrying transient errors.
+
+    One PUT, one object: no multipart. A single PUT is atomic in S3, so
+    the object only becomes gettable once every byte has landed. That is
+    what lets the daemon treat "the object exists" as "the result is
+    complete" when it recovers a job whose ``/status`` record is gone.
+
+    Only accepts ``http(s)`` URLs, for the same defensive reason
+    :func:`_download_pdf` does.
+
+    :param url: Presigned S3 PUT URL covering exactly one key.
+    :param body: Encoded JSON envelope.
+    :raises ResultUrlExpiredError: On HTTP 403 (dead signature).
+    :raises ResultUploadError: On any other non-2xx, or once the
+        retries are exhausted.
+    """
+    if not isinstance(url, str) or not url.startswith(("http://", "https://")):
+        raise ResultUploadError(
+            f"refusing to upload result to non-http(s) URL: {url!r}"
+        )
+
+    timeout = (RESULT_UPLOAD_CONNECT_TIMEOUT, RESULT_UPLOAD_TIMEOUT)
+    last_error = ""
+
+    for attempt in range(RESULT_UPLOAD_MAX_ATTEMPTS):
+        try:
+            r = requests.put(
+                url,
+                data=body,
+                headers={"Content-Type": RESULT_CONTENT_TYPE},
+                timeout=timeout,
+            )
+            # Expired or otherwise invalid signature. Retrying the same
+            # URL is pointless; fail fast so the daemon re-signs.
+            #
+            # A bucket policy that rejects the PUT (a required
+            # encryption header, say) also answers 403, and no amount
+            # of re-signing fixes that -- it just burns the daemon's
+            # transient retries, one paid GPU run each. S3's reason is
+            # in the body, so log it rather than assuming expiry.
+            if r.status_code == 403:
+                raise ResultUrlExpiredError(
+                    "presigned PUT rejected with HTTP 403 (expired "
+                    "signature, or the bucket refused the write): "
+                    f"{r.text[:300]}"
+                )
+            if r.status_code < 300:
+                return
+            # 5xx / 429 are S3 hiccups worth another attempt; anything
+            # else is a configuration error that fails identically on
+            # every retry, so stop and say so terminally.
+            if r.status_code != 429 and r.status_code < 500:
+                raise ResultUploadRejectedError(
+                    f"result upload rejected with HTTP {r.status_code}: "
+                    f"{r.text[:300]}"
+                )
+            last_error = f"HTTP {r.status_code}"
+        except _TRANSIENT_TRANSFER_ERRORS as exc:
+            last_error = str(exc)
+
+        if attempt == RESULT_UPLOAD_MAX_ATTEMPTS - 1:
+            break
+        backoff = min(2**attempt, RESULT_UPLOAD_BACKOFF_CAP)
+        backoff += random.uniform(0, backoff / 2)  # jitter
+        logger.warning(
+            "result upload attempt %d/%d failed (%s); retrying in %.1fs",
+            attempt + 1,
+            RESULT_UPLOAD_MAX_ATTEMPTS,
+            last_error,
+            backoff,
+        )
+        time.sleep(backoff)
+
+    raise ResultUploadError(
+        f"result upload failed after {RESULT_UPLOAD_MAX_ATTEMPTS} "
+        f"attempts: {last_error}"
+    )
+
+
+def _result_envelope(
+    result: dict, action: str, scan_pk: Any, job_id: Any
+) -> dict:
+    """Wrap an action's result in the self-describing S3 envelope.
+
+    The envelope exists so a consumer can tell *what* it just read
+    without trusting the key it read it from: schema version, which
+    action produced it, and which scan and job it belongs to. The
+    daemon checks all of that before using the payload.
+
+    :param result: The action's return dict.
+    :param action: Handler action that produced it.
+    :param scan_pk: Scan the job belongs to.
+    :param job_id: RunPod job id, i.e. which run generated this object.
+    :returns: The envelope to serialise.
+    :rtype: dict
+    """
+    return {
+        "schema_version": RESULT_SCHEMA_VERSION,
+        "action": action,
+        "scan_pk": scan_pk,
+        "job_id": job_id,
+        "payload": result,
+    }
+
+
+def _deliver_result(
+    result: dict, inputs: dict, action: str, job: dict
+) -> dict:
+    """PUT the result to S3 and return the slim job response.
+
+    Nothing is written to the worker's disk: the envelope is
+    serialised in memory and streamed straight to S3.
+
+    The response deliberately carries no copy of the payload. An
+    inline fallback would reinstate the size cap this exists to escape
+    and leave two sources of truth for one result. What's left is what
+    the daemon needs to find the object and log how the run went.
+
+    :param result: The action's return dict.
+    :param inputs: Handler input payload (``result_url`` /
+        ``result_key``).
+    :param action: Handler action that produced ``result``.
+    :param job: RunPod job dict, for the job id.
+    :returns: ``{"status": "succeed", "action", "result_key", "bytes",
+        "sha256", "upload_ms", ...timings}``.
+    :rtype: dict
+    :raises ResultUploadError: If the upload fails (see
+        :func:`_put_result`).
+    """
+    envelope = _result_envelope(
+        result, action, inputs.get("scan_pk"), job.get("id")
+    )
+    body = json.dumps(envelope, separators=(",", ":")).encode("utf-8")
+
+    t0 = time.monotonic()
+    _put_result(inputs["result_url"], body)
+    upload_ms = int((time.monotonic() - t0) * 1000)
+
+    result_key = inputs.get("result_key")
+    logger.info(
+        "result uploaded: %d bytes in %d ms (action=%s key=%s)",
+        len(body),
+        upload_ms,
+        action,
+        result_key,
+    )
+    return {
+        "status": "succeed",
+        "action": action,
+        "result_key": result_key,
+        "bytes": len(body),
+        "sha256": hashlib.sha256(body).hexdigest(),
+        "upload_ms": upload_ms,
+        "duration_ms": result.get("duration_ms"),
+        "model_durations_ms": result.get("model_durations_ms"),
+        "page_count": result.get("page_count"),
+    }
 
 
 # ── Actions ─────────────────────────────────────────────────────────
@@ -693,7 +933,10 @@ def handler(job: dict) -> dict:
 
     :param job: RunPod job dict. ``job["input"]`` must carry an
         ``action`` ("detect" | "analyze") and action-specific args.
-        An optional ``scan_pk`` is used to tag Sentry events.
+        An optional ``scan_pk`` is used to tag Sentry events. When
+        ``result_url`` (presigned PUT) and ``result_key`` are present
+        the payload goes to S3 and the response carries only the key,
+        size, digest and timings; otherwise it comes back inline.
     :returns: Action-specific result dict. Every successful return
         (and every structured error) also carries ``worker_boot_ms``
         (cold-start cost of this worker process, constant per
@@ -754,7 +997,27 @@ def handler(job: dict) -> dict:
     tmp_dir = Path(tempfile.mkdtemp(prefix="runpod-"))
     try:
         result = fn(inputs, tmp_dir)
-        return _with_worker_meta(result)
+        if not inputs.get("result_url"):
+            # No presigned PUT in the input: answer inline, as always.
+            return _with_worker_meta(result)
+        return _with_worker_meta(_deliver_result(result, inputs, action, job))
+    except ResultUploadError as exc:
+        # The compute succeeded and the delivery didn't, so this is
+        # worth a Sentry event: the job will be re-run and re-billed.
+        # Returned as a structured error rather than raised so the
+        # daemon can read ``error_code`` and classify it as transient.
+        if sentry_sdk is not None:
+            sentry_sdk.capture_exception(exc)
+        logger.error(
+            "result delivery failed: action=%s scan_pk=%s key=%s: %s",
+            action,
+            scan_pk,
+            inputs.get("result_key"),
+            exc,
+        )
+        return _with_worker_meta(
+            {"error": str(exc), "error_code": exc.error_code}
+        )
     except Exception as exc:
         if sentry_sdk is not None:
             sentry_sdk.capture_exception(exc)

--- a/scanning/runpod_client.py
+++ b/scanning/runpod_client.py
@@ -10,32 +10,57 @@ Remote mode flow:
 
 1. Upload the PDF to S3 under the scan's processing prefix if it's
    not already there (idempotent via ``head_object``).
-2. Generate a presigned GET URL.
+2. Generate a presigned GET URL for the input, and a presigned PUT
+   URL for the result key the worker will write to.
 3. ``POST /run`` to the RunPod endpoint with
-   ``{"input": {"action": ..., "pdf_url": ..., ...}}``.
+   ``{"input": {"action": ..., "pdf_url": ..., "result_url": ...}}``.
 4. Poll ``GET /status/{id}`` with exponential backoff until a
    terminal state (``COMPLETED`` / ``FAILED`` / ``TIMED_OUT`` /
    ``CANCELLED``). On timeout, ``POST /cancel/{id}`` so we stop
    paying.
-5. Return the handler's ``output`` dict.
+5. Read the result object off S3, validate its envelope, and return
+   the payload merged with the job's timing metadata.
 
-Payload size budget (see RUNPOD_MIGRATION_PLAN.md §5): ~2 MB for
-detect on a 500-page volume, ~0.5 MB for analyze. Well under
-RunPod's ~20 MB response cap.
+Job status stays the authority for whether a job finished: we poll to
+a terminal state, then pull the object. The one exception is a 404
+from ``/status`` (the job aged out of RunPod's retention window):
+there the key we hold in memory is checked with a ``head_object``
+before the run is thrown away and resubmitted.
+
+Why the payload travels through S3 rather than inline in the job
+response: RunPod caps a response at ~20 MB, which is the reason we
+can't return per-word bounding boxes, and it discards the response
+entirely once the ~30 min retention window closes. An S3 object has
+neither limit and outlives both.
+
+Result keys are per scan and action rather than per run, so a re-run
+overwrites its predecessor instead of leaving orphans behind. Nothing
+is read without first checking the object was written after the
+reading job was submitted, which is what keeps a reused key from
+serving a previous attempt's output.
+
+Inline results remain supported and are still what a worker returns
+when ``result_url`` is absent from the input, which is the case in
+dev / CI without AWS credentials and with worker images predating the
+contract. Rolling the worker image back is therefore enough to revert
+to inline delivery, with no daemon change.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import tempfile
 import time
 from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import boto3
 import requests
-from botocore.exceptions import ClientError
+from botocore.config import Config
+from botocore.exceptions import BotoCoreError, ClientError
 from django.conf import settings
 
 if TYPE_CHECKING:
@@ -61,7 +86,32 @@ class RunpodTransientError(RunpodError):
 
 # Error codes the handler emits that the client translates into a
 # ``RunpodTransientError`` (retry) rather than ``RunpodError`` (fail).
-_TRANSIENT_ERROR_CODES = {"NO_GPU"}
+#
+# ``RESULT_UPLOAD_FAILED`` / ``RESULT_URL_EXPIRED``: the compute
+# succeeded but the worker couldn't deliver it, so nothing was written
+# and there is nothing to harvest. Resubmitting is the only recovery,
+# and it mints a fresh presigned PUT -- which is what an expired
+# signature needs, since the dead URL can never be reused.
+#
+# Deliberately absent: ``RESULT_UPLOAD_REJECTED``, which S3 returns for
+# a misconfiguration (wrong signing region, a bucket policy demanding
+# headers we don't send). Every retry re-runs the GPU work, pays for
+# it, and fails identically, so that one stays terminal.
+_TRANSIENT_ERROR_CODES = {
+    "NO_GPU",
+    "RESULT_UPLOAD_FAILED",
+    "RESULT_URL_EXPIRED",
+}
+
+# Version of the result envelope this client understands. Must match
+# ``RESULT_SCHEMA_VERSION`` in ``scanning/runpod/handler.py``.
+RESULT_SCHEMA_VERSION = 1
+
+# Slack allowed between our clock and S3's when deciding whether a
+# result object was written by the run that's reading it. Generous
+# enough that a skewed clock never discards a good result, far short
+# of the minutes between a job and its retry.
+_RESULT_CLOCK_SKEW = timedelta(seconds=60)
 
 # RunPod ``/run`` submit-time error codes that mean "the endpoint can't
 # take work right now" rather than "this job is bad" -- e.g. the
@@ -81,14 +131,20 @@ _ACTION_LABELS = {
     "analyze": "OCR (analyze)",
 }
 
+# Input fields holding a presigned URL. Masked before logging.
+_SIGNED_URL_FIELDS = ("pdf_url", "result_url")
 
-def _redact_pdf_url(body: dict[str, Any]) -> dict[str, Any]:
+
+def _redact_urls(body: dict[str, Any]) -> dict[str, Any]:
     """Return a shallow copy of the RunPod submit body with any
-    ``pdf_url`` under ``input`` replaced by ``***``.
+    presigned URL under ``input`` replaced by ``***``.
 
-    Presigned GET URLs grant time-limited read access to a single S3
-    object. They should never land in persistent logs (even at DEBUG),
-    so we mask them before passing the body to ``logger``.
+    Presigned URLs grant time-limited access to a single S3 object:
+    read for ``pdf_url``, **write** for ``result_url``. Neither should
+    land in persistent logs (even at DEBUG), so we mask them before
+    passing the body to ``logger``. ``result_key`` is left visible --
+    it's the key alone, no capability attached, and it's the thing
+    you need in a log line to find a job's output later.
 
     :param body: The ``{"input": {...}}`` dict about to be POSTed.
     :returns: A masked shallow copy safe to log.
@@ -96,8 +152,10 @@ def _redact_pdf_url(body: dict[str, Any]) -> dict[str, Any]:
     """
     redacted = {**body}
     inp = redacted.get("input")
-    if isinstance(inp, dict) and "pdf_url" in inp:
-        redacted["input"] = {**inp, "pdf_url": "***"}
+    if isinstance(inp, dict):
+        masked = {field: "***" for field in _SIGNED_URL_FIELDS if field in inp}
+        if masked:
+            redacted["input"] = {**inp, **masked}
     return redacted
 
 
@@ -281,6 +339,38 @@ def _analyze_local(
 
 
 # ── Remote: S3 presigning ───────────────────────────────────────────
+# Content type the worker PUTs its result with. Signed into the URL,
+# so the two must agree exactly -- see :func:`_presign_result_put`.
+_RESULT_CONTENT_TYPE = "application/json"
+
+
+def _s3() -> Any:
+    """Return an S3 client pinned to SigV4 and the bucket's region.
+
+    Both halves matter, and neither is the ambient default:
+
+    - **Signature version.** A bare ``boto3.client("s3")`` inherits
+      whatever the local AWS config resolves to, and some environments
+      still resolve to SigV2. That's invisible for a presigned GET (the
+      worker sends no signed headers when downloading) but fatal for
+      the result PUT: SigV2 folds ``Content-Type`` into the string to
+      sign, so a URL signed without it and a request sent with it
+      disagree -- ``SignatureDoesNotMatch``.
+    - **Region.** SigV4 encodes the region into the credential scope,
+      so signing for the wrong one is rejected outright with
+      ``AuthorizationQueryParametersError``. Unset, boto3 assumes
+      ``us-east-1``. SigV2 had no such field, which is why this only
+      became load-bearing alongside the version pin.
+
+    :returns: A boto3 S3 client.
+    """
+    return boto3.client(
+        "s3",
+        region_name=settings.AWS_S3_REGION_NAME,
+        config=Config(signature_version="s3v4"),
+    )
+
+
 def _ensure_presigned_url(scan: Scan, pdf_path: str | Path) -> str:
     """Upload ``pdf_path`` to the scan's S3 processing prefix if
     missing, then return a presigned GET URL.
@@ -309,7 +399,7 @@ def _ensure_presigned_url(scan: Scan, pdf_path: str | Path) -> str:
 
     bucket = settings.AWS_PRIVATE_STORAGE_BUCKET_NAME
     key = f"{s3_sync.s3_processing_prefix(scan)}{Path(pdf_path).name}"
-    s3 = boto3.client("s3")
+    s3 = _s3()
 
     # Only "the object isn't there yet" should trigger an upload. Any
     # other ClientError (bad credentials, wrong region, access denied,
@@ -343,6 +433,326 @@ def _ensure_presigned_url(scan: Scan, pdf_path: str | Path) -> str:
     )
 
 
+# ── Remote: result delivery via S3 ──────────────────────────────────
+def _results_to_s3_enabled() -> bool:
+    """Return True if the worker should PUT its result to S3.
+
+    Credentials are the only question: without them there's nothing to
+    presign with, so the worker has to answer inline. Remote mode
+    already requires them for the input PDF's presigned GET, so in
+    practice this is only ever false alongside ``RUNPOD_ENABLED=False``
+    -- but the S3 path checks for itself rather than assuming.
+
+    :returns: Whether to hand the worker a presigned PUT.
+    :rtype: bool
+    """
+    from scanning.utils import has_s3_credentials
+
+    return has_s3_credentials()
+
+
+def _presign_result_put(scan: Scan, action: str) -> tuple[str, str]:
+    """Return the result key for this scan + action and a PUT for it.
+
+    The key is computed here, before submission, rather than discovered
+    afterwards: a presigned PUT covers exactly one object and a prefix
+    cannot be presigned, so it has to be known at submit time anyway.
+    That also means the daemon can find the object later by name --
+    ``head_object`` on a known key, not a search.
+
+    Deliberately not run-scoped. One object per scan and action means a
+    re-run overwrites its predecessor rather than accumulating orphans
+    nobody will ever read. The staleness that invites (reading an old
+    attempt's output) is handled by checking the object's write time
+    against this run's submission, in :func:`_result_object_is_fresh`.
+
+    The URL's TTL is ``RUNPOD_PRESIGNED_TTL`` (1 day by default), which
+    has to outlive queue time plus execution; ``RUNPOD_REQUEST_TIMEOUT``
+    (30 min) sits well inside it, so we cancel a wedged job long before
+    its signature dies.
+
+    ``ContentType`` is signed deliberately. The worker sends that header
+    on the PUT, and whether S3 folds it into the signature depends on
+    the signature version -- SigV2 always does, SigV4 only if it was
+    signed. Signing it makes the two sides agree either way, and leaves
+    the stored object correctly typed instead of octet-stream. It does
+    mean the header and this constant must stay in lockstep, which is
+    why the worker sends exactly ``_RESULT_CONTENT_TYPE``.
+
+    :param scan: The Scan owning the job.
+    :param action: Handler action / pipeline stage.
+    :returns: ``(result_key, presigned_put_url)``.
+    :rtype: tuple[str, str]
+    """
+    from scanning import s3_sync
+
+    bucket = settings.AWS_PRIVATE_STORAGE_BUCKET_NAME
+    key = s3_sync.s3_job_result_key(scan, action)
+    url = _s3().generate_presigned_url(
+        "put_object",
+        Params={
+            "Bucket": bucket,
+            "Key": key,
+            "ContentType": _RESULT_CONTENT_TYPE,
+        },
+        ExpiresIn=int(settings.RUNPOD_PRESIGNED_TTL),
+    )
+    return key, url
+
+
+def _result_object_is_fresh(key: str, submitted_at: datetime) -> bool:
+    """Return True if ``key`` holds an object *this* run wrote.
+
+    Two questions, one ``head_object``, because they share an answer
+    shape:
+
+    - Is anything there? A single PUT is atomic, so a partial upload
+      never becomes a gettable object: presence means the whole result
+      is present.
+    - Is it ours? Result keys are per scan and action, not per run, so
+      the object at one can be a leftover from an earlier attempt.
+      Anything written before we submitted this job is one of those and
+      must not be read as this job's output.
+
+    :param key: The result key.
+    :param submitted_at: When this job was handed to RunPod (UTC).
+    :returns: Whether a result from this run is present.
+    :rtype: bool
+    """
+    bucket = settings.AWS_PRIVATE_STORAGE_BUCKET_NAME
+    try:
+        head = _s3().head_object(Bucket=bucket, Key=key)
+    except ClientError as exc:
+        err_code = exc.response.get("Error", {}).get("Code", "")
+        if err_code in ("404", "NoSuchKey", "NotFound"):
+            return False
+        # Anything else (access denied, wrong region) is a real S3
+        # problem: don't report it as "the worker produced nothing".
+        raise
+
+    last_modified = head.get("LastModified")
+    if last_modified is None:
+        # Real S3 always sends it. If something else doesn't, fall back
+        # to plain presence rather than discarding a good result.
+        return True
+    return last_modified >= submitted_at - _RESULT_CLOCK_SKEW
+
+
+def _result_survived_the_job(
+    result_key: str | None, submitted_at: datetime | None
+) -> bool:
+    """Return True if a finished result is waiting despite a lost job.
+
+    The probe :func:`_poll` runs when ``/status`` 404s. Deliberately
+    swallows every S3 error instead of propagating: the caller's
+    fallback (re-queue and resubmit) is always safe, whereas an
+    exception raised here lands in ``_poll``'s request ``try`` and gets
+    retried as if it were a status-poll blip -- a loop that can only
+    spin to the deadline, since ``/status`` will keep 404ing.
+
+    The 403-not-404 case is worth naming: ``head_object`` on a missing
+    key answers ``403 AccessDenied`` rather than 404 when the caller
+    lacks ``s3:ListBucket``. Swallowing keeps that IAM shape merely
+    unhelpful rather than pathological.
+
+    :param result_key: Key the worker was told to write to, if any.
+    :param submitted_at: When this job was submitted (UTC).
+    :returns: Whether this run's result is on S3.
+    :rtype: bool
+    """
+    if not result_key or not submitted_at:
+        return False
+    try:
+        return _result_object_is_fresh(result_key, submitted_at)
+    except Exception:
+        logger.warning(
+            "could not check %s for a finished result; treating the job "
+            "as lost and re-queueing",
+            result_key,
+            exc_info=True,
+        )
+        return False
+
+
+def _fetch_result(key: str, submitted_at: datetime) -> dict:
+    """Read and parse the JSON envelope the worker wrote.
+
+    Heads the object first: "the job reported success but left nothing
+    from this run behind" is a different (and more interesting) failure
+    than a body that won't parse, and saying so plainly beats a raw
+    botocore ``NoSuchKey``. Read straight into memory -- the payload is
+    parsed JSON we hand to the caller, so it never touches the daemon's
+    disk or the ``/tmp`` tree the cleanup command sweeps.
+
+    :param key: The result key.
+    :param submitted_at: When this job was submitted (UTC), used to
+        reject an earlier attempt's leftover object.
+    :returns: The parsed envelope.
+    :rtype: dict
+    :raises RunpodTransientError: If the object is missing, stale,
+        unreadable or unparseable. Re-running the job is the only
+        recovery, and the daemon's transient-retry cap still bounds
+        that.
+    """
+    bucket = settings.AWS_PRIVATE_STORAGE_BUCKET_NAME
+    try:
+        fresh = _result_object_is_fresh(key, submitted_at)
+    except (BotoCoreError, ClientError) as exc:
+        # Throttling, expired instance credentials, a region blip: the
+        # result may well be sitting there intact, so this must not
+        # escape as a bare botocore error. Anything that isn't a
+        # RunpodTransientError marks the whole scan ERROR.
+        raise RunpodTransientError(
+            f"could not check job result at s3://{bucket}/{key}: {exc}"
+        ) from exc
+    if not fresh:
+        raise RunpodTransientError(
+            f"job reported success but no result from this run at "
+            f"s3://{bucket}/{key}"
+        )
+    try:
+        obj = _s3().get_object(Bucket=bucket, Key=key)
+        return json.loads(obj["Body"].read())
+    except (BotoCoreError, ClientError, ValueError) as exc:
+        # BotoCoreError covers the streaming failures a mid-read
+        # connection drop raises (ResponseStreamingError, ReadTimeout),
+        # which are not ClientErrors.
+        raise RunpodTransientError(
+            f"could not read job result from s3://{bucket}/{key}: {exc}"
+        ) from exc
+
+
+def _validate_envelope(
+    envelope: Any, scan: Scan, action: str, key: str, job_id: str
+) -> dict:
+    """Check a result envelope describes the job we're consuming.
+
+    The envelope is self-describing precisely so a file from another
+    run, another action, or a future schema fails loudly here instead
+    of being consumed as this job's result.
+
+    Two classes of mismatch, deliberately classified differently:
+
+    - ``action`` / ``scan_pk`` / a malformed envelope are **terminal**.
+      They mean the contract is broken, and re-running would produce
+      the same mismatch.
+    - ``job_id`` and ``schema_version`` are **transient**. A foreign
+      ``job_id`` means we're looking at an earlier attempt's object at
+      this (deliberately reused) key, which a re-run replaces. A future
+      ``schema_version`` means the worker image is deployed ahead of
+      the daemon, which resolves itself when the daemon catches up --
+      terminal there would ``ERROR`` every in-flight scan over a deploy
+      ordering, each needing a manual re-queue.
+
+    :param envelope: Parsed JSON from the result object.
+    :param scan: The Scan the job belongs to.
+    :param action: The action we submitted.
+    :param key: The key it was read from (for the error message).
+    :param job_id: The RunPod job we're consuming the result of.
+    :returns: The validated payload dict.
+    :rtype: dict
+    :raises RunpodError: On a terminal mismatch.
+    :raises RunpodTransientError: On a mismatch a re-run can fix.
+    """
+
+    def fail(reason: str) -> RunpodError:
+        return RunpodError(f"invalid job result at {key}: {reason}")
+
+    if not isinstance(envelope, dict):
+        raise fail(f"expected a JSON object, got {type(envelope).__name__}")
+
+    version = envelope.get("schema_version")
+    if version != RESULT_SCHEMA_VERSION:
+        raise RunpodTransientError(
+            f"job result at {key} has schema_version {version!r}, expected "
+            f"{RESULT_SCHEMA_VERSION} (worker image ahead of the daemon?)"
+        )
+    if envelope.get("action") != action:
+        raise fail(f"action {envelope.get('action')!r}, expected {action!r}")
+    if envelope.get("scan_pk") != scan.pk:
+        raise fail(
+            f"scan_pk {envelope.get('scan_pk')!r}, expected {scan.pk!r}"
+        )
+
+    # The authoritative "is this ours?" check. ``_result_object_is_fresh``
+    # gets there first and more cheaply, but its clock comparison is
+    # coarse: a scan re-queued on the daemon's 5 s tick resubmits well
+    # inside the skew allowance, so a leftover object can look fresh.
+    # The job id can't.
+    envelope_job = envelope.get("job_id")
+    if envelope_job and envelope_job != job_id:
+        raise RunpodTransientError(
+            f"job result at {key} was written by job {envelope_job!r}, not "
+            f"{job_id!r}; it is an earlier attempt's output"
+        )
+
+    payload = envelope.get("payload")
+    if not isinstance(payload, dict):
+        raise fail("payload is missing or not an object")
+
+    return payload
+
+
+def _harvest(
+    output: dict,
+    scan: Scan,
+    action: str,
+    result_key: str | None,
+    submitted_at: datetime,
+    job_id: str,
+) -> dict:
+    """Resolve a job's output into the payload the caller expects.
+
+    Two shapes arrive here. One carries ``result_key`` and no payload
+    (the S3 path): read the object, validate it, and merge the payload
+    over the job's timing metadata. The other carries the payload
+    itself (the inline path, used when we sent no ``result_url`` or
+    when an older worker image ignored it): pass it straight through.
+
+    :param output: The handler's ``output`` dict.
+    :param scan: The Scan owning the job.
+    :param action: The action we submitted.
+    :param result_key: The key we presigned, or ``None`` if we asked
+        for an inline result.
+    :param submitted_at: When this job was submitted (UTC).
+    :param job_id: The RunPod job whose result we're consuming.
+    :returns: Output dict guaranteed to carry the action's payload.
+    :rtype: dict
+    :raises RunpodError: If the worker named a key we didn't ask for,
+        or the envelope fails validation.
+    """
+    key = output.get("result_key")
+    if not key:
+        if result_key:
+            logger.info(
+                "worker returned %s inline despite result_url (older "
+                "image?); using the response payload",
+                action,
+            )
+        return output
+
+    if key != result_key:
+        # The worker can only write where the signature lets it, so a
+        # response naming a different object -- or naming one at all
+        # when we asked for an inline result -- is describing something
+        # we didn't ask for. Don't fetch it.
+        raise RunpodError(
+            f"worker reported result_key {key!r} but the job was "
+            f"presigned for {result_key!r}"
+        )
+
+    payload = _validate_envelope(
+        _fetch_result(key, submitted_at), scan, action, key, job_id
+    )
+    logger.info(
+        "harvested %s result from s3 key=%s (%s bytes)",
+        action,
+        key,
+        output.get("bytes", "?"),
+    )
+    return {**output, **payload}
+
+
 # ── Remote: invocation + polling ────────────────────────────────────
 def _invoke(
     action: str,
@@ -358,7 +768,8 @@ def _invoke(
     :param payload: Remaining ``input`` fields (e.g. ``pdf_url``,
         action args). Merged with ``action`` and ``scan_pk``.
     :param progress_callback: Optional coarse progress emitter.
-    :returns: The handler's ``output`` dict.
+    :returns: The handler's ``output`` dict, with the payload merged
+        in from S3 when the worker delivered it that way.
     :rtype: dict
     :raises RunpodError: On terminal failure, handler error, or
         exhausted retries.
@@ -370,19 +781,43 @@ def _invoke(
 
     base_url = f"https://api.runpod.ai/v2/{endpoint}"
     headers = {"Authorization": f"Bearer {api_key}"}
-    body = {
-        "input": {"action": action, "scan_pk": scan.pk, **payload},
+    job_input: dict[str, Any] = {
+        "action": action,
+        "scan_pk": scan.pk,
+        **payload,
     }
+
+    result_key: str | None = None
+    if _results_to_s3_enabled():
+        result_key, result_url = _presign_result_put(scan, action)
+        job_input["result_key"] = result_key
+        job_input["result_url"] = result_url
+
+    body = {"input": job_input}
 
     deadline = time.monotonic() + int(settings.RUNPOD_REQUEST_TIMEOUT)
     max_retries = int(settings.RUNPOD_MAX_RETRIES)
 
+    # Wall clock, unlike ``deadline``: it's compared against an S3
+    # object's ``LastModified`` to tell this run's result from an
+    # earlier attempt's. Taken before the submit so a slow /run call
+    # can only make the window wider, never miss a real result.
+    submitted_at = datetime.now(UTC)
+
     job_id = _submit(
         base_url, headers, body, action, max_retries, progress_callback
     )
-    return _poll(
-        base_url, headers, job_id, action, deadline, progress_callback
+    output = _poll(
+        base_url,
+        headers,
+        job_id,
+        action,
+        deadline,
+        progress_callback,
+        result_key=result_key,
+        submitted_at=submitted_at,
     )
+    return _harvest(output, scan, action, result_key, submitted_at, job_id)
 
 
 def _submit_error_detail(exc: Exception) -> tuple[int | None, str, str]:
@@ -452,7 +887,7 @@ def _submit(
                 "runpod %s job %s submitted (input=%s)",
                 action,
                 job_id,
-                _redact_pdf_url(body).get("input"),
+                _redact_urls(body).get("input"),
             )
             if progress_callback:
                 label = _ACTION_LABELS.get(action, action)
@@ -507,6 +942,8 @@ def _poll(
     action: str,
     deadline: float,
     progress_callback: ProgressCallback | None,
+    result_key: str | None = None,
+    submitted_at: datetime | None = None,
 ) -> dict:
     """Poll ``/status/{job_id}`` until terminal, with backoff.
 
@@ -516,14 +953,20 @@ def _poll(
     Every poll logs at DEBUG (enable with ``SCANNING_LOG_LEVEL=DEBUG``);
     status transitions log at INFO.
 
-    :returns: The handler's ``output`` dict on COMPLETED.
+    :param result_key: Key the worker was told to PUT its result to, if
+        any. Lets the 404 branch check S3 before giving up.
+    :param submitted_at: When the job was submitted (UTC), used to tell
+        this run's result from an earlier attempt's.
+    :returns: The handler's ``output`` dict on COMPLETED, or a
+        ``{"result_key": ...}`` stand-in when the job record is gone
+        but its result object is on S3.
     :rtype: dict
     :raises RunpodError: On FAILED / TIMED_OUT / CANCELLED / deadline
         exceeded / malformed output.
-    :raises RunpodTransientError: On HTTP 404 from ``/status`` (the
-        job was either aged out of RunPod's retention window or
-        discarded after internal retries; the inputs are still on S3
-        so a fresh submit will re-run the work).
+    :raises RunpodTransientError: On HTTP 404 from ``/status`` with no
+        result on S3 (the job aged out of RunPod's retention window or
+        was discarded after internal retries; the inputs are still on
+        S3 so a fresh submit will re-run the work).
     """
     # Happy-path cadence: 1 s, 2 s, 4 s, 8 s, 15 s, 15 s, ... Advances
     # on every successful poll that returns a non-terminal status.
@@ -549,9 +992,22 @@ def _poll(
             # 404 from /status means the job is gone: either RunPod
             # discarded it after exhausting their internal retries, or
             # the result aged past the retention window (30 min async).
-            # The inputs are still on S3, so re-queueing the scan lets
-            # the next daemon tick resubmit with a fresh presigned URL.
+            #
+            # The work itself may still have finished. When the worker
+            # was given a presigned PUT, its output outlives the job
+            # record, so check the key before throwing away a run we
+            # already paid for. Only an object written after we
+            # submitted counts: the key is per scan and action, so an
+            # older one is a previous attempt's leftover.
             if r.status_code == 404:
+                if _result_survived_the_job(result_key, submitted_at):
+                    logger.info(
+                        "runpod job %s is gone (HTTP 404) but its result "
+                        "is on S3 (%s); harvesting instead of resubmitting",
+                        job_id,
+                        result_key,
+                    )
+                    return {"result_key": result_key}
                 raise RunpodTransientError(
                     f"RunPod job {job_id} not found (HTTP 404 from "
                     "/status). Re-queueing so the next daemon tick "

--- a/scanning/s3_sync.py
+++ b/scanning/s3_sync.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 @functools.lru_cache(maxsize=1)
 def _cached_s3_client():
     """Build and memoize a single S3 client (see :func:`_s3_client`)."""
-    return boto3.client("s3")
+    return boto3.client("s3", region_name=settings.AWS_S3_REGION_NAME)
 
 
 def _s3_client():
@@ -47,6 +47,14 @@ def _s3_client():
     build one and reuse it. Cached on first use, not at import, so
     credential resolution happens once the app is actually serving.
 
+    The region is pinned rather than left to boto3's ambient resolution.
+    ``generate_presigned_post`` signs with SigV4, which folds the region
+    into the credential scope, so a client that guessed ``us-east-1``
+    for a ``us-west-2`` bucket would hand the browser an upload policy
+    S3 rejects. Same failure the GPU worker's result PUT hit; the
+    signature version is deliberately *not* pinned here, since nothing
+    on this path depends on which one is used.
+
     Under ``TESTING`` the cache is bypassed and a fresh client is built
     each call, so tests that patch ``scanning.s3_sync.boto3`` always see
     their own mock -- a cached client from an earlier test can't silently
@@ -56,7 +64,7 @@ def _s3_client():
     :returns: A boto3 S3 client (process-wide outside tests).
     """
     if getattr(settings, "TESTING", False):
-        return boto3.client("s3")
+        return boto3.client("s3", region_name=settings.AWS_S3_REGION_NAME)
     return _cached_s3_client()
 
 

--- a/scanning/s3_sync.py
+++ b/scanning/s3_sync.py
@@ -68,6 +68,13 @@ def _s3_client():
 APPROVED_SUBDIR_PREFIXES = ("redacted/", "images/")
 APPROVED_FILE_SUFFIXES = (".original.pdf", ".redacted.pdf")
 
+# Subdirectory under a scan's processing prefix where GPU workers PUT
+# their job results (see ``scanning/runpod_client.py``). Deliberately
+# excluded from the processing-file sync in both directions: these are
+# wire artifacts the daemon consumes once and writes to Postgres, not
+# files the viewer or the pipeline ever reads off disk.
+JOB_RESULTS_SUBDIR = "jobs/"
+
 
 def _s3_enabled() -> bool:
     """Return True when we should actually use S3.
@@ -123,6 +130,38 @@ def s3_processing_prefix(scan: Scan) -> str:
     """
     reporter_slug, volume, start_page = _scan_path_parts(scan)
     return f"processing/{scan.pk}/{reporter_slug}/{volume}/{start_page}/"
+
+
+def s3_job_result_key(scan: Scan, stage: str) -> str:
+    """Return the S3 key a GPU worker PUTs one job's result to.
+
+    One object per scan and stage: a re-run overwrites the previous
+    attempt's output instead of leaving an orphan behind. Nothing
+    reads the object without first checking it was written after the
+    job that's reading it was submitted, so an overwritten-in-place
+    key can't be mistaken for a stale one (see
+    ``runpod_client._result_object_is_fresh``).
+
+    :param scan: The scan the job belongs to.
+    :param stage: Pipeline stage / handler action (``detect`` /
+        ``analyze``).
+    :returns: Key of the form
+        ``{processing_prefix}jobs/{stage}/result.json``.
+    :rtype: str
+    """
+    return (
+        f"{s3_processing_prefix(scan)}{JOB_RESULTS_SUBDIR}{stage}/result.json"
+    )
+
+
+def _is_job_result(rel: str) -> bool:
+    """Return True if a processing-prefix relative key is a job result.
+
+    :param rel: Object key relative to the scan's processing prefix.
+    :returns: Whether the key lives under the ``jobs/`` subtree.
+    :rtype: bool
+    """
+    return rel.startswith(JOB_RESULTS_SUBDIR)
 
 
 def tmp_output_dir(scan: Scan) -> Path:
@@ -206,6 +245,8 @@ def upload_processing_files(scan: Scan) -> int:
     count = 0
     for path in _iter_files_to_sync(local_root):
         rel = path.relative_to(local_root).as_posix()
+        if _is_job_result(rel):
+            continue
         s3.upload_file(str(path), bucket, f"{prefix}{rel}")
         count += 1
 
@@ -245,7 +286,7 @@ def download_processing_files(scan: Scan) -> Path | None:
         for obj in page.get("Contents", []):
             key = obj["Key"]
             rel = key[len(prefix) :]
-            if not rel:
+            if not rel or _is_job_result(rel):
                 continue
             local_path = local_root / rel
             if local_path.is_file() and local_path.stat().st_size == obj.get(

--- a/scanning/settings/third_party/aws.py
+++ b/scanning/settings/third_party/aws.py
@@ -27,9 +27,10 @@ AWS_PRIVATE_STORAGE_BUCKET_NAME = env(
 # so a mismatch is a hard ``AuthorizationQueryParametersError`` -- and
 # without this set, boto3 falls back to ``us-east-1``.
 #
-# Also read by django-storages, which is deliberate: one region for
-# every S3 client in the app rather than two ways to be wrong. Both
-# buckets must be in it; check with
+# Read by django-storages under this exact name, which is why it's
+# named for the library rather than for us, and passed explicitly by
+# the two clients we build ourselves (``s3_sync._s3_client`` and
+# ``runpod_client._s3``). Both buckets must be in it; check with
 # ``aws s3api get-bucket-location --bucket <name>``.
 AWS_S3_REGION_NAME = env("AWS_S3_REGION_NAME", default="us-west-2")
 

--- a/scanning/settings/third_party/aws.py
+++ b/scanning/settings/third_party/aws.py
@@ -21,6 +21,18 @@ AWS_PRIVATE_STORAGE_BUCKET_NAME = env(
     default="com-freelawproject-scanning-private-storage",
 )
 
+# Region the buckets live in. Until presigned PUTs arrived nothing
+# needed this: SigV2 URLs carry no region, and S3 redirects a
+# misdirected GET. SigV4 encodes the region into the credential scope,
+# so a mismatch is a hard ``AuthorizationQueryParametersError`` -- and
+# without this set, boto3 falls back to ``us-east-1``.
+#
+# Also read by django-storages, which is deliberate: one region for
+# every S3 client in the app rather than two ways to be wrong. Both
+# buckets must be in it; check with
+# ``aws s3api get-bucket-location --bucket <name>``.
+AWS_S3_REGION_NAME = env("AWS_S3_REGION_NAME", default="us-west-2")
+
 AWS_S3_CUSTOM_DOMAIN = env(
     "AWS_S3_CUSTOM_DOMAIN",
     default=f"{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com",

--- a/scanning/tests/test_runpod_client.py
+++ b/scanning/tests/test_runpod_client.py
@@ -7,19 +7,25 @@ PDFs.
 
 Covers:
 
-- ``_redact_pdf_url`` masking behaviour.
+- ``_redact_urls`` masking behaviour.
 - ``_ensure_presigned_url`` upload / head-object / error classification.
 - ``_submit`` retry logic and malformed-response handling.
 - ``_poll`` terminal states, transient classification, deadline expiry,
-  404-as-transient, and structured-error mapping.
+  structured-error mapping, and the ``head_object`` check that salvages
+  a finished job whose ``/status`` record has 404'd.
 - ``_invoke`` body construction and missing-credential guard.
+- Result delivery via presigned PUT: key/URL minting, the freshness
+  check that keeps a reused key from serving a previous attempt's
+  output, envelope validation, and the inline path.
 - Public ``detect`` / ``analyze`` local fallback + remote dispatch.
 """
 
+import json
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import requests
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, ResponseStreamingError
 from django.test import TestCase, override_settings
 
 from scanning import runpod_client
@@ -65,8 +71,8 @@ def _client_error(code: str) -> ClientError:
 
 
 # ── Pure helpers ────────────────────────────────────────────────────
-class TestRedactPdfUrl(TestCase):
-    """``_redact_pdf_url`` masks pdf_url without mutating input."""
+class TestRedactUrls(TestCase):
+    """``_redact_urls`` masks presigned URLs without mutating input."""
 
     def test_masks_pdf_url_under_input(self):
         body = {
@@ -77,8 +83,23 @@ class TestRedactPdfUrl(TestCase):
                 "models": ["small"],
             }
         }
-        redacted = runpod_client._redact_pdf_url(body)
+        redacted = runpod_client._redact_urls(body)
         self.assertEqual(redacted["input"]["pdf_url"], "***")
+
+    def test_masks_result_url_but_keeps_result_key(self):
+        body = {
+            "input": {
+                "action": "detect",
+                "result_url": "https://s3.example/out?X-Amz-Signature=abc",
+                "result_key": "processing/1/x/jobs/detect/result.json",
+            }
+        }
+        redacted = runpod_client._redact_urls(body)
+        self.assertEqual(redacted["input"]["result_url"], "***")
+        self.assertEqual(
+            redacted["input"]["result_key"],
+            "processing/1/x/jobs/detect/result.json",
+        )
 
     def test_preserves_other_input_keys(self):
         body = {
@@ -90,25 +111,32 @@ class TestRedactPdfUrl(TestCase):
                 "confidence": 0.2,
             }
         }
-        redacted = runpod_client._redact_pdf_url(body)
+        redacted = runpod_client._redact_urls(body)
         self.assertEqual(redacted["input"]["action"], "detect")
         self.assertEqual(redacted["input"]["scan_pk"], 42)
         self.assertEqual(redacted["input"]["models"], ["small"])
         self.assertEqual(redacted["input"]["confidence"], 0.2)
 
     def test_does_not_mutate_original(self):
-        body = {"input": {"pdf_url": "https://s3.example/x"}}
-        runpod_client._redact_pdf_url(body)
+        body = {
+            "input": {
+                "pdf_url": "https://s3.example/x",
+                "result_url": "https://s3.example/y",
+            }
+        }
+        runpod_client._redact_urls(body)
         self.assertEqual(body["input"]["pdf_url"], "https://s3.example/x")
+        self.assertEqual(body["input"]["result_url"], "https://s3.example/y")
 
-    def test_no_pdf_url_no_change(self):
+    def test_no_urls_no_change(self):
         body = {"input": {"action": "detect", "scan_pk": 42}}
-        redacted = runpod_client._redact_pdf_url(body)
+        redacted = runpod_client._redact_urls(body)
         self.assertNotIn("pdf_url", redacted["input"])
+        self.assertNotIn("result_url", redacted["input"])
 
     def test_non_dict_input_not_touched(self):
         body = {"input": "not a dict"}
-        redacted = runpod_client._redact_pdf_url(body)
+        redacted = runpod_client._redact_urls(body)
         self.assertEqual(redacted["input"], "not a dict")
 
 
@@ -532,6 +560,37 @@ class TestPoll(TestCase):
             ctx.exception, runpod_client.RunpodTransientError
         )
 
+    def test_result_upload_codes_are_classified_by_cause(self):
+        # The two delivery failures a re-run can fix re-queue the scan;
+        # the one that means "S3 refused this write" does not, because
+        # each retry pays for another GPU run to fail identically.
+        cases = {
+            "RESULT_UPLOAD_FAILED": True,
+            "RESULT_URL_EXPIRED": True,
+            "RESULT_UPLOAD_REJECTED": False,
+        }
+        for code, is_transient in cases.items():
+            with self.subTest(code=code):
+                with self.assertRaises(runpod_client.RunpodError) as ctx:
+                    self._poll(
+                        [
+                            (
+                                200,
+                                {
+                                    "status": "FAILED",
+                                    "error": "upload",
+                                    "output": {"error_code": code},
+                                },
+                            )
+                        ]
+                    )
+                self.assertEqual(
+                    isinstance(
+                        ctx.exception, runpod_client.RunpodTransientError
+                    ),
+                    is_transient,
+                )
+
     def test_failed_with_no_output_raises_transient(self):
         # RunPod platform failures (worker timeout, "job timed out after N
         # retries", worker crash) arrive as FAILED with no output field.
@@ -602,7 +661,21 @@ class TestPoll(TestCase):
     RUNPOD_MAX_RETRIES=0,
 )
 class TestInvoke(TestCase):
-    """``_invoke`` body shape and missing-config guards."""
+    """``_invoke`` body shape and missing-config guards.
+
+    Pinned to inline mode (no AWS credentials, so nothing to presign a
+    PUT with): no ``result_url`` goes into the job input and the
+    handler's output is returned as-is. The S3 path has its own test
+    classes below.
+    """
+
+    def setUp(self):
+        patcher = patch(
+            "scanning.runpod_client._results_to_s3_enabled",
+            return_value=False,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def test_builds_body_with_scan_pk_and_passes_to_submit(self):
         scan = ScanFactory()
@@ -638,6 +711,8 @@ class TestInvoke(TestCase):
         self.assertEqual(
             captured["body"]["input"]["pdf_url"], "https://x/y.pdf"
         )
+        self.assertNotIn("result_url", captured["body"]["input"])
+        self.assertNotIn("result_key", captured["body"]["input"])
 
     @override_settings(RUNPOD_ENDPOINT_ID="")
     def test_missing_endpoint_id_raises(self):
@@ -713,7 +788,18 @@ class TestAnalyzeLocalFallback(TestCase):
     RUNPOD_PRESIGNED_TTL=3600,
 )
 class TestDetectRemote(TestCase):
-    """``detect()`` with RUNPOD_ENABLED=True walks presign + submit + poll."""
+    """``detect()`` with RUNPOD_ENABLED=True walks presign + submit + poll.
+
+    Inline mode, pinned as in :class:`TestInvoke`.
+    """
+
+    def setUp(self):
+        patcher = patch(
+            "scanning.runpod_client._results_to_s3_enabled",
+            return_value=False,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def test_remote_detect_happy_path(self):
         scan = ScanFactory()
@@ -756,7 +842,18 @@ class TestDetectRemote(TestCase):
     RUNPOD_PRESIGNED_TTL=3600,
 )
 class TestAnalyzeRemote(TestCase):
-    """``analyze()`` with RUNPOD_ENABLED=True walks presign + submit + poll."""
+    """``analyze()`` with RUNPOD_ENABLED=True walks presign + submit + poll.
+
+    Inline mode, pinned as in :class:`TestInvoke`.
+    """
+
+    def setUp(self):
+        patcher = patch(
+            "scanning.runpod_client._results_to_s3_enabled",
+            return_value=False,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def test_remote_analyze_happy_path(self):
         scan = ScanFactory()
@@ -790,3 +887,540 @@ class TestAnalyzeRemote(TestCase):
             )
         # analyze() returns {"results": [...]} discarding extras.
         self.assertEqual(result, {"results": worker_output["results"]})
+
+
+# ── Result delivery via presigned PUT ───────────────────────────────
+# Result keys are reused across runs, so every read is gated on the
+# object having been written after the reading job was submitted.
+_SUBMITTED_AT = datetime(2026, 8, 5, 12, 0, tzinfo=UTC)
+_FRESH = _SUBMITTED_AT + timedelta(seconds=30)
+_STALE = _SUBMITTED_AT - timedelta(hours=2)
+
+
+_JOB_ID = "job-1"
+
+
+def _envelope(
+    action="detect",
+    scan_pk=1,
+    payload=None,
+    schema_version=runpod_client.RESULT_SCHEMA_VERSION,
+    job_id=_JOB_ID,
+):
+    """Build a result envelope the way the worker writes it.
+
+    :param action: Action that produced the payload.
+    :param scan_pk: Scan the job belongs to.
+    :param payload: The action's result dict.
+    :param schema_version: Envelope version to claim.
+    :param job_id: RunPod job to claim wrote it.
+    :returns: The envelope dict.
+    :rtype: dict
+    """
+    return {
+        "schema_version": schema_version,
+        "action": action,
+        "scan_pk": scan_pk,
+        "job_id": job_id,
+        "payload": payload if payload is not None else {"detections": []},
+    }
+
+
+def _body_stub(raw: bytes):
+    """Wrap raw bytes as a ``get_object`` response body."""
+    body = MagicMock()
+    body.read.return_value = raw
+    return {"Body": body}
+
+
+def _s3_stub(envelope=None, head_error=None, last_modified=_FRESH):
+    """Return a stub S3 client serving one result object.
+
+    :param envelope: Object body ``get_object`` returns, JSON-encoded.
+    :param head_error: ``ClientError`` ``head_object`` should raise.
+    :param last_modified: ``LastModified`` ``head_object`` reports.
+        Defaults to just after :data:`_SUBMITTED_AT`, i.e. an object
+        this run wrote.
+    :returns: MagicMock standing in for a boto3 S3 client.
+    :rtype: MagicMock
+    """
+    s3 = MagicMock()
+    s3.generate_presigned_url.return_value = "https://signed.example/put"
+    if head_error is not None:
+        s3.head_object.side_effect = head_error
+    else:
+        s3.head_object.return_value = {"LastModified": last_modified}
+    if envelope is not None:
+        s3.get_object.return_value = _body_stub(json.dumps(envelope).encode())
+    return s3
+
+
+class TestResultsToS3Enabled(TestCase):
+    """``_results_to_s3_enabled`` gates on AWS credentials.
+
+    This is what keeps CI and credential-less dev off the S3 path, so
+    it's tested directly rather than patched out (as the classes below
+    do).
+    """
+
+    def _enabled(self, creds):
+        with patch("scanning.utils.has_s3_credentials", return_value=creds):
+            return runpod_client._results_to_s3_enabled()
+
+    def test_on_with_credentials(self):
+        self.assertTrue(self._enabled(True))
+
+    def test_off_without_credentials(self):
+        # Nothing to presign with, so the worker must answer inline.
+        self.assertFalse(self._enabled(False))
+
+
+@override_settings(
+    AWS_PRIVATE_STORAGE_BUCKET_NAME="bucket",
+    RUNPOD_PRESIGNED_TTL=3600,
+)
+class TestPresignResultPut(TestCase):
+    """``_presign_result_put`` names the key and signs a PUT for it."""
+
+    def test_key_is_per_scan_and_action(self):
+        from scanning import s3_sync
+
+        scan = ScanFactory()
+        s3 = _s3_stub()
+        with patch("scanning.runpod_client.boto3.client", return_value=s3):
+            key, url = runpod_client._presign_result_put(scan, "detect")
+            again, _ = runpod_client._presign_result_put(scan, "detect")
+            analyze_key, _ = runpod_client._presign_result_put(scan, "analyze")
+
+        prefix = s3_sync.s3_processing_prefix(scan)
+        self.assertEqual(key, f"{prefix}jobs/detect/result.json")
+        self.assertEqual(url, "https://signed.example/put")
+        # Stable across submissions, so a re-run overwrites rather than
+        # leaving an orphan; distinct per action.
+        self.assertEqual(key, again)
+        self.assertNotEqual(key, analyze_key)
+
+    def test_presigns_put_for_that_one_key(self):
+        scan = ScanFactory()
+        s3 = _s3_stub()
+        with patch("scanning.runpod_client.boto3.client", return_value=s3):
+            key, _ = runpod_client._presign_result_put(scan, "analyze")
+
+        # ContentType is signed, and must match the header the worker
+        # sends byte for byte or S3 rejects the PUT.
+        s3.generate_presigned_url.assert_called_once_with(
+            "put_object",
+            Params={
+                "Bucket": "bucket",
+                "Key": key,
+                "ContentType": "application/json",
+            },
+            ExpiresIn=3600,
+        )
+
+    @override_settings(AWS_S3_REGION_NAME="us-west-2")
+    def test_client_is_pinned_to_sigv4_and_the_bucket_region(self):
+        # Both are ambient otherwise: SigV2 folds Content-Type into the
+        # string to sign (which the worker's header then contradicts),
+        # and an unset region signs for us-east-1, which S3 rejects
+        # outright for a bucket that lives somewhere else.
+        scan = ScanFactory()
+        with patch(
+            "scanning.runpod_client.boto3.client", return_value=_s3_stub()
+        ) as mock_client:
+            runpod_client._presign_result_put(scan, "detect")
+
+        _, kwargs = mock_client.call_args
+        self.assertEqual(kwargs["config"].signature_version, "s3v4")
+        self.assertEqual(kwargs["region_name"], "us-west-2")
+
+
+@override_settings(AWS_PRIVATE_STORAGE_BUCKET_NAME="bucket")
+class TestResultObjectIsFresh(TestCase):
+    """``_result_object_is_fresh`` gates on presence *and* write time."""
+
+    KEY = "processing/1/x/1/1/jobs/detect/result.json"
+
+    def _is_fresh(self, s3):
+        with patch("scanning.runpod_client.boto3.client", return_value=s3):
+            return runpod_client._result_object_is_fresh(
+                self.KEY, _SUBMITTED_AT
+            )
+
+    def test_object_written_after_submit_is_ours(self):
+        self.assertTrue(self._is_fresh(_s3_stub(last_modified=_FRESH)))
+
+    def test_object_written_before_submit_is_a_leftover(self):
+        # A previous attempt's output at the same key. Reading it would
+        # report stale detections as this run's result.
+        self.assertFalse(self._is_fresh(_s3_stub(last_modified=_STALE)))
+
+    def test_clock_skew_is_tolerated(self):
+        # S3's clock running slightly behind ours must not discard a
+        # result the worker really did just write.
+        just_before = _SUBMITTED_AT - timedelta(seconds=5)
+        self.assertTrue(self._is_fresh(_s3_stub(last_modified=just_before)))
+
+    def test_missing_object(self):
+        self.assertFalse(
+            self._is_fresh(_s3_stub(head_error=_client_error("404")))
+        )
+
+    def test_other_client_error_propagates(self):
+        # AccessDenied means S3 is misconfigured, not that the worker
+        # produced nothing.
+        with self.assertRaises(ClientError):
+            self._is_fresh(_s3_stub(head_error=_client_error("AccessDenied")))
+
+
+@override_settings(AWS_PRIVATE_STORAGE_BUCKET_NAME="bucket")
+class TestHarvest(TestCase):
+    """``_harvest`` resolves an output into the action's payload."""
+
+    def setUp(self):
+        self.scan = ScanFactory()
+        self.key = "processing/1/x/1/1/jobs/detect/result.json"
+
+    def _harvest(self, output, envelope=None, s3=None):
+        s3 = s3 if s3 is not None else _s3_stub(envelope=envelope)
+        with patch("scanning.runpod_client.boto3.client", return_value=s3):
+            return runpod_client._harvest(
+                output, self.scan, "detect", self.key, _SUBMITTED_AT, _JOB_ID
+            )
+
+    def test_inline_output_passes_through(self):
+        # No result_url was sent (or an older worker ignored it), so the
+        # payload is already in the response.
+        output = {"detections": [{"page_index": 0}], "duration_ms": 5}
+        with patch("scanning.runpod_client.boto3.client") as mock_client:
+            result = runpod_client._harvest(
+                output, self.scan, "detect", None, _SUBMITTED_AT, _JOB_ID
+            )
+        self.assertEqual(result, output)
+        mock_client.assert_not_called()
+
+    def test_key_we_never_presigned_is_not_fetched(self):
+        # Inline mode: we sent no result_url, so a response naming a key
+        # is describing an object we didn't ask for.
+        s3 = _s3_stub(envelope=_envelope(scan_pk=self.scan.pk))
+        with patch("scanning.runpod_client.boto3.client", return_value=s3):
+            with self.assertRaises(runpod_client.RunpodError):
+                runpod_client._harvest(
+                    {"result_key": "someone/elses.json"},
+                    self.scan,
+                    "detect",
+                    None,
+                    _SUBMITTED_AT,
+                    _JOB_ID,
+                )
+        s3.get_object.assert_not_called()
+
+    def test_s3_payload_is_merged_over_job_metadata(self):
+        detections = [{"page_index": 0, "label": "CASE_CAPTION"}]
+        envelope = _envelope(
+            scan_pk=self.scan.pk, payload={"detections": detections}
+        )
+        output = {
+            "result_key": self.key,
+            "bytes": 120,
+            "sha256": "abc",
+            "status": "succeed",
+            "duration_ms": 42,
+        }
+        result = self._harvest(output, envelope=envelope)
+        self.assertEqual(result["detections"], detections)
+        # Job-level timings survive the merge.
+        self.assertEqual(result["duration_ms"], 42)
+        self.assertEqual(result["bytes"], 120)
+
+    def test_unexpected_key_is_terminal(self):
+        envelope = _envelope(scan_pk=self.scan.pk)
+        with self.assertRaises(runpod_client.RunpodError) as ctx:
+            self._harvest(
+                {"result_key": "somewhere/else.json"}, envelope=envelope
+            )
+        self.assertNotIsInstance(
+            ctx.exception, runpod_client.RunpodTransientError
+        )
+
+    def test_unknown_schema_version_is_transient(self):
+        # A worker image deployed ahead of the daemon. Failing the scan
+        # outright would ERROR everything in flight over a deploy
+        # ordering; re-queueing rides it out until the daemon catches up.
+        envelope = _envelope(scan_pk=self.scan.pk, schema_version=99)
+        with self.assertRaises(runpod_client.RunpodTransientError):
+            self._harvest({"result_key": self.key}, envelope=envelope)
+
+    def test_another_jobs_result_is_transient(self):
+        # The authoritative staleness check: the key is reused across
+        # runs, and a scan re-queued on the daemon's 5 s tick resubmits
+        # well inside the clock-skew allowance, so LastModified alone
+        # can call a leftover fresh. The job id can't.
+        envelope = _envelope(scan_pk=self.scan.pk, job_id="an-earlier-job")
+        with self.assertRaises(runpod_client.RunpodTransientError) as ctx:
+            self._harvest({"result_key": self.key}, envelope=envelope)
+        self.assertIn("earlier attempt", str(ctx.exception))
+
+    def test_envelope_without_a_job_id_is_accepted(self):
+        # Can't compare what isn't there; the freshness check stands.
+        envelope = _envelope(scan_pk=self.scan.pk, job_id=None)
+        result = self._harvest({"result_key": self.key}, envelope=envelope)
+        self.assertEqual(result["detections"], [])
+
+    def test_wrong_scan_pk_is_terminal(self):
+        envelope = _envelope(scan_pk=self.scan.pk + 1000)
+        with self.assertRaises(runpod_client.RunpodError):
+            self._harvest({"result_key": self.key}, envelope=envelope)
+
+    def test_wrong_action_is_terminal(self):
+        envelope = _envelope(action="analyze", scan_pk=self.scan.pk)
+        with self.assertRaises(runpod_client.RunpodError):
+            self._harvest({"result_key": self.key}, envelope=envelope)
+
+    def test_missing_payload_is_terminal(self):
+        envelope = _envelope(scan_pk=self.scan.pk)
+        del envelope["payload"]
+        with self.assertRaises(runpod_client.RunpodError):
+            self._harvest({"result_key": self.key}, envelope=envelope)
+
+    def test_missing_object_is_transient(self):
+        # The job said it succeeded but nothing is at the key: worth
+        # re-running, and worth saying so plainly.
+        s3 = _s3_stub(head_error=_client_error("404"))
+        with self.assertRaises(runpod_client.RunpodTransientError) as ctx:
+            self._harvest({"result_key": self.key}, s3=s3)
+        self.assertIn("no result from this run", str(ctx.exception))
+        s3.get_object.assert_not_called()
+
+    def test_leftover_object_is_not_consumed(self):
+        # Same key, but written before this job was submitted: it's a
+        # previous attempt's output, not ours.
+        s3 = _s3_stub(
+            envelope=_envelope(scan_pk=self.scan.pk), last_modified=_STALE
+        )
+        with self.assertRaises(runpod_client.RunpodTransientError):
+            self._harvest({"result_key": self.key}, s3=s3)
+        s3.get_object.assert_not_called()
+
+    def test_unreadable_object_is_transient(self):
+        s3 = _s3_stub()
+        s3.get_object.side_effect = _client_error("AccessDenied")
+        with self.assertRaises(runpod_client.RunpodTransientError):
+            self._harvest({"result_key": self.key}, s3=s3)
+
+    def test_head_failure_is_transient_not_terminal(self):
+        # Throttling, expired instance credentials, a region blip. The
+        # result may be sitting there intact, so this must re-queue --
+        # anything that isn't a RunpodTransientError ERRORs the scan.
+        s3 = _s3_stub(head_error=_client_error("SlowDown"))
+        with self.assertRaises(runpod_client.RunpodTransientError):
+            self._harvest({"result_key": self.key}, s3=s3)
+
+    def test_mid_read_connection_drop_is_transient(self):
+        # ResponseStreamingError is a BotoCoreError, not a ClientError.
+        s3 = _s3_stub()
+        s3.get_object.side_effect = ResponseStreamingError(error="reset")
+        with self.assertRaises(runpod_client.RunpodTransientError):
+            self._harvest({"result_key": self.key}, s3=s3)
+
+    def test_unparseable_body_is_transient(self):
+        s3 = _s3_stub()
+        s3.get_object.return_value = _body_stub(b"<html>nope</html>")
+        with self.assertRaises(runpod_client.RunpodTransientError):
+            self._harvest({"result_key": self.key}, s3=s3)
+
+    def test_non_dict_envelope_is_terminal(self):
+        s3 = _s3_stub()
+        s3.get_object.return_value = _body_stub(b"[1, 2, 3]")
+        with self.assertRaises(runpod_client.RunpodError) as ctx:
+            self._harvest({"result_key": self.key}, s3=s3)
+        self.assertNotIsInstance(
+            ctx.exception, runpod_client.RunpodTransientError
+        )
+
+
+@override_settings(
+    RUNPOD_ENABLED=True,
+    RUNPOD_ENDPOINT_ID="ep-abc",
+    RUNPOD_API_KEY="apikey",
+    RUNPOD_REQUEST_TIMEOUT=900,
+    RUNPOD_MAX_RETRIES=0,
+    AWS_PRIVATE_STORAGE_BUCKET_NAME="bucket",
+    RUNPOD_PRESIGNED_TTL=3600,
+)
+class TestInvokeWithResultsToS3(TestCase):
+    """``_invoke`` submits a presigned PUT and harvests the object.
+
+    ``_invoke`` stamps ``submitted_at`` from the real clock, so the
+    stubbed objects here report a ``LastModified`` of "now" to look
+    like something this run just wrote.
+    """
+
+    def setUp(self):
+        self.scan = ScanFactory()
+        patcher = patch(
+            "scanning.runpod_client._results_to_s3_enabled",
+            return_value=True,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _s3(self, envelope=None, **kwargs):
+        """Stub S3 whose object was written just now, i.e. by this run."""
+        kwargs.setdefault("last_modified", datetime.now(UTC))
+        return _s3_stub(envelope=envelope, **kwargs)
+
+    def _invoke(self, status_responses, s3, captured=None):
+        """Run ``_invoke`` against stubbed RunPod HTTP and S3."""
+
+        def fake_post(url, headers=None, json=None, timeout=None):
+            if captured is not None:
+                captured["body"] = json
+            return _mock_response(200, {"id": "job-1"})
+
+        with (
+            patch("scanning.runpod_client.boto3.client", return_value=s3),
+            patch(
+                "scanning.runpod_client.requests.post", side_effect=fake_post
+            ),
+            patch(
+                "scanning.runpod_client.requests.get",
+                side_effect=[
+                    _mock_response(c, b) for c, b in status_responses
+                ],
+            ),
+            patch("scanning.runpod_client.time.sleep", return_value=None),
+        ):
+            return runpod_client._invoke(
+                action="detect",
+                scan=self.scan,
+                payload={"pdf_url": "https://x/y.pdf"},
+                progress_callback=None,
+            )
+
+    def test_job_input_carries_result_url_and_key(self):
+        captured = {}
+        s3 = self._s3(envelope=_envelope(scan_pk=self.scan.pk))
+        # The worker echoes back the key it was given.
+        with patch(
+            "scanning.runpod_client._presign_result_put",
+            return_value=("the/key.json", "https://signed.example/put"),
+        ):
+            self._invoke(
+                [
+                    (
+                        200,
+                        {
+                            "status": "COMPLETED",
+                            "output": {"result_key": "the/key.json"},
+                        },
+                    )
+                ],
+                s3,
+                captured=captured,
+            )
+        job_input = captured["body"]["input"]
+        self.assertEqual(job_input["result_key"], "the/key.json")
+        self.assertEqual(job_input["result_url"], "https://signed.example/put")
+
+    def test_completed_job_returns_payload_from_s3(self):
+        detections = [{"page_index": 0, "label": "KEY_ICON"}]
+        s3 = self._s3(
+            envelope=_envelope(
+                scan_pk=self.scan.pk, payload={"detections": detections}
+            )
+        )
+        with patch(
+            "scanning.runpod_client._presign_result_put",
+            return_value=("the/key.json", "https://signed.example/put"),
+        ):
+            result = self._invoke(
+                [
+                    (
+                        200,
+                        {
+                            "status": "COMPLETED",
+                            "output": {
+                                "status": "succeed",
+                                "result_key": "the/key.json",
+                                "bytes": 99,
+                            },
+                        },
+                    )
+                ],
+                s3,
+            )
+        self.assertEqual(result["detections"], detections)
+
+    def test_status_404_harvests_a_result_the_worker_already_wrote(self):
+        # RunPod dropped the job record, but the worker had already
+        # uploaded. head_object finds it, so the finished GPU run is
+        # harvested instead of being paid for twice.
+        detections = [{"page_index": 3}]
+        s3 = self._s3(
+            envelope=_envelope(
+                scan_pk=self.scan.pk, payload={"detections": detections}
+            )
+        )
+        with patch(
+            "scanning.runpod_client._presign_result_put",
+            return_value=("the/key.json", "https://signed.example/put"),
+        ):
+            result = self._invoke([(404, None)], s3)
+        s3.head_object.assert_called_with(Bucket="bucket", Key="the/key.json")
+        self.assertEqual(result["detections"], detections)
+
+    def test_status_404_with_no_object_stays_transient(self):
+        s3 = self._s3(head_error=_client_error("404"))
+        with patch(
+            "scanning.runpod_client._presign_result_put",
+            return_value=("the/key.json", "https://signed.example/put"),
+        ):
+            with self.assertRaises(runpod_client.RunpodTransientError):
+                self._invoke([(404, None)], s3)
+
+    def test_status_404_with_s3_unreachable_stays_transient(self):
+        # head_object failing must not be mistaken for a status-poll
+        # blip: /status keeps 404ing, so retrying can only spin to the
+        # deadline and then fail the scan terminally. Note AccessDenied
+        # is what a *missing* key answers when the daemon's IAM lacks
+        # s3:ListBucket, so this is a realistic shape, not a stretch.
+        s3 = self._s3(head_error=_client_error("AccessDenied"))
+        with patch(
+            "scanning.runpod_client._presign_result_put",
+            return_value=("the/key.json", "https://signed.example/put"),
+        ):
+            with self.assertRaises(runpod_client.RunpodTransientError):
+                self._invoke([(404, None)], s3)
+        # One probe, one answer: no retry loop.
+        self.assertEqual(s3.head_object.call_count, 1)
+
+    def test_status_404_with_a_leftover_object_stays_transient(self):
+        # An object is there, but it predates this submission: it's the
+        # previous attempt's output, so resubmit rather than consume it.
+        s3 = self._s3(
+            envelope=_envelope(scan_pk=self.scan.pk),
+            last_modified=datetime.now(UTC) - timedelta(hours=2),
+        )
+        with patch(
+            "scanning.runpod_client._presign_result_put",
+            return_value=("the/key.json", "https://signed.example/put"),
+        ):
+            with self.assertRaises(runpod_client.RunpodTransientError):
+                self._invoke([(404, None)], s3)
+        s3.get_object.assert_not_called()
+
+    def test_worker_answering_inline_is_still_accepted(self):
+        # An older worker image ignores result_url and returns the
+        # payload in the response. Use it rather than failing.
+        output = {"detections": [{"page_index": 1}], "duration_ms": 3}
+        s3 = self._s3()
+        with patch(
+            "scanning.runpod_client._presign_result_put",
+            return_value=("the/key.json", "https://signed.example/put"),
+        ):
+            result = self._invoke(
+                [(200, {"status": "COMPLETED", "output": output})], s3
+            )
+        self.assertEqual(result, output)
+        s3.get_object.assert_not_called()

--- a/scanning/tests/test_runpod_handler.py
+++ b/scanning/tests/test_runpod_handler.py
@@ -12,12 +12,15 @@ before it touches any real model code.
 These exercise the resumable download path in ``_download_pdf`` without
 real sockets: ``requests.get`` is replaced with a fake that yields chunks
 and can simulate a connection drop, a Range-ignoring server, an expired
-URL, and a short body.
+URL, and a short body. The result-delivery path is covered the same way,
+with ``requests.put`` standing in for the presigned PUT target.
 """
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
+import json
 import sys
 from pathlib import Path
 from unittest import mock
@@ -322,3 +325,259 @@ class ValidatePdfTest(SimpleTestCase):
         self.path.write_bytes(b"<html>nope</html>\n%%EOF")
         with self.assertRaisesRegex(ValueError, "not a PDF"):
             handler._validate_pdf(self.path)
+
+
+class PutResultTest(SimpleTestCase):
+    """``handler._put_result`` upload retries and error classification."""
+
+    URL = "https://s3.example/presigned/result.json?X-Amz-Signature=abc"
+
+    def setUp(self):
+        mock.patch.object(handler.time, "sleep").start()
+        mock.patch.object(handler.random, "uniform", return_value=0.0).start()
+        self.addCleanup(mock.patch.stopall)
+
+    def _patch_put(self, outcomes):
+        """Patch ``requests.put`` to yield ``outcomes`` in order.
+
+        Each outcome is either an HTTP status code or an exception
+        instance to raise instead of responding.
+        """
+        calls = []
+        it = iter(outcomes)
+
+        def fake_put(url, data=None, headers=None, timeout=None):
+            calls.append({"url": url, "data": data, "headers": headers or {}})
+            outcome = next(it)
+            if isinstance(outcome, Exception):
+                raise outcome
+            # An outcome may be a bare status, or (status, body) when
+            # the test cares what S3 said.
+            status, text = (
+                outcome
+                if isinstance(outcome, tuple)
+                else (outcome, f"HTTP {outcome}")
+            )
+            resp = mock.MagicMock()
+            resp.status_code = status
+            resp.text = text
+            return resp
+
+        patcher = mock.patch.object(
+            handler.requests, "put", side_effect=fake_put
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        return calls
+
+    def test_single_put_on_success(self):
+        calls = self._patch_put([200])
+        handler._put_result(self.URL, b'{"a":1}')
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["url"], self.URL)
+        self.assertEqual(calls[0]["data"], b'{"a":1}')
+        # Signed into the presigned URL daemon-side, so this must match
+        # what _presign_result_put signs or S3 rejects the PUT.
+        self.assertEqual(
+            calls[0]["headers"].get("Content-Type"),
+            handler.RESULT_CONTENT_TYPE,
+        )
+
+    def test_retries_5xx_then_succeeds(self):
+        # The GPU work is already paid for, so a server-side blip must
+        # not cost a re-run.
+        calls = self._patch_put([503, 500, 200])
+        handler._put_result(self.URL, b"{}")
+        self.assertEqual(len(calls), 3)
+
+    def test_retries_connection_error_then_succeeds(self):
+        calls = self._patch_put(
+            [requests.exceptions.ConnectionError("reset"), 200]
+        )
+        handler._put_result(self.URL, b"{}")
+        self.assertEqual(len(calls), 2)
+
+    def test_403_fails_fast_as_expired(self):
+        # Retrying a dead signature can never succeed.
+        calls = self._patch_put([403, 200])
+        with self.assertRaises(handler.ResultUrlExpiredError) as ctx:
+            handler._put_result(self.URL, b"{}")
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(ctx.exception.error_code, "RESULT_URL_EXPIRED")
+
+    def test_other_4xx_is_terminal_and_not_retried(self):
+        # e.g. a signature scoped to the wrong region. Identical on
+        # every retry, and each one costs another GPU run, so this
+        # reports a code the daemon does NOT classify as transient.
+        calls = self._patch_put([400, 200])
+        with self.assertRaises(handler.ResultUploadRejectedError) as ctx:
+            handler._put_result(self.URL, b"{}")
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(ctx.exception.error_code, "RESULT_UPLOAD_REJECTED")
+
+    def test_rejection_body_is_surfaced(self):
+        # S3's XML says *why* (wrong region, missing encryption header).
+        # Losing it turns a five-second fix into a debugging session.
+        self._patch_put(
+            [(400, "<Error><Code>AuthorizationQueryParametersError</Code>")]
+        )
+        with self.assertRaisesRegex(
+            handler.ResultUploadError, "AuthorizationQueryParametersError"
+        ):
+            handler._put_result(self.URL, b"{}")
+
+    def test_gives_up_after_max_attempts(self):
+        calls = self._patch_put([503] * handler.RESULT_UPLOAD_MAX_ATTEMPTS)
+        with self.assertRaises(handler.ResultUploadError) as ctx:
+            handler._put_result(self.URL, b"{}")
+        self.assertEqual(len(calls), handler.RESULT_UPLOAD_MAX_ATTEMPTS)
+        self.assertEqual(ctx.exception.error_code, "RESULT_UPLOAD_FAILED")
+
+    def test_rejects_non_http_url(self):
+        with self.assertRaisesRegex(handler.ResultUploadError, "non-http"):
+            handler._put_result("file:///tmp/out.json", b"{}")
+
+
+class DeliverResultTest(SimpleTestCase):
+    """``handler._deliver_result`` envelope + slim job response."""
+
+    INPUTS = {
+        "scan_pk": 42,
+        "result_url": "https://s3.example/put",
+        "result_key": "processing/42/x/1/1/jobs/detect/result.json",
+    }
+
+    def test_uploads_envelope_and_returns_key_only(self):
+        result = {
+            "detections": [{"page_index": 0}, {"page_index": 1}],
+            "page_count": 7,
+            "duration_ms": 900,
+        }
+        uploaded = {}
+
+        def fake_put(url, body):
+            uploaded["url"] = url
+            uploaded["body"] = body
+
+        with mock.patch.object(handler, "_put_result", side_effect=fake_put):
+            response = handler._deliver_result(
+                result, self.INPUTS, "detect", {"id": "job-9"}
+            )
+
+        envelope = json.loads(uploaded["body"])
+        self.assertEqual(uploaded["url"], self.INPUTS["result_url"])
+        self.assertEqual(
+            envelope["schema_version"], handler.RESULT_SCHEMA_VERSION
+        )
+        self.assertEqual(envelope["action"], "detect")
+        self.assertEqual(envelope["scan_pk"], 42)
+        self.assertEqual(envelope["job_id"], "job-9")
+        self.assertEqual(envelope["payload"], result)
+
+        # The response carries no copy of the payload: one source of
+        # truth, and no ~20 MB cap to design around.
+        self.assertEqual(response["status"], "succeed")
+        self.assertEqual(response["action"], "detect")
+        self.assertEqual(response["result_key"], self.INPUTS["result_key"])
+        self.assertNotIn("detections", response)
+        self.assertEqual(response["bytes"], len(uploaded["body"]))
+        self.assertEqual(
+            response["sha256"],
+            hashlib.sha256(uploaded["body"]).hexdigest(),
+        )
+        self.assertEqual(response["duration_ms"], 900)
+        self.assertEqual(response["page_count"], 7)
+
+    def test_analyze_timings_ride_along(self):
+        result = {"results": [{"pdf_page": 1}], "duration_ms": 5}
+        with mock.patch.object(handler, "_put_result") as put:
+            response = handler._deliver_result(
+                result, self.INPUTS, "analyze", {"id": "job-9"}
+            )
+        envelope = json.loads(put.call_args.args[1])
+        self.assertEqual(envelope["action"], "analyze")
+        self.assertEqual(envelope["payload"], result)
+        self.assertEqual(response["action"], "analyze")
+        self.assertEqual(response["duration_ms"], 5)
+
+
+class HandlerResultModeTest(SimpleTestCase):
+    """``handler.handler`` picks inline vs. S3 delivery per job."""
+
+    def setUp(self):
+        # The module-level preload saw no CUDA (see _load_handler), and
+        # handler() refuses jobs without a GPU. Flip it for these tests:
+        # what's under test is result delivery, not GPU fitness.
+        mock.patch.object(handler, "_CUDA_AVAILABLE", True).start()
+        mock.patch.object(
+            handler,
+            "_ACTIONS",
+            {
+                "detect": lambda inputs, tmp_dir: {
+                    "detections": [{"page_index": 0}],
+                    "duration_ms": 12,
+                }
+            },
+        ).start()
+        self.addCleanup(mock.patch.stopall)
+
+    def test_inline_when_no_result_url(self):
+        out = handler.handler({"id": "j", "input": {"action": "detect"}})
+        self.assertEqual(out["detections"], [{"page_index": 0}])
+        self.assertNotIn("result_key", out)
+
+    def test_uploads_when_result_url_present(self):
+        with mock.patch.object(handler, "_put_result") as put:
+            out = handler.handler(
+                {
+                    "id": "j",
+                    "input": {
+                        "action": "detect",
+                        "scan_pk": 1,
+                        "result_url": "https://s3.example/put",
+                        "result_key": "k.json",
+                    },
+                }
+            )
+        put.assert_called_once()
+        self.assertEqual(out["result_key"], "k.json")
+        self.assertNotIn("detections", out)
+        # Worker meta rides along either way.
+        self.assertIn("gpu_available", out)
+
+    def test_upload_failure_becomes_a_structured_error(self):
+        with mock.patch.object(
+            handler,
+            "_put_result",
+            side_effect=handler.ResultUploadError("s3 down"),
+        ):
+            out = handler.handler(
+                {
+                    "id": "j",
+                    "input": {
+                        "action": "detect",
+                        "result_url": "https://s3.example/put",
+                        "result_key": "k.json",
+                    },
+                }
+            )
+        self.assertEqual(out["error_code"], "RESULT_UPLOAD_FAILED")
+        self.assertIn("s3 down", out["error"])
+
+    def test_expired_url_reports_its_own_code(self):
+        with mock.patch.object(
+            handler,
+            "_put_result",
+            side_effect=handler.ResultUrlExpiredError("403"),
+        ):
+            out = handler.handler(
+                {
+                    "id": "j",
+                    "input": {
+                        "action": "detect",
+                        "result_url": "https://s3.example/put",
+                        "result_key": "k.json",
+                    },
+                }
+            )
+        self.assertEqual(out["error_code"], "RESULT_URL_EXPIRED")

--- a/scanning/tests/test_s3_sync.py
+++ b/scanning/tests/test_s3_sync.py
@@ -448,3 +448,30 @@ class TestS3EnabledBranches(SimpleTestCase):
                 "scanning.s3_sync.has_s3_credentials", return_value=True
             ):
                 self.assertFalse(s3_sync._s3_enabled())
+
+
+class TestS3ClientRegion(SimpleTestCase):
+    """The shared client signs for the bucket's region, not the ambient one.
+
+    ``generate_presigned_post`` signs with SigV4, which folds the region
+    into the credential scope, so a client left on boto3's ``us-east-1``
+    default hands the browser an upload policy S3 rejects.
+    """
+
+    @override_settings(AWS_S3_REGION_NAME="us-west-2", TESTING=True)
+    def test_client_is_built_with_the_configured_region(self):
+        with patch("scanning.s3_sync.boto3") as mock_boto3:
+            s3_sync._s3_client()
+        mock_boto3.client.assert_called_once_with(
+            "s3", region_name="us-west-2"
+        )
+
+    @override_settings(AWS_S3_REGION_NAME="us-west-2", TESTING=False)
+    def test_cached_client_is_built_with_the_configured_region(self):
+        s3_sync._cached_s3_client.cache_clear()
+        self.addCleanup(s3_sync._cached_s3_client.cache_clear)
+        with patch("scanning.s3_sync.boto3") as mock_boto3:
+            s3_sync._s3_client()
+        mock_boto3.client.assert_called_once_with(
+            "s3", region_name="us-west-2"
+        )

--- a/scanning/tests/test_s3_sync.py
+++ b/scanning/tests/test_s3_sync.py
@@ -128,6 +128,61 @@ class TestSyncHelpersWithCredentials(TestCase):
             },
         )
 
+    def test_job_result_key_is_per_scan_and_stage(self):
+        scan = _reporter_scan()
+        key = s3_sync.s3_job_result_key(scan, "detect")
+        self.assertEqual(
+            key,
+            f"processing/{scan.pk}/tc/164/1/jobs/detect/result.json",
+        )
+
+    def test_upload_processing_files_skips_job_results(self):
+        # GPU job results are wire artifacts the daemon consumes into
+        # Postgres. If one ever lands in the local tree it must not be
+        # pushed back up with the deliverables.
+        scan = _reporter_scan()
+        local_root = pathlib.Path(scan.output_dir)
+        (local_root / "jobs" / "detect").mkdir(parents=True)
+        (local_root / "jobs" / "detect" / "result.json").write_text("{}")
+        (local_root / "bitonal.pdf").write_bytes(b"pdf")
+
+        mock_s3 = MagicMock()
+        with patch("scanning.s3_sync.boto3") as mock_boto3:
+            mock_boto3.client.return_value = mock_s3
+            count = s3_sync.upload_processing_files(scan)
+
+        self.assertEqual(count, 1)
+        uploaded_keys = {
+            call.args[2] for call in mock_s3.upload_file.call_args_list
+        }
+        prefix = f"processing/{scan.pk}/tc/164/1/"
+        self.assertEqual(uploaded_keys, {f"{prefix}bitonal.pdf"})
+
+    def test_download_processing_files_skips_job_results(self):
+        scan = _reporter_scan()
+        prefix = s3_sync.s3_processing_prefix(scan)
+        mock_s3 = MagicMock()
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [
+            {
+                "Contents": [
+                    {"Key": f"{prefix}bitonal.pdf", "Size": 5},
+                    {
+                        "Key": f"{prefix}jobs/detect/result.json",
+                        "Size": 9,
+                    },
+                ]
+            }
+        ]
+        mock_s3.get_paginator.return_value = mock_paginator
+
+        with patch("scanning.s3_sync.boto3") as mock_boto3:
+            mock_boto3.client.return_value = mock_s3
+            s3_sync.download_processing_files(scan)
+
+        downloaded = {c.args[1] for c in mock_s3.download_file.call_args_list}
+        self.assertEqual(downloaded, {f"{prefix}bitonal.pdf"})
+
     def test_is_approved_deliverable(self):
         self.assertTrue(s3_sync._is_approved_deliverable("redacted/foo.pdf"))
         self.assertTrue(s3_sync._is_approved_deliverable("images/1-001.png"))


### PR DESCRIPTION
Fixes #157.

First implementation of presigned PUT result delivery. Deliberately minimal: it changes how a job's payload gets back to the daemon and nothing else, so the pipeline, the daemon loop and the services layer all behave exactly as they do today. Most of the logic here should be reusable as-is when the job row (#150) and batch submission (#156) land.

## What changes

The daemon presigns a PUT alongside the presigned GET it already sends, and passes `result_url` + `result_key` in the job input. The worker writes one JSON object with a single PUT and returns only status, key, size, digest and timings. The daemon polls `/status` exactly as before and, on COMPLETED, pulls the object and validates it instead of reading the payload out of the response.

Why: RunPod caps a job response at ~20 MB (the reason we cannot return per-word bounding boxes) and discards it once the ~30 min retention window closes. An S3 object has neither limit.

`detect()` and `analyze()` return the same shape they always have, so `services.py` is untouched.

## Result keys and staleness

Keys are per scan and action (`processing/{pk}/.../jobs/{action}/result.json`), not per run, so a re-run overwrites its predecessor rather than accumulating orphans.

Because the key is reused, nothing is read without checking the object was written after the reading job was submitted (`head_object` on `LastModified`, 60s clock skew allowance), and the envelope's `job_id` is checked against the job we polled. The time check is the cheap first pass; the job id is authoritative.

A 404 from `/status` now probes that key before giving up, so a job that finished and uploaded before RunPod dropped its record is harvested instead of being paid for twice. Any S3 error during that probe is swallowed and the scan re-queues as before.

## Backwards compatibility

Nothing happens without AWS credentials, so local dev and CI keep using the in-process blackletter path untouched.

If `result_url` is absent the worker answers inline exactly as today, and the daemon accepts an inline response even when it sent a `result_url`. That means rolling the worker image back is a complete rollback, with no daemon change.

## S3 region (needs a decision before merge)

Nothing in this project set an S3 region, so boto3 fell back to `us-east-1`. That was invisible until now because SigV2 presigned URLs carry no region and S3 redirects a misdirected GET. These URLs are SigV4 (needed so the signature covers the PUT's `Content-Type`), and SigV4 signs the region into the credential scope, so a mismatch fails outright with `AuthorizationQueryParametersError`.

Added `AWS_S3_REGION_NAME`, defaulting to **`us-west-2`**, which is where the dev buckets live (confirmed by hitting the error against `dev-com-freelawproject-scanning-private-storage`).

Two things to check before this merges:

- Confirm the production buckets are also `us-west-2`: `aws s3api get-bucket-location --bucket <name>`. Override with the env var if not.
- That setting name is the one django-storages reads, so it now pins the region for ordinary media uploads too. Intentional (one region for every S3 client beats two ways to be wrong) and it should be strictly more correct, but it does touch the upload path. Happy to scope it to the RunPod client only if reviewers prefer.

## Error codes

| `error_code` | Cause | Daemon behaviour |
|---|---|---|
| `RESULT_UPLOAD_FAILED` | PUT failed after retries (5xx, 429, dropped connections) | Re-queue (transient) |
| `RESULT_URL_EXPIRED` | Presigned PUT dead (HTTP 403) | Re-queue; resubmitting mints a fresh signature |
| `RESULT_UPLOAD_REJECTED` | S3 refused the write for a reason a re-run cannot fix (wrong signing region, bucket policy) | Mark scan ERROR |

The last one is terminal on purpose: those are configuration errors, and treating them as transient re-runs the GPU work, and re-bills it, once per retry before failing with the same message.

## Testing

Full suite green (406 tests, +40 here). Covers the upload retry ladder, 403 and 4xx handling, the inline path, envelope validation, the freshness and job-id checks, and the 404 probe.

Verified end to end against a real endpoint (image on a personal Docker Hub repo, RunPod serverless, dev bucket):

- Job response carried no `detections`, only `{"status": "succeed", "result_key", "bytes": 4956, "sha256", "upload_ms": 695, ...}`.
- Object present at the expected key, `ContentType: application/json`, `ContentLength` matching the reported `bytes`.
- `sha256sum` of the downloaded object identical to the digest the worker reported.
- Envelope `job_id` identical to the RunPod job id, 23 detections across 15 pages in the payload.

## Out of scope

Persisting the job id and result key on a job row so a restarted daemon can resume (#150), the non-blocking sweep and batch submission (#156), sharding and per-shard partial failure, and the S3 lifecycle expiry rule on the results prefix (infra config, not yet applied).
