### PR TITLE
perf(scanning): run bitonal conversion across multiple workers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,12 @@ DB_SSL_MODE=prefer
 # rejects them. Default us-west-2.
 # AWS_S3_REGION_NAME=us-west-2
 
+# Processing
+# Worker processes bitonal conversion is split across. Unset (the default)
+# derives it from the cores the pod was actually granted, leaving ~20% of
+# them free. Set it to pin the count, or to 1 to convert inline.
+# BITONAL_WORKERS=
+
 # Sentry
 # SENTRY_DSN=
 

--- a/docker/django/docker-entrypoint.sh
+++ b/docker/django/docker-entrypoint.sh
@@ -5,6 +5,7 @@ case "$1" in
 'web-dev')
     # Install blackletter from local mount if available
     if [ -d /opt/blackletter ]; then
+        echo "Installing local blackletter..."
         uv pip install -e /opt/blackletter 2>/dev/null || pip install -e /opt/blackletter 2>/dev/null || true
     fi
     python manage.py migrate
@@ -19,6 +20,7 @@ case "$1" in
 'run_daemon')
     # Install blackletter from local mount if available
     if [ -d /opt/blackletter ]; then
+        echo "Installing local blackletter..."
         uv pip install -e /opt/blackletter 2>/dev/null || pip install -e /opt/blackletter 2>/dev/null || true
     fi
     exec python manage.py run_daemon

--- a/docker/django/docker-entrypoint.sh
+++ b/docker/django/docker-entrypoint.sh
@@ -1,13 +1,20 @@
 #!/bin/sh
 set -e
 
-case "$1" in
-'web-dev')
-    # Install blackletter from local mount if available
+# Install blackletter from the local mount when one is present, so a
+# developer iterating on the library sees their checkout instead of the
+# version pinned in pyproject.toml. The log line matters: without it there
+# is no way to tell from the logs which of the two a container is running.
+install_local_blackletter() {
     if [ -d /opt/blackletter ]; then
         echo "Installing local blackletter..."
         uv pip install -e /opt/blackletter 2>/dev/null || pip install -e /opt/blackletter 2>/dev/null || true
     fi
+}
+
+case "$1" in
+'web-dev')
+    install_local_blackletter
     python manage.py migrate
     python manage.py loaddata reporters
     python manage.py make_dev_data
@@ -18,11 +25,7 @@ case "$1" in
     exec python manage.py runserver 0.0.0.0:8000
     ;;
 'run_daemon')
-    # Install blackletter from local mount if available
-    if [ -d /opt/blackletter ]; then
-        echo "Installing local blackletter..."
-        uv pip install -e /opt/blackletter 2>/dev/null || pip install -e /opt/blackletter 2>/dev/null || true
-    fi
+    install_local_blackletter
     exec python manage.py run_daemon
     ;;
 'web-prod')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   # accepts. Move this back to a `>=` release floor once that lands and a
   # version is tagged. The commit is on the PR branch, so it stays reachable
   # only while that branch does; re-pin promptly.
-  "blackletter @ git+https://github.com/freelawproject/blackletter@9fcc1f4088cb5d9e170d71d18e305fe7ce29817f",
+  "blackletter @ git+https://github.com/freelawproject/blackletter@a6e905fcb585b624a970fef2d178aeca89241f38",
   # No longer called directly: the pipeline embeds no text layer. Declared
   # so LLM_PAGE_TEXT_LAYER (blackletter's add_text_layer) has an engine, and
   # because base blackletter requires it anyway.
@@ -73,7 +73,7 @@ dev = [
 # offline daemon, and the RunPod worker image. Excluded from the lean web image.
 local-ml = [
   # Same commit as the base pin above; both must move together.
-  "blackletter[detect,analyze] @ git+https://github.com/freelawproject/blackletter@9fcc1f4088cb5d9e170d71d18e305fe7ce29817f",
+  "blackletter[detect,analyze] @ git+https://github.com/freelawproject/blackletter@a6e905fcb585b624a970fef2d178aeca89241f38",
   "torch",
   "torchvision",
   "ultralytics>=8.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,12 @@ dependencies = [
   # validation and the ink geometry — no torch/paddle. The heavy in-process
   # inference stack lives in the `local-ml` extra so the web/daemon images stay
   # lean whenever detection is offloaded to RunPod (RUNPOD_ENABLED=True).
-  # 0.2.0 is the floor: it is the release that carries the ink geometry
-  # (blackletter #68/#69) this app reads instead of measuring it here.
-  "blackletter>=0.2.0",
+  # Pinned to a commit rather than a release: the daemon passes `workers` to
+  # `api.bitonal` (blackletter #71 / PR 72), which no published version
+  # accepts. Move this back to a `>=` release floor once that lands and a
+  # version is tagged. The commit is on the PR branch, so it stays reachable
+  # only while that branch does; re-pin promptly.
+  "blackletter @ git+https://github.com/freelawproject/blackletter@9fcc1f4088cb5d9e170d71d18e305fe7ce29817f",
   # No longer called directly: the pipeline embeds no text layer. Declared
   # so LLM_PAGE_TEXT_LAYER (blackletter's add_text_layer) has an engine, and
   # because base blackletter requires it anyway.
@@ -69,7 +72,8 @@ dev = [
 # wherever detection runs locally instead of on RunPod: local dev, CI, the
 # offline daemon, and the RunPod worker image. Excluded from the lean web image.
 local-ml = [
-  "blackletter[detect,analyze]>=0.2.0",
+  # Same commit as the base pin above; both must move together.
+  "blackletter[detect,analyze] @ git+https://github.com/freelawproject/blackletter@9fcc1f4088cb5d9e170d71d18e305fe7ce29817f",
   "torch",
   "torchvision",
   "ultralytics>=8.3",

--- a/scanning/services.py
+++ b/scanning/services.py
@@ -401,10 +401,15 @@ def _ensure_bitonal(scan: "Scan", output_dir: Path) -> Path:
             _update_progress(scan.pk, message, current=current, total=total)
 
         with _log_stage("Bitonal conversion") as stage:
+            # blackletter defaults to converting inline; the worker count is
+            # ours to choose because only this side knows what the pod was
+            # given. Above 1 the progress callback fires once per finished
+            # page range rather than per page, so the bar steps.
             bl_bitonal(
                 scan.pdf_path,
                 str(output_dir),
                 progress_callback=_bitonal_progress,
+                workers=settings.BITONAL_WORKERS,
             )
             size_mb = bitonal_path.stat().st_size / 1024 / 1024
             stage.done_detail = f"{size_mb:.1f} MB"

--- a/scanning/settings/project/processing_storage.py
+++ b/scanning/settings/project/processing_storage.py
@@ -1,3 +1,6 @@
+import os
+from pathlib import Path
+
 import environ
 
 env = environ.FileAwareEnv()
@@ -43,3 +46,62 @@ PENDING_UPLOAD_TTL_HOURS = env.float("PENDING_UPLOAD_TTL_HOURS", default=9.0)
 # volume. It runs after redaction, so it never OCRs content that a rect is
 # about to cover.
 LLM_PAGE_TEXT_LAYER = env.bool("LLM_PAGE_TEXT_LAYER", default=False)
+
+
+def _cgroup_cpu_quota() -> float | None:
+    """CPU quota this container was granted, in cores, or None if unlimited.
+
+    Reads cgroup v2 first (``cpu.max``, "<quota> <period>" or "max <period>"),
+    then falls back to the v1 pair. Anything unreadable means we are not
+    constrained by a cgroup we can see.
+    """
+    v2 = Path("/sys/fs/cgroup/cpu.max")
+    try:
+        quota, period = v2.read_text().split()
+        return None if quota == "max" else float(quota) / float(period)
+    except (OSError, ValueError):
+        pass
+
+    try:
+        quota = float(Path("/sys/fs/cgroup/cpu/cpu.cfs_quota_us").read_text())
+        period = float(
+            Path("/sys/fs/cgroup/cpu/cpu.cfs_period_us").read_text()
+        )
+    except (OSError, ValueError):
+        return None
+    return quota / period if quota > 0 else None
+
+
+def _available_cpus() -> int:
+    """Cores this process may actually use.
+
+    ``os.cpu_count()`` reports the *host's* cores, which inside a pod is
+    whatever the node happens to have rather than what the pod was granted,
+    so using it directly oversubscribes badly. Affinity and the cgroup quota
+    are the numbers that bound us.
+    """
+    try:
+        usable = len(os.sched_getaffinity(0))
+    except AttributeError:  # non-POSIX
+        usable = os.cpu_count() or 1
+
+    quota = _cgroup_cpu_quota()
+    if quota:
+        usable = min(usable, int(quota))
+    return max(1, usable)
+
+
+# Share of the pod's CPUs bitonal conversion may occupy when BITONAL_WORKERS
+# is not set explicitly. Deliberately below 1.0: the daemon has other work to
+# do while a conversion runs, and throughput flattens out well before one
+# worker per core anyway (rasterisation is memory-bandwidth bound, not CPU
+# bound), so the last 20% of the cores buys little.
+BITONAL_CPU_FRACTION = 0.8
+
+# Worker processes blackletter splits bitonal conversion across. Set
+# BITONAL_WORKERS to pin it; leave it unset to derive it from the cores this
+# pod actually has. 1 converts inline, which is what blackletter does by
+# default and what the tests want.
+BITONAL_WORKERS = env.int("BITONAL_WORKERS", default=0) or max(
+    1, int(_available_cpus() * BITONAL_CPU_FRACTION)
+)

--- a/scanning/settings/project/testing.py
+++ b/scanning/settings/project/testing.py
@@ -14,3 +14,7 @@ if TESTING:
     # Isolate the processing cache so tests don't pollute each other
     # (or the developer's real /tmp/scanning) with stray output dirs.
     PROCESSING_TMP_DIR = tempfile.mkdtemp(prefix="scanning-test-")
+    # Convert inline. The derived default scales with the runner's cores, so
+    # leaving it alone would have any test that reaches a real conversion
+    # spawn a process pool sized to whatever CI happens to be running on.
+    BITONAL_WORKERS = 1

--- a/scanning/tests/test_services.py
+++ b/scanning/tests/test_services.py
@@ -1236,7 +1236,7 @@ class TestImmediateS3PushOnGeneration(TestCase):
         output = pathlib.Path(scan.output_dir)
         output.mkdir(parents=True, exist_ok=True)
 
-        def _fake_bitonal(src, out, progress_callback=None):
+        def _fake_bitonal(src, out, progress_callback=None, workers=1):
             (pathlib.Path(out) / "bitonal.pdf").write_bytes(b"%PDF-1.4 bw")
 
         with (
@@ -1248,6 +1248,49 @@ class TestImmediateS3PushOnGeneration(TestCase):
             services._ensure_bitonal(scan, output)
 
         push.assert_called_once_with(scan.pk, "bitonal.pdf")
+
+    def test_ensure_bitonal_passes_configured_worker_count(self):
+        """The pod's worker count reaches blackletter.
+
+        blackletter converts inline unless told otherwise, so a dropped
+        kwarg here costs the whole speedup without failing anything.
+        """
+        from scanning import services
+
+        scan = ScanFactory(start_page=1, end_page=2)
+        output = pathlib.Path(scan.output_dir)
+        output.mkdir(parents=True, exist_ok=True)
+
+        def _fake_bitonal(src, out, progress_callback=None, workers=1):
+            (pathlib.Path(out) / "bitonal.pdf").write_bytes(b"%PDF-1.4 bw")
+
+        with (
+            patch.object(
+                services, "bl_bitonal", side_effect=_fake_bitonal
+            ) as bitonal,
+            patch.object(services, "_push_generated_file_to_s3"),
+            patch.object(services.fitz, "open") as fitz_open,
+            self.settings(BITONAL_WORKERS=6),
+        ):
+            fitz_open.return_value.__enter__.return_value.page_count = 2
+            services._ensure_bitonal(scan, output)
+
+        assert bitonal.call_args.kwargs["workers"] == 6
+
+    def test_bitonal_worker_default_leaves_the_pod_headroom(self):
+        """The derived default never claims every core, nor fewer than one."""
+        from scanning.settings.project.processing_storage import (
+            BITONAL_CPU_FRACTION,
+            _available_cpus,
+        )
+
+        cpus = _available_cpus()
+        derived = max(1, int(cpus * BITONAL_CPU_FRACTION))
+
+        assert cpus >= 1
+        assert 1 <= derived <= cpus
+        if cpus >= 5:
+            assert derived < cpus, "should leave the pod at least one core"
 
     def test_ensure_bitonal_skips_push_when_already_present(self):
         """An existing bitonal is neither reconverted nor re-uploaded."""

--- a/scanning/tests/test_services.py
+++ b/scanning/tests/test_services.py
@@ -100,6 +100,17 @@ def _write_bitonal_copy(dest):
         fh.write(b"\n% bitonal\n")
 
 
+def _fake_bitonal(src, out, progress_callback=None, workers=1):
+    """Stand in for ``blackletter.api.bitonal``, writing only the output file.
+
+    The signature has to track the real one: it is patched in with
+    ``side_effect``, so a kwarg the caller passes that this does not accept
+    raises ``TypeError`` rather than being ignored.
+    """
+    del src, progress_callback, workers
+    (pathlib.Path(out) / "bitonal.pdf").write_bytes(b"%PDF-1.4 bw")
+
+
 def _run_detect_on_fixture(tmpdir):
     """Run YOLO detect on the fixture PDF, return detections list."""
     from blackletter.api import detect
@@ -1236,9 +1247,6 @@ class TestImmediateS3PushOnGeneration(TestCase):
         output = pathlib.Path(scan.output_dir)
         output.mkdir(parents=True, exist_ok=True)
 
-        def _fake_bitonal(src, out, progress_callback=None, workers=1):
-            (pathlib.Path(out) / "bitonal.pdf").write_bytes(b"%PDF-1.4 bw")
-
         with (
             patch.object(services, "bl_bitonal", side_effect=_fake_bitonal),
             patch.object(services, "_push_generated_file_to_s3") as push,
@@ -1260,9 +1268,6 @@ class TestImmediateS3PushOnGeneration(TestCase):
         scan = ScanFactory(start_page=1, end_page=2)
         output = pathlib.Path(scan.output_dir)
         output.mkdir(parents=True, exist_ok=True)
-
-        def _fake_bitonal(src, out, progress_callback=None, workers=1):
-            (pathlib.Path(out) / "bitonal.pdf").write_bytes(b"%PDF-1.4 bw")
 
         with (
             patch.object(

--- a/uv.lock
+++ b/uv.lock
@@ -142,17 +142,13 @@ wheels = [
 [[package]]
 name = "blackletter"
 version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/freelawproject/blackletter?rev=9fcc1f4088cb5d9e170d71d18e305fe7ce29817f#9fcc1f4088cb5d9e170d71d18e305fe7ce29817f" }
 dependencies = [
     { name = "numpy" },
     { name = "ocrmypdf" },
     { name = "opencv-python" },
     { name = "pillow" },
     { name = "pymupdf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/8a/a744ed3dbe5b00716a91f9b8b9933b125d7aa0b54710ebf4428621bcbf5e/blackletter-0.2.0.tar.gz", hash = "sha256:85a0d08edda53567f92b39bb1d2bc8378ed5a979882cb1a44a7fb1a0b01c01be", size = 170941, upload-time = "2026-08-05T01:36:06.898Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/61/db2868191379fadb08cea86cc8a6f3b2b897a045cb35a00b27147ad63ed9/blackletter-0.2.0-py3-none-any.whl", hash = "sha256:e909a0f2b96807de7287470874e75dbf1500ae7a7081196c3938c52d1b4f90b5", size = 130766, upload-time = "2026-08-05T01:36:05.595Z" },
 ]
 
 [package.optional-dependencies]
@@ -2359,8 +2355,8 @@ local-ml = [
 
 [package.metadata]
 requires-dist = [
-    { name = "blackletter", specifier = ">=0.2.0" },
-    { name = "blackletter", extras = ["detect", "analyze"], marker = "extra == 'local-ml'", specifier = ">=0.2.0" },
+    { name = "blackletter", git = "https://github.com/freelawproject/blackletter?rev=9fcc1f4088cb5d9e170d71d18e305fe7ce29817f" },
+    { name = "blackletter", extras = ["detect", "analyze"], marker = "extra == 'local-ml'", git = "https://github.com/freelawproject/blackletter?rev=9fcc1f4088cb5d9e170d71d18e305fe7ce29817f" },
     { name = "boto3" },
     { name = "daphne" },
     { name = "django", specifier = ">=6.0,<6.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -142,7 +142,7 @@ wheels = [
 [[package]]
 name = "blackletter"
 version = "0.2.0"
-source = { git = "https://github.com/freelawproject/blackletter?rev=9fcc1f4088cb5d9e170d71d18e305fe7ce29817f#9fcc1f4088cb5d9e170d71d18e305fe7ce29817f" }
+source = { git = "https://github.com/freelawproject/blackletter?rev=a6e905fcb585b624a970fef2d178aeca89241f38#a6e905fcb585b624a970fef2d178aeca89241f38" }
 dependencies = [
     { name = "numpy" },
     { name = "ocrmypdf" },
@@ -2355,8 +2355,8 @@ local-ml = [
 
 [package.metadata]
 requires-dist = [
-    { name = "blackletter", git = "https://github.com/freelawproject/blackletter?rev=9fcc1f4088cb5d9e170d71d18e305fe7ce29817f" },
-    { name = "blackletter", extras = ["detect", "analyze"], marker = "extra == 'local-ml'", git = "https://github.com/freelawproject/blackletter?rev=9fcc1f4088cb5d9e170d71d18e305fe7ce29817f" },
+    { name = "blackletter", git = "https://github.com/freelawproject/blackletter?rev=a6e905fcb585b624a970fef2d178aeca89241f38" },
+    { name = "blackletter", extras = ["detect", "analyze"], marker = "extra == 'local-ml'", git = "https://github.com/freelawproject/blackletter?rev=a6e905fcb585b624a970fef2d178aeca89241f38" },
     { name = "boto3" },
     { name = "daphne" },
     { name = "django", specifier = ">=6.0,<6.1" },


### PR DESCRIPTION
## Blocked until blackletter ships

This needs [blackletter#72](https://github.com/freelawproject/blackletter/pull/72) merged **and** a version tagged and published to PyPI. The daemon passes a `workers` argument to `api.bitonal` that no released blackletter accepts.

`pyproject.toml` is therefore pinned to a commit rather than a release, in both the base dependency and the `local-ml` extra:

```toml
"blackletter @ git+https://github.com/freelawproject/blackletter@a6e905fcb585b624a970fef2d178aeca89241f38",
```

That commit lives on the blackletter PR branch, so it stops being reachable if the branch is deleted on merge. **Re-pin to `blackletter>=0.3.0` (or whatever gets tagged) before this merges.** Do not land it with the git pin in place.

## What this does

Bitonal conversion ran sequentially in one process. blackletter can now split it across workers, and this side chooses how many, because only the deployment knows what the pod was granted.

`BITONAL_WORKERS` derives from the cores actually available, leaving about 20% headroom:

```python
BITONAL_WORKERS = env.int("BITONAL_WORKERS", default=0) or max(
    1, int(_available_cpus() * BITONAL_CPU_FRACTION)   # 0.8
)
```

`_available_cpus()` intersects `sched_getaffinity` with the cgroup quota (v2 `cpu.max`, falling back to the v1 pair). `os.cpu_count()` reports the *node's* cores inside a pod, which oversubscribes badly. Derivation checked at 22 cores to 17, **8 cores to 6**, 2 to 1, 1 to 1, and an explicit `BITONAL_WORKERS=3` to 3.

Under `TESTING` it is forced to 1, so a test that reaches a real conversion cannot spawn a pool sized to whatever CI happens to be running on.

## Measured on a real volume

Through the daemon, on a 929-page volume (1.33 GB source), before and after on identical input:

| bitonal conversion | time |
| --- | --- |
| before | 337.6s |
| after, 17 workers | 33.8s |

**10x**, same 68.3 MB output. On the 8-CPU pod expect roughly 65s rather than 33.8s.

Full pipeline for that scan is now 713s, of which bitonal is 4.7%. RunPod detection plus validation is 554s, or 77.7% of the run, so that is where any further pipeline work belongs rather than here.

## Entrypoint

`docker-entrypoint.sh` now logs `Installing local blackletter...` when it installs from the `/opt/blackletter` mount. Without it there is no way to tell from the logs whether a container is running the pinned package or a local checkout, which cost me a wrong diagnosis while testing this: a container silently running mounted code looks identical to one running the pinned wheel.

Worth knowing, since it interacts directly with the pin above: when that mount is present the editable install shadows whatever `pyproject.toml` pins. So in a dev container the pin is inert and the local checkout wins. That is the intended workflow for iterating on blackletter, but it means dev is not a test of the pin. Verified separately: a clean venv installing from the pinned URL, non-editable and with no mount, does expose `workers`.

The entrypoint only logs. It does not create the mount, which comes from `docker-compose.yml` and is not part of this PR, so the new line only fires for a developer who has added that volume themselves.

## Testing

Two new tests: one asserting the kwarg actually reaches blackletter (a dropped kwarg costs the entire speedup while failing nothing), one on the derivation bounds.

Full suite passes against the real pinned package rather than a mock: 461 passed, 1 skipped.
